### PR TITLE
docs: rewrite quickstart and add runtimes/system drivers structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,16 @@ Follow the style in `packages/secure-exec/src/index.ts`.
 - comment tricky ordering/invariants; skip noise
 - add inline comments and doc comments when behavior is non-obvious, especially where runtime/bridge/driver pieces depend on each other
 
+## Documentation
+
+- docs pages that must stay current with API changes:
+  - `docs/quickstart.mdx` — update when core setup flow changes
+  - `docs/api-reference.mdx` — update when any public export signature changes
+  - `docs/runtimes/node.mdx` — update when NodeRuntime options/behavior changes
+  - `docs/runtimes/python.mdx` — update when PythonRuntime options/behavior changes
+  - `docs/system-drivers/node.mdx` — update when createNodeDriver options change
+  - `docs/system-drivers/browser.mdx` — update when createBrowserDriver options change
+
 ## Skills
 
 - create project skills in `.claude/skills/`

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -1,0 +1,341 @@
+---
+title: API Reference
+description: Complete reference for all secure-exec exports.
+---
+
+## Runtimes
+
+### `NodeRuntime`
+
+Sandboxed JavaScript runtime using a V8 isolate.
+
+```ts
+new NodeRuntime(options: NodeRuntimeOptions)
+```
+
+**`NodeRuntimeOptions`**
+
+| Option | Type | Description |
+|---|---|---|
+| `systemDriver` | `SystemDriver` | Host capabilities (filesystem, network, permissions). **Required.** |
+| `runtimeDriverFactory` | `NodeRuntimeDriverFactory` | Creates the isolate execution environment. **Required.** |
+| `memoryLimit` | `number` | Isolate memory cap in MB. |
+| `cpuTimeLimitMs` | `number` | CPU time budget in ms. |
+| `timingMitigation` | `"off" \| "freeze"` | Timing side-channel mitigation. Default `"freeze"`. |
+| `onStdio` | `StdioHook` | Default console output hook. |
+| `payloadLimits` | `{ base64TransferBytes?: number; jsonPayloadBytes?: number }` | Bridge payload size limits. |
+
+**Methods**
+
+| Method | Returns | Description |
+|---|---|---|
+| `exec(code, options?)` | `Promise<ExecResult>` | Execute code without a return value. |
+| `run<T>(code, filePath?)` | `Promise<RunResult<T>>` | Execute code and return the default export. |
+| `network` | `{ fetch, dnsLookup, httpRequest }` | Network access from the host side. |
+| `dispose()` | `void` | Release resources synchronously. |
+| `terminate()` | `Promise<void>` | Terminate the runtime. |
+
+---
+
+### `PythonRuntime`
+
+Sandboxed Python runtime using Pyodide in a Worker thread.
+
+```ts
+new PythonRuntime(options: PythonRuntimeOptions)
+```
+
+**`PythonRuntimeOptions`**
+
+| Option | Type | Description |
+|---|---|---|
+| `systemDriver` | `SystemDriver` | Host capabilities. **Required.** |
+| `runtimeDriverFactory` | `PythonRuntimeDriverFactory` | Creates the Pyodide worker. **Required.** |
+| `cpuTimeLimitMs` | `number` | CPU time budget in ms. |
+| `onStdio` | `StdioHook` | Default console output hook. |
+
+**Methods**
+
+| Method | Returns | Description |
+|---|---|---|
+| `exec(code, options?)` | `Promise<ExecResult>` | Execute Python code without a return value. |
+| `run<T>(code, options?)` | `Promise<PythonRunResult<T>>` | Execute Python code and return a value. |
+| `dispose()` | `void` | Release resources synchronously. |
+| `terminate()` | `Promise<void>` | Terminate the runtime. |
+
+---
+
+## System Driver Factories
+
+### `createNodeDriver(options?)`
+
+Creates a system driver for Node.js environments.
+
+```ts
+createNodeDriver(options?: NodeDriverOptions): SystemDriver
+```
+
+**`NodeDriverOptions`**
+
+| Option | Type | Description |
+|---|---|---|
+| `filesystem` | `VirtualFileSystem` | Custom filesystem. Default: host fs with module overlay. |
+| `moduleAccess` | `ModuleAccessOptions` | Node modules overlay config. |
+| `networkAdapter` | `NetworkAdapter` | Network implementation. |
+| `commandExecutor` | `CommandExecutor` | Child process executor. |
+| `permissions` | `Permissions` | Access control rules. Deny-by-default. |
+| `useDefaultNetwork` | `boolean` | Enable default Node.js network adapter. |
+| `processConfig` | `ProcessConfig` | Process metadata (cwd, env, argv, etc.). |
+| `osConfig` | `OSConfig` | OS metadata (platform, arch, homedir, etc.). |
+
+### `createBrowserDriver(options?)`
+
+Creates a system driver for browser environments. Returns a promise because OPFS initialization is async.
+
+```ts
+createBrowserDriver(options?: BrowserDriverOptions): Promise<SystemDriver>
+```
+
+**`BrowserDriverOptions`**
+
+| Option | Type | Description |
+|---|---|---|
+| `filesystem` | `"opfs" \| "memory"` | Filesystem backend. Default: `"opfs"`. |
+| `permissions` | `Permissions` | Access control rules. Deny-by-default. |
+| `useDefaultNetwork` | `boolean` | Enable browser fetch network adapter. |
+
+---
+
+## Runtime Driver Factories
+
+### `createNodeRuntimeDriverFactory(options?)`
+
+Creates a factory for Node.js V8 isolate runtime drivers.
+
+```ts
+createNodeRuntimeDriverFactory(options?: {
+  createIsolate?(memoryLimit: number): unknown;
+}): NodeRuntimeDriverFactory
+```
+
+### `createBrowserRuntimeDriverFactory(options?)`
+
+Creates a factory for browser Worker-based runtime drivers.
+
+```ts
+createBrowserRuntimeDriverFactory(options?: {
+  workerUrl?: URL | string;
+}): NodeRuntimeDriverFactory
+```
+
+### `createPyodideRuntimeDriverFactory()`
+
+Creates a factory for Pyodide-based Python runtime drivers.
+
+```ts
+createPyodideRuntimeDriverFactory(): PythonRuntimeDriverFactory
+```
+
+---
+
+## Filesystem
+
+### `createInMemoryFileSystem()`
+
+Creates a fully in-memory filesystem backed by Maps.
+
+```ts
+createInMemoryFileSystem(): InMemoryFileSystem
+```
+
+### `createOpfsFileSystem()`
+
+Creates an OPFS-backed filesystem (browser only).
+
+```ts
+createOpfsFileSystem(): Promise<VirtualFileSystem>
+```
+
+### `NodeFileSystem`
+
+Thin wrapper around Node.js `fs/promises`.
+
+```ts
+new NodeFileSystem()
+```
+
+### `VirtualFileSystem` interface
+
+| Method | Returns | Description |
+|---|---|---|
+| `readFile(path)` | `Promise<Uint8Array>` | Read file as bytes. |
+| `readTextFile(path)` | `Promise<string>` | Read file as text. |
+| `readDir(path)` | `Promise<string[]>` | List directory entries. |
+| `readDirWithTypes(path)` | `Promise<DirEntry[]>` | List entries with type info. |
+| `writeFile(path, content)` | `Promise<void>` | Write file. |
+| `createDir(path)` | `Promise<void>` | Create directory. |
+| `mkdir(path)` | `Promise<void>` | Create directory (alias). |
+| `exists(path)` | `Promise<boolean>` | Check if path exists. |
+| `stat(path)` | `Promise<StatInfo>` | Get file metadata. |
+| `removeFile(path)` | `Promise<void>` | Delete a file. |
+| `removeDir(path)` | `Promise<void>` | Delete a directory. |
+| `rename(old, new)` | `Promise<void>` | Rename a file or directory. |
+
+---
+
+## Network
+
+### `createDefaultNetworkAdapter()`
+
+Creates a network adapter with real fetch, DNS, and HTTP support (Node.js only).
+
+```ts
+createDefaultNetworkAdapter(): NetworkAdapter
+```
+
+### `createBrowserNetworkAdapter()`
+
+Creates a fetch-only network adapter for browser environments. No DNS support.
+
+```ts
+createBrowserNetworkAdapter(): NetworkAdapter
+```
+
+### `NetworkAdapter` interface
+
+| Method | Returns | Description |
+|---|---|---|
+| `fetch(url, options?)` | `Promise<FetchResponse>` | HTTP fetch. |
+| `dnsLookup(hostname)` | `Promise<DnsResult>` | DNS resolution. |
+| `httpRequest(url, options?)` | `Promise<HttpResponse>` | Low-level HTTP request. |
+| `httpServerListen?(options)` | `Promise<{ address }>` | Start a loopback HTTP server. |
+| `httpServerClose?(serverId)` | `Promise<void>` | Close a loopback HTTP server. |
+
+---
+
+## Permissions
+
+### Pre-built helpers
+
+| Export | Description |
+|---|---|
+| `allowAll` | Allow all operations. |
+| `allowAllFs` | Allow all filesystem operations. |
+| `allowAllNetwork` | Allow all network operations. |
+| `allowAllChildProcess` | Allow all child process spawning. |
+| `allowAllEnv` | Allow all environment variable access. |
+
+### `Permissions` type
+
+```ts
+type Permissions = {
+  fs?: PermissionCheck<FsAccessRequest>;
+  network?: PermissionCheck<NetworkAccessRequest>;
+  childProcess?: PermissionCheck<ChildProcessAccessRequest>;
+  env?: PermissionCheck<EnvAccessRequest>;
+};
+```
+
+Each field accepts a `PermissionCheck`, which is either a boolean or a function `(request) => boolean | Promise<boolean>`.
+
+---
+
+## Execution Types
+
+### `ExecOptions`
+
+| Option | Type | Description |
+|---|---|---|
+| `filePath` | `string` | Script filename for error messages. |
+| `env` | `Record<string, string>` | Override environment variables. |
+| `cwd` | `string` | Working directory. |
+| `stdin` | `string` | Stdin data. |
+| `cpuTimeLimitMs` | `number` | CPU budget override. |
+| `timingMitigation` | `"off" \| "freeze"` | Timing mitigation override. |
+| `onStdio` | `StdioHook` | Per-execution stdio hook. |
+
+### `ExecResult`
+
+```ts
+{ code: number; errorMessage?: string }
+```
+
+### `RunResult<T>`
+
+```ts
+{ code: number; errorMessage?: string; exports?: T }
+```
+
+### `PythonRunResult<T>`
+
+```ts
+{ code: number; errorMessage?: string; value?: T; globals?: Record<string, unknown> }
+```
+
+### `PythonRunOptions`
+
+Extends `ExecOptions` with:
+
+| Option | Type | Description |
+|---|---|---|
+| `globals` | `string[]` | Python globals to return. |
+
+### `StdioHook`
+
+```ts
+type StdioHook = (event: { channel: "stdout" | "stderr"; message: string }) => void;
+```
+
+---
+
+## Configuration Types
+
+### `ProcessConfig`
+
+| Field | Type | Default |
+|---|---|---|
+| `platform` | `string` | — |
+| `arch` | `string` | — |
+| `version` | `string` | — |
+| `cwd` | `string` | `"/root"` |
+| `env` | `Record<string, string>` | — |
+| `argv` | `string[]` | — |
+| `execPath` | `string` | — |
+| `pid` | `number` | — |
+| `ppid` | `number` | — |
+| `uid` | `number` | — |
+| `gid` | `number` | — |
+| `stdin` | `string` | — |
+| `timingMitigation` | `"off" \| "freeze"` | — |
+| `frozenTimeMs` | `number` | — |
+
+### `OSConfig`
+
+| Field | Type | Default |
+|---|---|---|
+| `platform` | `string` | — |
+| `arch` | `string` | — |
+| `type` | `string` | — |
+| `release` | `string` | — |
+| `version` | `string` | — |
+| `homedir` | `string` | `"/root"` |
+| `tmpdir` | `string` | `"/tmp"` |
+| `hostname` | `string` | — |
+
+### `SystemDriver`
+
+```ts
+type SystemDriver = {
+  filesystem?: VirtualFileSystem;
+  network?: NetworkAdapter;
+  commandExecutor?: CommandExecutor;
+  permissions?: Permissions;
+  runtime: DriverRuntimeConfig;
+};
+```
+
+### `CommandExecutor` interface
+
+| Method | Returns | Description |
+|---|---|---|
+| `spawn(command, args, options?)` | `SpawnedProcess` | Spawn a child process. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -11,7 +11,23 @@
     "groups": [
       {
         "group": "Getting Started",
-        "pages": ["quickstart"]
+        "pages": ["quickstart", "api-reference"]
+      },
+      {
+        "group": "Runtimes",
+        "pages": [
+          "runtimes/overview",
+          "runtimes/node",
+          "runtimes/python"
+        ]
+      },
+      {
+        "group": "System Drivers",
+        "pages": [
+          "system-drivers/overview",
+          "system-drivers/node",
+          "system-drivers/browser"
+        ]
       },
       {
         "group": "Security",

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,36 +1,34 @@
 ---
 title: Quickstart
-description: Get secure-exec running from TypeScript in a few minutes.
+description: Get secure-exec running in a few minutes.
 ---
 
-<Steps>
-  <Step title="Install secure-exec">
-    ```bash
-    npm add secure-exec
-    ```
-  </Step>
-  <Step title="Execute code">
-    ```ts
-    import { NodeRuntime, createNodeDriver, createNodeRuntimeDriverFactory } from "secure-exec";
+## Install
 
-    const proc = new NodeRuntime({
-      systemDriver: createNodeDriver({}),
+```bash
+pnpm add secure-exec
+```
+
+## Create a runtime
+
+A runtime needs two things: a **system driver** that provides host capabilities (filesystem, network, permissions) and a **runtime driver** that manages the sandboxed execution environment.
+
+<Tabs>
+  <Tab title="Node">
+    ```ts
+    import {
+      NodeRuntime,
+      createNodeDriver,
+      createNodeRuntimeDriverFactory,
+    } from "secure-exec";
+
+    const runtime = new NodeRuntime({
+      systemDriver: createNodeDriver(),
       runtimeDriverFactory: createNodeRuntimeDriverFactory(),
     });
-    const logs: string[] = [];
-    const result = await proc.exec("console.log('hello from secure-exec')", {
-      onStdio: (event) => {
-        logs.push(`[${event.channel}] ${event.message}`);
-      },
-    });
-    if (result.errorMessage) {
-      throw new Error(result.errorMessage);
-    }
-    console.log(logs.join("\n"));
-    await proc.dispose();
     ```
-  </Step>
-  <Step title="Execute code in browser">
+  </Tab>
+  <Tab title="Browser">
     ```ts
     import {
       NodeRuntime,
@@ -39,17 +37,41 @@ description: Get secure-exec running from TypeScript in a few minutes.
     } from "secure-exec/browser";
 
     const runtime = new NodeRuntime({
-      systemDriver: await createBrowserDriver({
-        filesystem: "memory",
-      }),
+      systemDriver: await createBrowserDriver({ filesystem: "memory" }),
       runtimeDriverFactory: createBrowserRuntimeDriverFactory(),
     });
-
-    const result = await runtime.exec("console.log('hello from browser runtime')");
-    if (result.errorMessage) {
-      throw new Error(result.errorMessage);
-    }
-    await runtime.terminate();
     ```
-  </Step>
-</Steps>
+  </Tab>
+</Tabs>
+
+## Execute code
+
+Use `exec()` to run code in the sandbox. Console output is streamed through the `onStdio` hook.
+
+```ts
+const logs: string[] = [];
+
+const result = await runtime.exec("console.log('hello from secure-exec')", {
+  onStdio: (event) => logs.push(`[${event.channel}] ${event.message}`),
+});
+
+console.log(logs.join("\n"));
+// [stdout] hello from secure-exec
+```
+
+## Return a value
+
+Use `run()` to execute code and get an exported value back.
+
+```ts
+const result = await runtime.run<number>("export default 2 + 2");
+console.log(result.exports); // 4
+```
+
+## Clean up
+
+Dispose the runtime when you're done to free resources.
+
+```ts
+runtime.dispose();
+```

--- a/docs/runtimes/node.mdx
+++ b/docs/runtimes/node.mdx
@@ -1,0 +1,69 @@
+---
+title: Node Runtime
+description: Sandboxed JavaScript execution in a V8 isolate.
+---
+
+`NodeRuntime` runs JavaScript in an isolated V8 isolate. It supports memory limits, CPU time budgets, and timing side-channel mitigation. The sandbox provides Node.js-compatible APIs through a bridge layer.
+
+## Creating a runtime
+
+A `NodeRuntime` requires a [system driver](/system-drivers/overview) and a runtime driver factory.
+
+```ts
+import {
+  NodeRuntime,
+  createNodeDriver,
+  createNodeRuntimeDriverFactory,
+} from "secure-exec";
+
+const runtime = new NodeRuntime({
+  systemDriver: createNodeDriver(),
+  runtimeDriverFactory: createNodeRuntimeDriverFactory(),
+});
+```
+
+## exec vs run
+
+Use `exec()` when you care about side effects (logging, file writes) but don't need a return value.
+
+```ts
+const result = await runtime.exec("console.log('done')");
+console.log(result.code); // 0
+```
+
+Use `run()` when you need a value back. The sandboxed code should use `export default`.
+
+```ts
+const result = await runtime.run<number>("export default 40 + 2");
+console.log(result.exports); // 42
+```
+
+## Capturing output
+
+Console output is not buffered into the result. Use the `onStdio` hook to capture it.
+
+```ts
+const logs: string[] = [];
+await runtime.exec("console.log('hello'); console.error('oops')", {
+  onStdio: (event) => logs.push(`[${event.channel}] ${event.message}`),
+});
+// logs: ["[stdout] hello", "[stderr] oops"]
+```
+
+## Resource limits
+
+You can cap memory and CPU time to prevent runaway code from exhausting host resources.
+
+```ts
+const runtime = new NodeRuntime({
+  systemDriver: createNodeDriver(),
+  runtimeDriverFactory: createNodeRuntimeDriverFactory(),
+  memoryLimit: 128,        // 128 MB isolate memory cap
+  cpuTimeLimitMs: 5000,    // 5 second CPU budget
+  timingMitigation: "freeze", // freeze high-resolution timers (default)
+});
+```
+
+## Module loading
+
+The sandbox provides a read-only overlay of the host's `node_modules` at `/app/node_modules`. Sandboxed code can `import` or `require()` packages installed on the host without any additional configuration.

--- a/docs/runtimes/overview.mdx
+++ b/docs/runtimes/overview.mdx
@@ -1,0 +1,22 @@
+---
+title: Runtimes
+description: Sandboxed execution environments for running untrusted code.
+---
+
+A **runtime** is a sandboxed execution environment. You give it code, it runs that code in isolation, and returns the result. Runtimes enforce resource limits (CPU time, memory) and prevent untrusted code from accessing the host system directly.
+
+Every runtime exposes two methods for executing code:
+
+- **`exec(code)`** — run code for its side effects (console output, file writes). Returns an exit code.
+- **`run(code)`** — run code and get a value back (the default export in Node, or an evaluated expression in Python).
+
+Console output is not buffered by default. Use the `onStdio` hook to capture it.
+
+<CardGroup cols={2}>
+  <Card title="Node" icon="js" href="/runtimes/node">
+    Sandboxed JavaScript in a V8 isolate with memory limits, CPU budgets, and timing mitigation.
+  </Card>
+  <Card title="Python" icon="python" href="/runtimes/python">
+    Sandboxed Python via Pyodide in a Worker thread with CPU budgets and globals exchange.
+  </Card>
+</CardGroup>

--- a/docs/runtimes/python.mdx
+++ b/docs/runtimes/python.mdx
@@ -1,0 +1,60 @@
+---
+title: Python Runtime
+description: Sandboxed Python execution via Pyodide.
+---
+
+`PythonRuntime` runs Python code in a Pyodide environment inside a Worker thread. It supports CPU time budgets and bidirectional data exchange through globals.
+
+## Creating a runtime
+
+A `PythonRuntime` requires a [system driver](/system-drivers/overview) and a Pyodide runtime driver factory.
+
+```ts
+import {
+  PythonRuntime,
+  createNodeDriver,
+  createPyodideRuntimeDriverFactory,
+} from "secure-exec";
+
+const runtime = new PythonRuntime({
+  systemDriver: createNodeDriver(),
+  runtimeDriverFactory: createPyodideRuntimeDriverFactory(),
+});
+```
+
+## exec vs run
+
+Use `exec()` for side effects.
+
+```ts
+const result = await runtime.exec("print('hello from python')");
+console.log(result.code); // 0
+```
+
+Use `run()` to get a value back. The last expression in the code is returned as `value`. You can also request specific globals.
+
+```ts
+const result = await runtime.run<number>("x = 40 + 2\nx", {
+  globals: ["x"],
+});
+console.log(result.value);   // 42
+console.log(result.globals);  // { x: 42 }
+```
+
+## Capturing output
+
+Same pattern as Node — use the `onStdio` hook.
+
+```ts
+const logs: string[] = [];
+await runtime.exec("print('hello')", {
+  onStdio: (event) => logs.push(event.message),
+});
+```
+
+## Differences from Node runtime
+
+- No `memoryLimit` — Pyodide runs in a Worker thread, not a V8 isolate
+- No `timingMitigation` — not applicable to the Pyodide environment
+- `run()` returns `value` and `globals` instead of `exports`
+- Globals exchange lets you pass data into and out of the Python environment

--- a/docs/system-drivers/browser.mdx
+++ b/docs/system-drivers/browser.mdx
@@ -1,0 +1,63 @@
+---
+title: Browser System Driver
+description: Browser-compatible system driver with OPFS and fetch-based networking.
+---
+
+The browser system driver provides sandboxed runtimes with filesystem and network capabilities that work in browser environments. It uses OPFS or an in-memory filesystem and fetch-based networking.
+
+## Basic setup
+
+`createBrowserDriver` is async because OPFS initialization requires awaiting.
+
+```ts
+import {
+  NodeRuntime,
+  createBrowserDriver,
+  createBrowserRuntimeDriverFactory,
+} from "secure-exec/browser";
+
+const runtime = new NodeRuntime({
+  systemDriver: await createBrowserDriver(),
+  runtimeDriverFactory: createBrowserRuntimeDriverFactory(),
+});
+```
+
+## Filesystem options
+
+Choose between persistent OPFS storage or a transient in-memory filesystem.
+
+```ts
+// Persistent (default)
+const driver = await createBrowserDriver({ filesystem: "opfs" });
+
+// In-memory
+const driver = await createBrowserDriver({ filesystem: "memory" });
+```
+
+## Networking
+
+Enable the browser fetch adapter to allow sandboxed code to make HTTP requests.
+
+```ts
+const driver = await createBrowserDriver({
+  useDefaultNetwork: true,
+  permissions: { network: true },
+});
+```
+
+## Worker URL
+
+Customize the worker script URL if you need to serve it from a specific path.
+
+```ts
+const runtimeDriver = createBrowserRuntimeDriverFactory({
+  workerUrl: new URL("/workers/secure-exec.js", import.meta.url),
+});
+```
+
+## Differences from Node driver
+
+- **Async creation** — `createBrowserDriver` returns a `Promise`
+- **No child processes** — `CommandExecutor` is not available
+- **No DNS** — only fetch-based networking, no `dnsLookup`
+- **OPFS limitations** — atomic rename is not supported

--- a/docs/system-drivers/node.mdx
+++ b/docs/system-drivers/node.mdx
@@ -1,0 +1,77 @@
+---
+title: Node System Driver
+description: Server-side system driver with full host capabilities.
+---
+
+The Node system driver provides sandboxed runtimes with access to the host filesystem, networking, child processes, and environment — all behind a permission layer.
+
+## Basic setup
+
+With no options, the driver provides a filesystem with a read-only `node_modules` overlay and no network or child process access.
+
+```ts
+import { createNodeDriver } from "secure-exec";
+
+const driver = createNodeDriver();
+```
+
+## Configuring capabilities
+
+Pass options to enable and configure specific host capabilities.
+
+```ts
+import {
+  createNodeDriver,
+  createDefaultNetworkAdapter,
+  allowAllFs,
+  allowAllNetwork,
+} from "secure-exec";
+
+const driver = createNodeDriver({
+  useDefaultNetwork: true,
+  permissions: {
+    fs: allowAllFs,
+    network: allowAllNetwork,
+  },
+  processConfig: {
+    cwd: "/app",
+    env: { NODE_ENV: "production" },
+  },
+});
+```
+
+## Permissions
+
+Permissions are deny-by-default. Each capability (filesystem, network, child process, env) can be controlled independently with a boolean or a function for fine-grained checks.
+
+```ts
+const driver = createNodeDriver({
+  permissions: {
+    fs: (request) => request.path.startsWith("/app/data/"),
+    network: (request) => request.host === "api.example.com",
+    childProcess: false,
+    env: (request) => ["NODE_ENV", "PATH"].includes(request.name),
+  },
+});
+```
+
+## Filesystem
+
+By default, the driver uses `ModuleAccessFileSystem`, which provides a read-only overlay of the host's `node_modules`. You can supply a custom `VirtualFileSystem` implementation or use the built-in in-memory filesystem.
+
+```ts
+import { createNodeDriver, createInMemoryFileSystem } from "secure-exec";
+
+const fs = createInMemoryFileSystem();
+await fs.writeFile("/app/data.json", '{"key": "value"}');
+
+const driver = createNodeDriver({ filesystem: fs });
+```
+
+## Child processes
+
+Provide a `CommandExecutor` to allow sandboxed code to spawn processes. This is gated behind the `childProcess` permission.
+
+## Process and OS configuration
+
+Use `processConfig` and `osConfig` to control what the sandbox sees for `process.cwd()`, `process.env`, `os.platform()`, and similar APIs.

--- a/docs/system-drivers/overview.mdx
+++ b/docs/system-drivers/overview.mdx
@@ -1,0 +1,17 @@
+---
+title: System Drivers
+description: Host capabilities provided to sandboxed runtimes.
+---
+
+A **system driver** defines what host capabilities a sandboxed runtime can access. It controls the filesystem, network, child process execution, and permission boundaries available to untrusted code.
+
+All capabilities are **deny-by-default**. If you don't configure a filesystem, sandboxed code has no file access. If you don't configure a network adapter, it can't make requests. Permissions provide fine-grained control over what operations are allowed even when a capability is present.
+
+<CardGroup cols={2}>
+  <Card title="Node" icon="node-js" href="/system-drivers/node">
+    Full-featured driver for server-side Node.js with real filesystem, networking, and child process support.
+  </Card>
+  <Card title="Browser" icon="globe" href="/system-drivers/browser">
+    Browser-compatible driver with OPFS or in-memory filesystem and fetch-based networking.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Restructure documentation with new conceptual architecture:

- Rewrote quickstart with tabs for Node vs Browser setup
- Added complete API reference page listing all exports and types
- Introduced Runtimes group with overview, Node, and Python pages
- Introduced System Drivers group with overview, Node, and Browser pages
- Each runtime/driver page provides conceptual overview with illustrative code snippets
- Updated CLAUDE.md with documentation maintenance checklist