### PR TITLE
Extract TypeScript compiler to companion @secure-exec/typescript package

### DIFF
--- a/docs-internal/arch/overview.md
+++ b/docs-internal/arch/overview.md
@@ -1,9 +1,9 @@
 # Architecture Overview
 
 ```
-NodeRuntime | PythonRuntime
-  → SystemDriver + NodeRuntimeDriverFactory | PythonRuntimeDriverFactory
-  → NodeExecutionDriver (node target) | BrowserRuntimeDriver + Worker runtime (browser target) | PyodideRuntimeDriver + Worker runtime (python target)
+NodeRuntime | PythonRuntime | createTypeScriptTools
+  → SystemDriver + NodeRuntimeDriverFactory | PythonRuntimeDriverFactory | compiler SystemDriver + NodeRuntimeDriverFactory
+  → NodeExecutionDriver (node target) | BrowserRuntimeDriver + Worker runtime (browser target) | PyodideRuntimeDriver + Worker runtime (python target) | compiler NodeRuntime sandbox
 ```
 
 ## NodeRuntime / PythonRuntime
@@ -19,6 +19,16 @@ Public APIs. Thin facades that delegate orchestration to runtime drivers.
 - Requires both:
   - `systemDriver` for runtime capabilities/config
   - runtime-driver factory for runtime-driver construction
+
+## TypeScript Tools
+
+`packages/secure-exec-typescript/src/index.ts`
+
+Optional companion package for sandboxed TypeScript compiler work (`@secure-exec/typescript`).
+
+- `createTypeScriptTools(...)` — build project/source compile and typecheck helpers
+- Uses a dedicated `NodeRuntime` compiler sandbox per request
+- Keeps TypeScript compiler execution out of the core runtime path
 
 ## SystemDriver
 

--- a/docs-internal/friction.md
+++ b/docs-internal/friction.md
@@ -1,5 +1,12 @@
 # Sandboxed Node Friction Log
 
+## 2026-03-10
+
+1. **[resolved]** TypeScript compilation needed sandboxing without baking compiler behavior into the core runtime.
+   - Symptom: keeping TypeScript handling inside `NodeRuntime` blurred the runtime contract, risked host-memory pressure during compilation, and forced browser/runtime surfaces to inherit TypeScript-specific policy.
+   - Fix: core `secure-exec` now stays JavaScript-only, while sandboxed TypeScript typecheck/compile flows move to the separate `@secure-exec/typescript` package.
+   - Compatibility trade-off: callers that want TypeScript must perform an explicit compile/typecheck step before executing emitted JavaScript in the runtime.
+
 ## 2026-03-09
 
 1. **[resolved]** Python `exec()` env overrides bypassed `permissions.env`.

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -30,10 +30,41 @@ new NodeRuntime(options: NodeRuntimeOptions)
 | Method | Returns | Description |
 |---|---|---|
 | `exec(code, options?)` | `Promise<ExecResult>` | Execute code without a return value. |
-| `run<T>(code, filePath?)` | `Promise<RunResult<T>>` | Execute code and return the default export. |
+| `run<T>(code, filePath?)` | `Promise<RunResult<T>>` | Execute code and return the module namespace/default export object. |
 | `network` | `{ fetch, dnsLookup, httpRequest }` | Network access from the host side. |
 | `dispose()` | `void` | Release resources synchronously. |
 | `terminate()` | `Promise<void>` | Terminate the runtime. |
+
+---
+
+## TypeScript Tools (`@secure-exec/typescript`)
+
+### `createTypeScriptTools(options)`
+
+Creates sandboxed TypeScript project/source helpers backed by a dedicated compiler runtime.
+
+```ts
+createTypeScriptTools(options: TypeScriptToolsOptions)
+```
+
+**`TypeScriptToolsOptions`**
+
+| Option | Type | Description |
+|---|---|---|
+| `systemDriver` | `SystemDriver` | Compiler runtime capabilities and filesystem view. |
+| `runtimeDriverFactory` | `NodeRuntimeDriverFactory` | Creates the compiler sandbox runtime. |
+| `memoryLimit` | `number` | Compiler sandbox isolate memory cap in MB. Default `512`. |
+| `cpuTimeLimitMs` | `number` | Compiler sandbox CPU time budget in ms. |
+| `compilerSpecifier` | `string` | Module specifier used to load the TypeScript compiler. Default `"typescript"`. |
+
+**Methods**
+
+| Method | Returns | Description |
+|---|---|---|
+| `typecheckProject(options?)` | `Promise<TypeCheckResult>` | Type-check a filesystem-backed TypeScript project using `tsconfig` discovery or `configFilePath`. |
+| `compileProject(options?)` | `Promise<ProjectCompileResult>` | Compile a filesystem-backed project and write emitted files through the configured filesystem like `tsc`. |
+| `typecheckSource(options)` | `Promise<TypeCheckResult>` | Type-check one TypeScript source string without mutating the filesystem. |
+| `compileSource(options)` | `Promise<SourceCompileResult>` | Compile one TypeScript source string and return JavaScript text. |
 
 ---
 
@@ -284,6 +315,71 @@ Extends `ExecOptions` with:
 
 ```ts
 type StdioHook = (event: { channel: "stdout" | "stderr"; message: string }) => void;
+```
+
+### `ProjectCompilerOptions`
+
+```ts
+{
+  cwd?: string;
+  configFilePath?: string;
+}
+```
+
+### `SourceCompilerOptions`
+
+```ts
+{
+  sourceText: string;
+  filePath?: string;
+  cwd?: string;
+  configFilePath?: string;
+  compilerOptions?: Record<string, unknown>;
+}
+```
+
+### `TypeCheckResult`
+
+```ts
+{
+  success: boolean;
+  diagnostics: TypeScriptDiagnostic[];
+}
+```
+
+### `ProjectCompileResult`
+
+```ts
+{
+  success: boolean;
+  diagnostics: TypeScriptDiagnostic[];
+  emitSkipped: boolean;
+  emittedFiles: string[];
+}
+```
+
+### `SourceCompileResult`
+
+```ts
+{
+  success: boolean;
+  diagnostics: TypeScriptDiagnostic[];
+  outputText?: string;
+  sourceMapText?: string;
+}
+```
+
+### `TypeScriptDiagnostic`
+
+```ts
+{
+  code: number;
+  category: "error" | "warning" | "suggestion" | "message";
+  message: string;
+  filePath?: string;
+  line?: number;
+  column?: number;
+}
 ```
 
 ---

--- a/docs/node-compatability.mdx
+++ b/docs/node-compatability.mdx
@@ -60,6 +60,11 @@ Unsupported modules use: `"<module> is not supported in sandbox"`.
 - By default, secure-exec drops console emissions instead of buffering runtime-managed output.
 - Consumers that need logs should use the explicit `onStdio` hook to stream `stdout`/`stderr` events in emission order.
 
+## TypeScript Workflows
+
+- Core `secure-exec` runtimes execute JavaScript only.
+- Sandboxed TypeScript type checking and compilation belong in the separate `@secure-exec/typescript` package.
+
 ## Node-Modules Overlay Behavior
 
 - Node runtime composes a read-only `/app/node_modules` overlay from `<cwd>/node_modules` (default `cwd` is host `process.cwd()`, configurable via `moduleAccess.cwd`).

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -9,6 +9,12 @@ description: Get secure-exec running in a few minutes.
 pnpm add secure-exec
 ```
 
+Optional TypeScript tooling:
+
+```bash
+pnpm add @secure-exec/typescript
+```
+
 ## Create a runtime
 
 A runtime needs two things: a **system driver** that provides host capabilities (filesystem, network, permissions) and a **runtime driver** that manages the sandboxed execution environment.
@@ -51,7 +57,7 @@ Use `exec()` to run code in the sandbox. Console output is streamed through the 
 ```ts
 const logs: string[] = [];
 
-const result = await runtime.exec("console.log('hello from secure-exec')", {
+const result = await runtime.exec("const value = 'hello from secure-exec'; console.log(value)", {
   onStdio: (event) => logs.push(`[${event.channel}] ${event.message}`),
 });
 
@@ -64,9 +70,11 @@ console.log(logs.join("\n"));
 Use `run()` to execute code and get an exported value back.
 
 ```ts
-const result = await runtime.run<number>("export default 2 + 2");
-console.log(result.exports); // 4
+const result = await runtime.run<{ default: number }>("export default 2 + 2");
+console.log(result.exports?.default); // 4
 ```
+
+If you want sandboxed TypeScript type checking or compilation before execution, use the separate `@secure-exec/typescript` package and pass its emitted JavaScript into `secure-exec`.
 
 ## Clean up
 

--- a/docs/runtimes/node.mdx
+++ b/docs/runtimes/node.mdx
@@ -3,7 +3,7 @@ title: Node Runtime
 description: Sandboxed JavaScript execution in a V8 isolate.
 ---
 
-`NodeRuntime` runs JavaScript in an isolated V8 isolate. It supports memory limits, CPU time budgets, and timing side-channel mitigation. The sandbox provides Node.js-compatible APIs through a bridge layer.
+`NodeRuntime` runs JavaScript code in an isolated V8 isolate. The sandbox supports memory limits, CPU time budgets, and timing side-channel mitigation.
 
 ## Creating a runtime
 
@@ -27,15 +27,15 @@ const runtime = new NodeRuntime({
 Use `exec()` when you care about side effects (logging, file writes) but don't need a return value.
 
 ```ts
-const result = await runtime.exec("console.log('done')");
+const result = await runtime.exec("const label = 'done'; console.log(label)");
 console.log(result.code); // 0
 ```
 
 Use `run()` when you need a value back. The sandboxed code should use `export default`.
 
 ```ts
-const result = await runtime.run<number>("export default 40 + 2");
-console.log(result.exports); // 42
+const result = await runtime.run<{ default: number }>("export default 40 + 2");
+console.log(result.exports?.default); // 42
 ```
 
 ## Capturing output
@@ -49,6 +49,10 @@ await runtime.exec("console.log('hello'); console.error('oops')", {
 });
 // logs: ["[stdout] hello", "[stderr] oops"]
 ```
+
+## TypeScript workflows
+
+`NodeRuntime` executes JavaScript only. For sandboxed TypeScript type checking or compilation, use the separate `@secure-exec/typescript` package. See [TypeScript support](#typescript-support).
 
 ## Resource limits
 
@@ -67,3 +71,141 @@ const runtime = new NodeRuntime({
 ## Module loading
 
 The sandbox provides a read-only overlay of the host's `node_modules` at `/app/node_modules`. Sandboxed code can `import` or `require()` packages installed on the host without any additional configuration.
+
+## TypeScript support
+
+TypeScript support lives in the companion `@secure-exec/typescript` package. It runs the TypeScript compiler inside a dedicated sandbox so untrusted inputs cannot consume host CPU or memory during type checking or compilation.
+
+Shared setup:
+
+```ts
+import {
+  createInMemoryFileSystem,
+  createNodeDriver,
+  createNodeRuntimeDriverFactory,
+} from "secure-exec";
+import { createTypeScriptTools } from "@secure-exec/typescript";
+
+const filesystem = createInMemoryFileSystem();
+const systemDriver = createNodeDriver({ filesystem });
+const runtimeDriverFactory = createNodeRuntimeDriverFactory();
+const ts = createTypeScriptTools({
+  systemDriver,
+  runtimeDriverFactory,
+});
+```
+
+### Type check source
+
+Use `typecheckSource(...)` when you want to quickly validate AI-generated code before running it:
+
+```ts
+const result = await ts.typecheckSource({
+  filePath: "/root/snippet.ts",
+  sourceText: `
+    export function greet(name: string) {
+      return "hello " + missingValue;
+    }
+  `,
+});
+
+console.log(result.success); // false
+console.log(result.diagnostics[0]?.message);
+```
+
+### Type check project
+
+Use `typecheckProject(...)` when you want to validate a full TypeScript project from the filesystem exposed by the system driver. That means `tsconfig.json`, source files, and any other project inputs are read from that sandbox filesystem view.
+
+```ts
+await filesystem.mkdir("/root/src");
+await filesystem.writeFile(
+  "/root/tsconfig.json",
+  JSON.stringify({
+    compilerOptions: {
+      module: "nodenext",
+      moduleResolution: "nodenext",
+      target: "es2022",
+    },
+    include: ["src/**/*.ts"],
+  }),
+);
+await filesystem.writeFile(
+  "/root/src/index.ts",
+  "export const value: string = 123;\n",
+);
+
+const result = await ts.typecheckProject({ cwd: "/root" });
+
+console.log(result.success); // false
+console.log(result.diagnostics[0]?.message);
+```
+
+### Compile source
+
+Use `compileSource(...)` when you want to transpile one TypeScript source string and then hand the emitted JavaScript to `NodeRuntime`:
+
+```ts
+import { NodeRuntime } from "secure-exec";
+
+const compiled = await ts.compileSource({
+  filePath: "/root/example.ts",
+  sourceText: "export default 40 + 2;",
+  compilerOptions: {
+    module: "esnext",
+    target: "es2022",
+  },
+});
+
+const runtime = new NodeRuntime({
+  systemDriver,
+  runtimeDriverFactory,
+});
+
+const execution = await runtime.run<{ default: number }>(
+  compiled.outputText ?? "",
+  "/root/example.js",
+);
+
+console.log(execution.exports?.default); // 42
+```
+
+### Compile project
+
+Use `compileProject(...)` when you want TypeScript to read a real project from the filesystem exposed by the system driver and write emitted files back into that same sandbox filesystem view.
+
+```ts
+import {
+  NodeRuntime,
+} from "secure-exec";
+await filesystem.mkdir("/root/src");
+await filesystem.writeFile(
+  "/root/tsconfig.json",
+  JSON.stringify({
+    compilerOptions: {
+      module: "commonjs",
+      target: "es2022",
+      outDir: "/root/dist",
+    },
+    include: ["src/**/*.ts"],
+  }),
+);
+await filesystem.writeFile(
+  "/root/src/index.ts",
+  "export const answer: number = 42;\n",
+);
+
+await ts.compileProject({ cwd: "/root" });
+
+const runtime = new NodeRuntime({
+  systemDriver,
+  runtimeDriverFactory,
+});
+
+const execution = await runtime.run<{ answer: number }>(
+  "module.exports = require('./dist/index.js');",
+  "/root/entry.js",
+);
+
+console.log(execution.exports); // { answer: 42 }
+```

--- a/openspec/changes/extract-typescript-tools-package/.openspec.yaml
+++ b/openspec/changes/extract-typescript-tools-package/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-10

--- a/openspec/changes/extract-typescript-tools-package/design.md
+++ b/openspec/changes/extract-typescript-tools-package/design.md
@@ -1,0 +1,99 @@
+# Design: Sandbox TypeScript in a companion package
+
+## Context
+
+`secure-exec` should execute JavaScript. TypeScript compile and typecheck are separate toolchain concerns, and here they also carry a security concern: compiler work must not execute on the host where untrusted type graphs can grow memory usage outside the sandbox boundary.
+
+The extracted design keeps the runtime contract simple:
+
+- core runtime executes JavaScript only
+- TypeScript tooling lives in a companion package
+- compiler work runs inside a dedicated `NodeRuntime` sandbox
+
+## Goals
+
+- Prevent TypeScript compiler work from running on the host.
+- Restore a JavaScript-only core runtime contract across Node and browser targets.
+- Support both filesystem-backed projects and simple string-based TypeScript workflows.
+- Keep project compilation behavior close to `tsc`, including filesystem writes through the configured sandbox filesystem.
+- Return deterministic diagnostics when compiler sandbox limits are exceeded.
+
+## Non-Goals
+
+- Embedding TypeScript handling back into `NodeRuntime`.
+- Supporting watch mode, project references, or long-lived language-server behavior in v1.
+- Implementing whole-project bundling into one JavaScript file.
+
+## Decisions
+
+### Decision: Add a companion `@secure-exec/typescript` package
+
+The new package exposes a factory:
+
+- `createTypeScriptTools({ systemDriver, runtimeDriverFactory, memoryLimit, cpuTimeLimitMs, compilerSpecifier })`
+
+And four methods:
+
+- `typecheckProject(...)`
+- `compileProject(...)`
+- `typecheckSource(...)`
+- `compileSource(...)`
+
+This keeps TypeScript policy out of the core runtime while still giving callers a straightforward convenience layer.
+
+### Decision: Use the TypeScript compiler API inside the sandbox
+
+The implementation loads the `typescript` package inside the compiler sandbox and uses compiler APIs directly instead of invoking the `tsc` CLI.
+
+Why:
+
+- keeps compiler execution inside the sandbox
+- avoids host `tsc` process orchestration
+- allows source helpers to use an in-memory overlay host for string input
+- lets project compile and typecheck share one straightforward API surface
+
+### Decision: Project helpers follow `tsc`-style filesystem behavior
+
+`typecheckProject(...)` resolves `tsconfig.json` discovery and project graphs through the compiler API.
+
+`compileProject(...)` emits files through the configured filesystem like `tsc`. The initial implementation writes outputs as the compiler emits them, which preserves the familiar partial-write shape of project compilation rather than adding a separate transactional layer.
+
+### Decision: Source helpers are simple string-in/string-out utilities
+
+`typecheckSource(...)` and `compileSource(...)` accept one source string plus optional file/config/compiler options.
+
+They do not bundle dependency graphs. `compileSource(...)` returns emitted JavaScript text for a single source module.
+
+### Decision: Compiler failures normalize to deterministic diagnostics
+
+If compiler execution exceeds the configured sandbox memory or CPU limit, the package returns a failed result with a deterministic diagnostic message rather than surfacing raw host crashes.
+
+## Architecture
+
+```text
+caller TS/project
+  -> createTypeScriptTools(...)
+  -> compiler request
+  -> dedicated NodeRuntime compiler sandbox
+  -> load `typescript` inside sandbox
+  -> compiler API uses configured filesystem/module-access view
+  -> diagnostics + emitted outputs returned to caller
+  -> caller executes emitted JavaScript in NodeRuntime or browser runtime
+```
+
+## Risks And Mitigations
+
+- Risk: project compilation can still consume significant resources inside the compiler sandbox.
+  - Mitigation: require compiler sandbox memory/CPU limits and normalize limit failures.
+- Risk: project/source semantics drift away from `tsc`.
+  - Mitigation: use the compiler API directly and keep tests focused on `tsconfig`, `node_modules` type resolution, and filesystem writes.
+- Risk: callers assume browser runtime can host the compiler sandbox directly.
+  - Mitigation: document that browser execution remains JS-only and TypeScript should be compiled before browser runtime execution.
+
+## Implementation Outline
+
+1. Remove TypeScript runtime options and compiler paths from `packages/secure-exec`.
+2. Remove browser runtime TypeScript handling and restore browser/playground TypeScript transpilation outside the core runtime.
+3. Add `packages/secure-exec-typescript` with sandboxed project/source helpers published as `@secure-exec/typescript`.
+4. Update docs, architecture notes, friction log, and OpenSpec baselines.
+5. Add integration coverage for compiler sandbox behavior and JS-only runtime regressions.

--- a/openspec/changes/extract-typescript-tools-package/proposal.md
+++ b/openspec/changes/extract-typescript-tools-package/proposal.md
@@ -1,0 +1,45 @@
+# Proposal: Extract TypeScript tooling into a sandboxed companion package
+
+## Why
+
+TypeScript compiler work does not belong in the core runtime path. It widens the core API contract, duplicates behavior across runtime targets, and allows untrusted compiler workloads to consume host resources before execution reaches the sandbox boundary we actually trust.
+
+We need to:
+
+- keep core `secure-exec` runtime behavior JavaScript-only
+- move TypeScript project/source workflows into a dedicated companion package
+- run the TypeScript compiler API inside a dedicated sandbox runtime instead of on the host
+- remove the browser runtime TypeScript path and keep browser execution JavaScript-only
+
+## What Changes
+
+- Remove TypeScript-specific runtime options, typecheck APIs, and transpilation/typecheck behavior from the core `secure-exec` runtime and browser runtime path.
+- Add a new `@secure-exec/typescript` package exposing:
+  - `typecheckProject(...)`
+  - `compileProject(...)`
+  - `typecheckSource(...)`
+  - `compileSource(...)`
+- Implement those helpers by running the TypeScript compiler API inside a dedicated compiler sandbox runtime with deterministic runtime-limit failures.
+- Update the playground/browser flow to keep TypeScript transpilation outside the core browser runtime.
+- Update docs and OpenSpec baselines so the JS-only core runtime boundary and companion tooling package are explicit.
+
+## Modified Capabilities
+
+- `node-runtime`
+- `compatibility-governance`
+
+## Added Capabilities
+
+- `typescript-tools`
+
+## Tests
+
+- Update Node runtime-driver coverage to prove TypeScript-only syntax fails as JavaScript in the Node runtime.
+- Update browser runtime-driver coverage to prove TypeScript-only syntax fails as JavaScript in the browser runtime.
+- Add `@secure-exec/typescript` integration coverage for:
+  - project typecheck with types resolved from `node_modules`
+  - project compile writing outputs to the configured filesystem
+  - source typecheck without filesystem mutation
+  - source compile returning JavaScript text
+  - deterministic compiler memory-limit failures
+- Run targeted playground/browser regression coverage touched by the browser TypeScript-path removal.

--- a/openspec/changes/extract-typescript-tools-package/specs/compatibility-governance/spec.md
+++ b/openspec/changes/extract-typescript-tools-package/specs/compatibility-governance/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+### Requirement: TypeScript Tooling Split Must Stay Documented
+Changes that add, remove, or materially alter TypeScript compile/typecheck behavior MUST update core runtime docs and companion tooling docs in the same change so the JS-only core/runtime boundary stays explicit.
+
+#### Scenario: Core runtime TypeScript handling changes
+- **WHEN** the core runtime adds or removes implicit TypeScript preprocessing behavior
+- **THEN** `docs/quickstart.mdx`, `docs/api-reference.mdx`, `docs/runtimes/node.mdx`, `docs/node-compatability.mdx`, `docs-internal/arch/overview.md`, and `docs-internal/friction.md` MUST be updated in the same change
+
+#### Scenario: Companion TypeScript tooling API changes
+- **WHEN** the public API of the companion TypeScript tooling package changes
+- **THEN** `docs/quickstart.mdx` and `docs/api-reference.mdx` MUST be updated in the same change so project/source helper semantics remain accurate

--- a/openspec/changes/extract-typescript-tools-package/specs/node-runtime/spec.md
+++ b/openspec/changes/extract-typescript-tools-package/specs/node-runtime/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+### Requirement: Core Runtime Executes JavaScript Without Implicit TypeScript Preprocessing
+The core `NodeRuntime` SHALL treat string input as JavaScript for both Node-target and browser-target runtime drivers and SHALL NOT provide built-in TypeScript type checking or transpilation behavior.
+
+#### Scenario: Node target rejects TypeScript-only syntax through normal execution failure
+- **WHEN** a caller invokes `NodeRuntime.exec()` or `NodeRuntime.run()` with TypeScript-only syntax such as type annotations in a Node-target runtime
+- **THEN** execution MUST fail through the normal JavaScript parse or evaluation path instead of applying implicit TypeScript preprocessing
+
+#### Scenario: Browser target rejects TypeScript-only syntax through normal execution failure
+- **WHEN** a caller invokes `NodeRuntime.exec()` or `NodeRuntime.run()` with TypeScript-only syntax such as type annotations in a browser-target runtime
+- **THEN** execution MUST fail through the normal JavaScript parse or evaluation path instead of applying implicit TypeScript preprocessing

--- a/openspec/changes/extract-typescript-tools-package/specs/typescript-tools/spec.md
+++ b/openspec/changes/extract-typescript-tools-package/specs/typescript-tools/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+### Requirement: Companion Package Exposes Project And Source Helpers
+The project SHALL provide a companion TypeScript tooling package that exposes project-backed and source-backed compile/typecheck helpers through a factory API.
+
+#### Scenario: Create TypeScript tools with compiler sandbox drivers
+- **WHEN** a caller creates the TypeScript tools factory with a system driver and runtime-driver factory
+- **THEN** the package MUST expose `typecheckProject`, `compileProject`, `typecheckSource`, and `compileSource` helpers that run against that configured compiler sandbox
+
+### Requirement: Project Helpers Must Follow TypeScript Project Semantics
+Project-backed helpers SHALL resolve `tsconfig` and module/type inputs using the TypeScript compiler API and the configured filesystem view, and project compilation SHALL write emitted files through that filesystem like `tsc`.
+
+#### Scenario: Project typecheck resolves workspace node_modules types
+- **WHEN** a project `tsconfig.json` references Node types or packages available through the configured module-access view
+- **THEN** `typecheckProject` MUST resolve those types through the compiler API and report diagnostics as TypeScript would for that project graph
+
+#### Scenario: Project compile writes emitted files to the configured filesystem
+- **WHEN** `compileProject` succeeds for a filesystem-backed project with an `outDir`
+- **THEN** emitted JavaScript and related outputs MUST be written through the configured filesystem and the result MUST report emitted file paths
+
+### Requirement: Source Helpers Must Support Simple String Workflows
+Source-backed helpers SHALL support single-source TypeScript inputs without requiring the caller to materialize a full project on disk.
+
+#### Scenario: Source typecheck reports diagnostics for a single string input
+- **WHEN** a caller invokes `typecheckSource` with one TypeScript source string
+- **THEN** the result MUST include TypeScript diagnostics for that source without mutating the configured filesystem
+
+#### Scenario: Source compile returns JavaScript text
+- **WHEN** a caller invokes `compileSource` with one TypeScript source string
+- **THEN** the result MUST return emitted JavaScript text for that source and MAY return an emitted source map when compiler options request one
+
+### Requirement: Compiler Execution Must Stay Sandboxed And Deterministic
+The companion package SHALL run TypeScript compiler work inside a dedicated sandbox runtime and SHALL normalize compiler runtime-limit failures into deterministic diagnostics.
+
+#### Scenario: Compiler sandbox memory limit failure returns deterministic diagnostics
+- **WHEN** compiler work exceeds the configured sandbox memory limit
+- **THEN** the package MUST return a failed result with deterministic diagnostics and MUST NOT crash the host process

--- a/openspec/changes/extract-typescript-tools-package/tasks.md
+++ b/openspec/changes/extract-typescript-tools-package/tasks.md
@@ -1,0 +1,32 @@
+## 1. Core Runtime Cleanup
+
+- [x] 1.1 Remove TypeScript-specific runtime APIs and types from `packages/secure-exec` so `NodeRuntime` and browser runtime targets execute JavaScript only.
+- [x] 1.2 Remove the browser runtime TypeScript path and restore browser/playground TypeScript transpilation outside the core runtime.
+- [x] 1.3 Add Node/browser runtime-driver regression tests proving TypeScript-only syntax fails through normal JavaScript execution.
+
+## 2. Companion Package
+
+- [x] 2.1 Add `packages/secure-exec-typescript` with `createTypeScriptTools(...)`, published as `@secure-exec/typescript`.
+- [x] 2.2 Implement `typecheckProject(...)` and `compileProject(...)` using the TypeScript compiler API inside a dedicated sandbox runtime.
+- [x] 2.3 Implement `typecheckSource(...)` and `compileSource(...)` for single-source string workflows.
+- [x] 2.4 Add integration coverage for project compile/typecheck, source compile/typecheck, and deterministic compiler memory-limit failures.
+
+## 3. Docs And Specs
+
+- [x] 3.1 Update docs to describe the JS-only core runtime and the companion `@secure-exec/typescript` package.
+- [x] 3.2 Update architecture/friction notes for the extracted compiler sandbox design.
+- [x] 3.3 Update OpenSpec baselines and add the new `typescript-tools` capability.
+
+## 4. Validation
+
+- [x] 4.1 Run `pnpm install` if needed to refresh workspace links for the new package.
+- [x] 4.2 Run `pnpm --filter secure-exec check-types`.
+- [x] 4.3 Run `pnpm --filter @secure-exec/typescript check-types`.
+- [x] 4.4 Run targeted secure-exec runtime coverage:
+  - `pnpm --filter secure-exec exec vitest run tests/runtime-driver/node/runtime.test.ts`
+  - `pnpm --filter secure-exec exec vitest run --config vitest.browser.config.ts tests/runtime-driver/browser/runtime.test.ts`
+  - `pnpm --filter secure-exec exec vitest run tests/test-suite/node.test.ts`
+  - `pnpm --filter secure-exec exec vitest run --config vitest.browser.config.ts tests/test-suite/node.test.ts`
+- [x] 4.5 Run `pnpm --filter @secure-exec/typescript exec vitest run tests/typescript-tools.integration.test.ts`.
+- [x] 4.6 Run `pnpm --filter playground exec vitest run tests/server.behavior.test.ts`.
+- [x] 4.7 Run `pnpm turbo build --filter @secure-exec/typescript`.

--- a/openspec/specs/README.md
+++ b/openspec/specs/README.md
@@ -3,6 +3,7 @@
 Use these baseline capabilities when proposing secure-exec runtime or bridge changes:
 
 - `node-runtime`
+- `typescript-tools`
 - `node-stdlib`
 - `node-bridge`
 - `node-permissions`
@@ -18,6 +19,7 @@ Use these baseline capabilities when proposing secure-exec runtime or bridge cha
 ## Typical Mapping
 
 - Runtime execution semantics, async completion, module loading behavior -> `node-runtime`
+- Sandboxed TypeScript compile/typecheck helpers -> `typescript-tools`
 - Stdlib support tiers, builtin resolution behavior, polyfill/stub policy -> `node-stdlib`
 - Bridge scope, module-resolution boundary, capability exposure rules -> `node-bridge`
 - Permission defaults and allow/deny behavior -> `node-permissions`

--- a/openspec/specs/compatibility-governance/spec.md
+++ b/openspec/specs/compatibility-governance/spec.md
@@ -3,6 +3,17 @@
 ## Purpose
 Define compatibility and tracking obligations for secure-exec changes.
 ## Requirements
+### Requirement: TypeScript Tooling Split Must Stay Documented
+Changes that add, remove, or materially alter TypeScript compile/typecheck behavior MUST update core runtime docs and companion tooling docs in the same change so the JS-only core/runtime boundary stays explicit.
+
+#### Scenario: Core runtime TypeScript handling changes
+- **WHEN** the core runtime adds or removes implicit TypeScript preprocessing behavior
+- **THEN** `docs/quickstart.mdx`, `docs/api-reference.mdx`, `docs/runtimes/node.mdx`, `docs/node-compatability.mdx`, `docs-internal/arch/overview.md`, and `docs-internal/friction.md` MUST be updated in the same change
+
+#### Scenario: Companion TypeScript tooling API changes
+- **WHEN** the public API of the companion TypeScript tooling package changes
+- **THEN** `docs/quickstart.mdx` and `docs/api-reference.mdx` MUST be updated in the same change so project/source helper semantics remain accurate
+
 ### Requirement: Maintain Node Stdlib Compatibility Matrix
 Changes affecting bridged or polyfilled Node APIs MUST keep `docs/node-compatability.mdx` synchronized with the actual runtime surface, including supported, limited, and unsupported modules/APIs. Every module entry in the matrix MUST include an explicit support-tier classification (Bridge, Polyfill, Stub, Deferred, or Unsupported) as defined by the `node-stdlib` spec. The page MUST include a top-of-page target Node version statement.
 
@@ -285,4 +296,3 @@ Repository test wiring MUST keep `packages/secure-exec/tests/test-suite.test.ts`
 #### Scenario: Canonical shared runtime entrypoint remains singular
 - **WHEN** contributors update package scripts or Vitest include patterns for shared runtime coverage
 - **THEN** shared runtime matrix execution MUST remain anchored on `packages/secure-exec/tests/test-suite.test.ts` as the canonical entrypoint
-

--- a/openspec/specs/node-runtime/spec.md
+++ b/openspec/specs/node-runtime/spec.md
@@ -30,6 +30,17 @@ The project SHALL provide a stable sandbox execution interface through `NodeRunt
 - **WHEN** a caller invokes `run()` with ESM code containing both `export default` and named `export` declarations
 - **THEN** the result's `exports` field MUST be an object containing both the `default` property and all named export properties
 
+### Requirement: Core Runtime Executes JavaScript Without Implicit TypeScript Preprocessing
+The core `NodeRuntime` SHALL treat string input as JavaScript for both Node-target and browser-target runtime drivers and SHALL NOT provide built-in TypeScript type checking or transpilation behavior.
+
+#### Scenario: Node target rejects TypeScript-only syntax through normal execution failure
+- **WHEN** a caller invokes `NodeRuntime.exec()` or `NodeRuntime.run()` with TypeScript-only syntax such as type annotations in a Node-target runtime
+- **THEN** execution MUST fail through the normal JavaScript parse or evaluation path instead of applying implicit TypeScript preprocessing
+
+#### Scenario: Browser target rejects TypeScript-only syntax through normal execution failure
+- **WHEN** a caller invokes `NodeRuntime.exec()` or `NodeRuntime.run()` with TypeScript-only syntax such as type annotations in a browser-target runtime
+- **THEN** execution MUST fail through the normal JavaScript parse or evaluation path instead of applying implicit TypeScript preprocessing
+
 ### Requirement: Driver-Based Capability Composition
 Runtime capabilities SHALL be composed through host-provided system drivers so filesystem, network, and child-process behavior are controlled by configured adapters rather than hardcoded runtime behavior. `NodeRuntime` construction SHALL require both a capability-side `SystemDriver` and an execution-side `RuntimeDriverFactory`.
 
@@ -424,4 +435,3 @@ The runtime contract MUST expose browser execution through `NodeRuntime` driver 
 #### Scenario: Runtime entrypoint is unified by driver target
 - **WHEN** a caller needs browser execution behavior
 - **THEN** they MUST construct `NodeRuntime` with browser system/runtime drivers rather than a separate browser sandbox runtime class
-

--- a/openspec/specs/typescript-tools/spec.md
+++ b/openspec/specs/typescript-tools/spec.md
@@ -1,0 +1,41 @@
+# typescript-tools Specification
+
+## Purpose
+Define the sandboxed TypeScript compile/typecheck helper contract exposed outside the core runtime.
+
+## Requirements
+### Requirement: Companion Package Exposes Project And Source Helpers
+The project SHALL provide a companion TypeScript tooling package that exposes project-backed and source-backed compile/typecheck helpers through a factory API.
+
+#### Scenario: Create TypeScript tools with compiler sandbox drivers
+- **WHEN** a caller creates the TypeScript tools factory with a system driver and runtime-driver factory
+- **THEN** the package MUST expose `typecheckProject`, `compileProject`, `typecheckSource`, and `compileSource` helpers that run against that configured compiler sandbox
+
+### Requirement: Project Helpers Must Follow TypeScript Project Semantics
+Project-backed helpers SHALL resolve `tsconfig` and module/type inputs using the TypeScript compiler API and the configured filesystem view, and project compilation SHALL write emitted files through that filesystem like `tsc`.
+
+#### Scenario: Project typecheck resolves workspace node_modules types
+- **WHEN** a project `tsconfig.json` references Node types or packages available through the configured module-access view
+- **THEN** `typecheckProject` MUST resolve those types through the compiler API and report diagnostics as TypeScript would for that project graph
+
+#### Scenario: Project compile writes emitted files to the configured filesystem
+- **WHEN** `compileProject` succeeds for a filesystem-backed project with an `outDir`
+- **THEN** emitted JavaScript and related outputs MUST be written through the configured filesystem and the result MUST report emitted file paths
+
+### Requirement: Source Helpers Must Support Simple String Workflows
+Source-backed helpers SHALL support single-source TypeScript inputs without requiring the caller to materialize a full project on disk.
+
+#### Scenario: Source typecheck reports diagnostics for a single string input
+- **WHEN** a caller invokes `typecheckSource` with one TypeScript source string
+- **THEN** the result MUST include TypeScript diagnostics for that source without mutating the configured filesystem
+
+#### Scenario: Source compile returns JavaScript text
+- **WHEN** a caller invokes `compileSource` with one TypeScript source string
+- **THEN** the result MUST return emitted JavaScript text for that source and MAY return an emitted source map when compiler options request one
+
+### Requirement: Compiler Execution Must Stay Sandboxed And Deterministic
+The companion package SHALL run TypeScript compiler work inside a dedicated sandbox runtime and SHALL normalize compiler runtime-limit failures into deterministic diagnostics.
+
+#### Scenario: Compiler sandbox memory limit failure returns deterministic diagnostics
+- **WHEN** compiler work exceeds the configured sandbox memory limit
+- **THEN** the package MUST return a failed result with deterministic diagnostics and MUST NOT crash the host process

--- a/packages/playground/tests/server.behavior.test.ts
+++ b/packages/playground/tests/server.behavior.test.ts
@@ -1,7 +1,26 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { createBrowserPlaygroundServer } from "../backend/server.js";
 
 let server: ReturnType<typeof createBrowserPlaygroundServer> | null = null;
+const playgroundDir = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const vendorDir = resolve(playgroundDir, "vendor");
+let tempDir: string | null = null;
+
+async function createVendorFixture(): Promise<string> {
+	tempDir = await mkdtemp(resolve(tmpdir(), "playground-vendor-"));
+	const sourcePath = resolve(tempDir, "fixture.js");
+	const linkPath = resolve(vendorDir, "test-fixture.js");
+
+	await mkdir(vendorDir, { recursive: true });
+	await writeFile(sourcePath, 'console.log("fixture");\n');
+	await symlink(sourcePath, linkPath);
+
+	return "/vendor/test-fixture.js";
+}
 
 function listenOnRandomPort(s: ReturnType<typeof createBrowserPlaygroundServer>): Promise<number> {
 	return new Promise((resolve, reject) => {
@@ -30,15 +49,21 @@ afterEach(async () => {
 		});
 		server = null;
 	}
+	await rm(resolve(vendorDir, "test-fixture.js"), { force: true });
+	if (tempDir) {
+		await rm(tempDir, { recursive: true, force: true });
+		tempDir = null;
+	}
 });
 
 describe("browser playground server", () => {
 	it("serves vendor assets with COEP/COOP headers", async () => {
 		server = createBrowserPlaygroundServer();
 		const port = await listenOnRandomPort(server);
+		const assetPath = await createVendorFixture();
 
 		const response = await fetch(
-			`http://127.0.0.1:${port}/vendor/monaco/vs/loader.js`,
+			`http://127.0.0.1:${port}${assetPath}`,
 		);
 
 		expect(response.status).toBe(200);

--- a/packages/secure-exec-typescript/package.json
+++ b/packages/secure-exec-typescript/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@secure-exec/typescript",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rivet-dev/secure-exec.git",
+    "directory": "packages/secure-exec-typescript"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "secure-exec": "workspace:*",
+    "typescript": "^5.9.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/secure-exec-typescript/src/index.ts
+++ b/packages/secure-exec-typescript/src/index.ts
@@ -1,0 +1,492 @@
+import { NodeRuntime } from "secure-exec";
+import type { NodeRuntimeDriverFactory, SystemDriver } from "secure-exec";
+
+export interface TypeScriptDiagnostic {
+	code: number;
+	category: "error" | "warning" | "suggestion" | "message";
+	message: string;
+	filePath?: string;
+	line?: number;
+	column?: number;
+}
+
+export interface TypeCheckResult {
+	success: boolean;
+	diagnostics: TypeScriptDiagnostic[];
+}
+
+export interface ProjectCompileResult extends TypeCheckResult {
+	emitSkipped: boolean;
+	emittedFiles: string[];
+}
+
+export interface SourceCompileResult extends TypeCheckResult {
+	outputText?: string;
+	sourceMapText?: string;
+}
+
+export interface ProjectCompilerOptions {
+	cwd?: string;
+	configFilePath?: string;
+}
+
+export interface SourceCompilerOptions {
+	sourceText: string;
+	filePath?: string;
+	cwd?: string;
+	configFilePath?: string;
+	compilerOptions?: Record<string, unknown>;
+}
+
+export interface TypeScriptToolsOptions {
+	systemDriver: SystemDriver;
+	runtimeDriverFactory: NodeRuntimeDriverFactory;
+	memoryLimit?: number;
+	cpuTimeLimitMs?: number;
+	compilerSpecifier?: string;
+}
+
+type CompilerRequest =
+	| {
+			kind: "typecheckProject";
+			compilerSpecifier: string;
+			options: ProjectCompilerOptions;
+	  }
+	| {
+			kind: "compileProject";
+			compilerSpecifier: string;
+			options: ProjectCompilerOptions;
+	  }
+	| {
+			kind: "typecheckSource";
+			compilerSpecifier: string;
+			options: SourceCompilerOptions;
+	  }
+	| {
+			kind: "compileSource";
+			compilerSpecifier: string;
+			options: SourceCompilerOptions;
+	  };
+
+type CompilerResponse =
+	| TypeCheckResult
+	| ProjectCompileResult
+	| SourceCompileResult;
+
+type CompilerTools = {
+	typecheckProject(options?: ProjectCompilerOptions): Promise<TypeCheckResult>;
+	compileProject(options?: ProjectCompilerOptions): Promise<ProjectCompileResult>;
+	typecheckSource(options: SourceCompilerOptions): Promise<TypeCheckResult>;
+	compileSource(options: SourceCompilerOptions): Promise<SourceCompileResult>;
+};
+
+const DEFAULT_COMPILER_RUNTIME_MEMORY_LIMIT = 512;
+const COMPILER_RUNTIME_FILE_PATH = "/root/__secure_exec_typescript_compiler__.js";
+
+export function createTypeScriptTools(
+	options: TypeScriptToolsOptions,
+): CompilerTools {
+	return {
+		typecheckProject: async (requestOptions = {}) =>
+			runCompilerRequest<TypeCheckResult>(options, {
+				kind: "typecheckProject",
+				compilerSpecifier: options.compilerSpecifier ?? "typescript",
+				options: requestOptions,
+			}),
+		compileProject: async (requestOptions = {}) =>
+			runCompilerRequest<ProjectCompileResult>(options, {
+				kind: "compileProject",
+				compilerSpecifier: options.compilerSpecifier ?? "typescript",
+				options: requestOptions,
+			}),
+		typecheckSource: async (requestOptions) =>
+			runCompilerRequest<TypeCheckResult>(options, {
+				kind: "typecheckSource",
+				compilerSpecifier: options.compilerSpecifier ?? "typescript",
+				options: requestOptions,
+			}),
+		compileSource: async (requestOptions) =>
+			runCompilerRequest<SourceCompileResult>(options, {
+				kind: "compileSource",
+				compilerSpecifier: options.compilerSpecifier ?? "typescript",
+				options: requestOptions,
+			}),
+	};
+}
+
+async function runCompilerRequest<TResult extends CompilerResponse>(
+	options: TypeScriptToolsOptions,
+	request: CompilerRequest,
+): Promise<TResult> {
+	const runtime = new NodeRuntime({
+		systemDriver: options.systemDriver,
+		runtimeDriverFactory: options.runtimeDriverFactory,
+		memoryLimit: options.memoryLimit ?? DEFAULT_COMPILER_RUNTIME_MEMORY_LIMIT,
+		cpuTimeLimitMs: options.cpuTimeLimitMs,
+	});
+
+	try {
+		const result = await runtime.run<TResult>(
+			buildCompilerRuntimeSource(request),
+			COMPILER_RUNTIME_FILE_PATH,
+		);
+		if (result.code === 0 && result.exports) {
+			return result.exports;
+		}
+		return createFailureResult<TResult>(request.kind, result.errorMessage);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return createFailureResult<TResult>(request.kind, message);
+	} finally {
+		runtime.dispose();
+	}
+}
+
+function createFailureResult<TResult extends CompilerResponse>(
+	kind: CompilerRequest["kind"],
+	errorMessage?: string,
+): TResult {
+	const diagnostic = {
+		code: 0,
+		category: "error" as const,
+		message: normalizeCompilerFailureMessage(errorMessage),
+	};
+	if (kind === "compileProject") {
+		return {
+			success: false,
+			diagnostics: [diagnostic],
+			emitSkipped: true,
+			emittedFiles: [],
+		} as unknown as TResult;
+	}
+	if (kind === "compileSource") {
+		return {
+			success: false,
+			diagnostics: [diagnostic],
+		} as unknown as TResult;
+	}
+	return {
+		success: false,
+		diagnostics: [diagnostic],
+	} as unknown as TResult;
+}
+
+function normalizeCompilerFailureMessage(errorMessage?: string): string {
+	const message = (errorMessage ?? "TypeScript compiler failed").trim();
+	if (/memory limit/i.test(message)) {
+		return "TypeScript compiler exceeded sandbox memory limit";
+	}
+	if (/cpu time limit exceeded|timed out/i.test(message)) {
+		return "TypeScript compiler exceeded sandbox CPU time limit";
+	}
+	return message;
+}
+
+function buildCompilerRuntimeSource(request: CompilerRequest): string {
+	return `module.exports = (${compilerRuntimeMain.toString()})(${JSON.stringify(request)});`;
+}
+
+function compilerRuntimeMain(request: CompilerRequest): CompilerResponse {
+	const fs = require("node:fs") as typeof import("node:fs");
+	const path = require("node:path") as typeof import("node:path");
+	const ts = require(request.compilerSpecifier) as typeof import("typescript");
+
+	function toDiagnostic(
+		diagnostic: import("typescript").Diagnostic,
+	): TypeScriptDiagnostic {
+		const message = ts.flattenDiagnosticMessageText(
+			diagnostic.messageText,
+			"\n",
+		).trim();
+		const result: TypeScriptDiagnostic = {
+			code: diagnostic.code,
+			category: toDiagnosticCategory(diagnostic.category),
+			message,
+		};
+		if (!diagnostic.file || diagnostic.start === undefined) {
+			return result;
+		}
+		const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(
+			diagnostic.start,
+		);
+		result.filePath = diagnostic.file.fileName.replace(/\\/g, "/");
+		result.line = line + 1;
+		result.column = character + 1;
+		return result;
+	}
+
+	function toDiagnosticCategory(
+		category: import("typescript").DiagnosticCategory,
+	): TypeScriptDiagnostic["category"] {
+		switch (category) {
+			case ts.DiagnosticCategory.Warning:
+				return "warning";
+			case ts.DiagnosticCategory.Suggestion:
+				return "suggestion";
+			case ts.DiagnosticCategory.Message:
+				return "message";
+			case ts.DiagnosticCategory.Error:
+			default:
+				return "error";
+		}
+	}
+
+	function hasErrors(diagnostics: TypeScriptDiagnostic[]): boolean {
+		return diagnostics.some((diagnostic) => diagnostic.category === "error");
+	}
+
+	function convertCompilerOptions(
+		compilerOptions: Record<string, unknown> | undefined,
+		basePath: string,
+	): import("typescript").CompilerOptions {
+		if (!compilerOptions) {
+			return {};
+		}
+		const converted = ts.convertCompilerOptionsFromJson(compilerOptions, basePath);
+		if (converted.errors.length > 0) {
+			throw new Error(
+				converted.errors
+					.map((diagnostic) => toDiagnostic(diagnostic).message)
+					.join("\n"),
+			);
+		}
+		return converted.options;
+	}
+
+	function resolveProjectConfig(
+		options: ProjectCompilerOptions,
+		overrideCompilerOptions: import("typescript").CompilerOptions = {},
+	) {
+		const cwd = path.resolve(options.cwd ?? "/root");
+		const configFilePath =
+			options.configFilePath
+				? path.resolve(cwd, options.configFilePath)
+				: ts.findConfigFile(cwd, ts.sys.fileExists, "tsconfig.json");
+		if (!configFilePath) {
+			throw new Error(`Unable to find tsconfig.json from '${cwd}'`);
+		}
+		const configFile = ts.readConfigFile(configFilePath, ts.sys.readFile);
+		if (configFile.error) {
+			return {
+				parsed: null,
+				diagnostics: [toDiagnostic(configFile.error)],
+			};
+		}
+		const parsed = ts.parseJsonConfigFileContent(
+			configFile.config,
+			ts.sys,
+			path.dirname(configFilePath),
+			overrideCompilerOptions,
+			configFilePath,
+		);
+		return {
+			parsed,
+			diagnostics: parsed.errors.map(toDiagnostic),
+		};
+	}
+
+	function createSourceProgram(
+		options: SourceCompilerOptions,
+		overrideCompilerOptions: import("typescript").CompilerOptions = {},
+	) {
+		const cwd = path.resolve(options.cwd ?? "/root");
+		const filePath = path.resolve(
+			cwd,
+			options.filePath ?? "__secure_exec_typescript_input__.ts",
+		);
+		const projectCompilerOptions = options.configFilePath
+			? resolveProjectConfig(
+				{ cwd, configFilePath: options.configFilePath },
+				overrideCompilerOptions,
+			)
+			: { parsed: null, diagnostics: [] as TypeScriptDiagnostic[] };
+		if (projectCompilerOptions.diagnostics.length > 0) {
+			return {
+				filePath,
+				program: null,
+				host: null,
+				diagnostics: projectCompilerOptions.diagnostics,
+			};
+		}
+		const compilerOptions = {
+			target: ts.ScriptTarget.ES2022,
+			module: ts.ModuleKind.CommonJS,
+			...projectCompilerOptions.parsed?.options,
+			...convertCompilerOptions(options.compilerOptions, cwd),
+			...overrideCompilerOptions,
+		};
+		const host = ts.createCompilerHost(compilerOptions);
+		const normalizedFilePath = ts.sys.useCaseSensitiveFileNames
+			? filePath
+			: filePath.toLowerCase();
+		const defaultGetSourceFile = host.getSourceFile.bind(host);
+		const defaultReadFile = host.readFile.bind(host);
+		const defaultFileExists = host.fileExists.bind(host);
+
+		host.fileExists = (candidatePath) => {
+			const normalizedCandidate = ts.sys.useCaseSensitiveFileNames
+				? candidatePath
+				: candidatePath.toLowerCase();
+			return normalizedCandidate === normalizedFilePath || defaultFileExists(candidatePath);
+		};
+		host.readFile = (candidatePath) => {
+			const normalizedCandidate = ts.sys.useCaseSensitiveFileNames
+				? candidatePath
+				: candidatePath.toLowerCase();
+			if (normalizedCandidate === normalizedFilePath) {
+				return options.sourceText;
+			}
+			return defaultReadFile(candidatePath);
+		};
+		host.getSourceFile = (candidatePath, languageVersion, onError, shouldCreateNewSourceFile) => {
+			const normalizedCandidate = ts.sys.useCaseSensitiveFileNames
+				? candidatePath
+				: candidatePath.toLowerCase();
+			if (normalizedCandidate === normalizedFilePath) {
+				return ts.createSourceFile(
+					candidatePath,
+					options.sourceText,
+					languageVersion,
+					true,
+				);
+			}
+			return defaultGetSourceFile(
+				candidatePath,
+				languageVersion,
+				onError,
+				shouldCreateNewSourceFile,
+			);
+		};
+
+		return {
+			filePath,
+			host,
+			program: ts.createProgram([filePath], compilerOptions, host),
+			diagnostics: [] as TypeScriptDiagnostic[],
+		};
+	}
+
+	switch (request.kind) {
+		case "typecheckProject": {
+			const { parsed, diagnostics } = resolveProjectConfig(request.options, {
+				noEmit: true,
+			});
+			if (!parsed) {
+				return {
+					success: false,
+					diagnostics,
+				};
+			}
+			const program = ts.createProgram({
+				rootNames: parsed.fileNames,
+				options: parsed.options,
+				projectReferences: parsed.projectReferences,
+			});
+			const combinedDiagnostics = ts
+				.sortAndDeduplicateDiagnostics([
+					...parsed.errors,
+					...ts.getPreEmitDiagnostics(program),
+				])
+				.map(toDiagnostic);
+			return {
+				success: !hasErrors(combinedDiagnostics),
+				diagnostics: combinedDiagnostics,
+			};
+		}
+		case "compileProject": {
+			const { parsed, diagnostics } = resolveProjectConfig(request.options);
+			if (!parsed) {
+				return {
+					success: false,
+					diagnostics,
+					emitSkipped: true,
+					emittedFiles: [],
+				};
+			}
+			const program = ts.createProgram({
+				rootNames: parsed.fileNames,
+				options: parsed.options,
+				projectReferences: parsed.projectReferences,
+			});
+			const emittedFiles: string[] = [];
+			const emitResult = program.emit(
+				undefined,
+				(fileName, text) => {
+					fs.mkdirSync(path.dirname(fileName), { recursive: true });
+					fs.writeFileSync(fileName, text, "utf8");
+					emittedFiles.push(fileName.replace(/\\/g, "/"));
+				},
+			);
+			const combinedDiagnostics = ts
+				.sortAndDeduplicateDiagnostics([
+					...parsed.errors,
+					...ts.getPreEmitDiagnostics(program),
+					...emitResult.diagnostics,
+				])
+				.map(toDiagnostic);
+			return {
+				success: !hasErrors(combinedDiagnostics),
+				diagnostics: combinedDiagnostics,
+				emitSkipped: emitResult.emitSkipped,
+				emittedFiles,
+			};
+		}
+		case "typecheckSource": {
+			const { program, diagnostics } = createSourceProgram(request.options, {
+				noEmit: true,
+			});
+			if (!program) {
+				return {
+					success: false,
+					diagnostics,
+				};
+			}
+			const combinedDiagnostics = ts
+				.sortAndDeduplicateDiagnostics(ts.getPreEmitDiagnostics(program))
+				.map(toDiagnostic);
+			return {
+				success: !hasErrors(combinedDiagnostics),
+				diagnostics: combinedDiagnostics,
+			};
+		}
+		case "compileSource": {
+			const { program, diagnostics } = createSourceProgram(request.options);
+			if (!program) {
+				return {
+					success: false,
+					diagnostics,
+				};
+			}
+			let outputText: string | undefined;
+			let sourceMapText: string | undefined;
+			const emitResult = program.emit(
+				undefined,
+				(fileName, text) => {
+					if (
+						fileName.endsWith(".js") ||
+						fileName.endsWith(".mjs") ||
+						fileName.endsWith(".cjs")
+					) {
+						outputText = text;
+						return;
+					}
+					if (fileName.endsWith(".map")) {
+						sourceMapText = text;
+					}
+				},
+			);
+			const combinedDiagnostics = ts
+				.sortAndDeduplicateDiagnostics([
+					...ts.getPreEmitDiagnostics(program),
+					...emitResult.diagnostics,
+				])
+				.map(toDiagnostic);
+			return {
+				success: !hasErrors(combinedDiagnostics),
+				diagnostics: combinedDiagnostics,
+				outputText,
+				sourceMapText,
+			};
+		}
+	}
+}

--- a/packages/secure-exec-typescript/tests/typescript-tools.integration.test.ts
+++ b/packages/secure-exec-typescript/tests/typescript-tools.integration.test.ts
@@ -1,0 +1,148 @@
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	NodeRuntime,
+	allowAllFs,
+	createInMemoryFileSystem,
+	createNodeDriver,
+	createNodeRuntimeDriverFactory,
+} from "secure-exec";
+import { createTypeScriptTools } from "../src/index.js";
+
+const workspaceRoot = resolve(fileURLToPath(new URL("../../..", import.meta.url)));
+
+function createTools(memoryLimit?: number) {
+	const filesystem = createInMemoryFileSystem();
+	return {
+		filesystem,
+		tools: createTypeScriptTools({
+			systemDriver: createNodeDriver({
+				filesystem,
+				moduleAccess: { cwd: workspaceRoot },
+				permissions: allowAllFs,
+			}),
+			runtimeDriverFactory: createNodeRuntimeDriverFactory(),
+			memoryLimit,
+		}),
+	};
+}
+
+describe("@secure-exec/typescript", () => {
+	it("typechecks a project with node types from node_modules", async () => {
+		const { filesystem, tools } = createTools();
+		await filesystem.mkdir("/root/src");
+		await filesystem.writeFile(
+			"/root/tsconfig.json",
+			JSON.stringify({
+				compilerOptions: {
+					module: "nodenext",
+					moduleResolution: "nodenext",
+					target: "es2022",
+					types: ["node"],
+					skipLibCheck: true,
+				},
+				include: ["src/**/*.ts"],
+			}),
+		);
+		await filesystem.writeFile(
+			"/root/src/index.ts",
+			'import { Buffer } from "node:buffer";\nexport const output: Buffer = Buffer.from("ok");\n',
+		);
+
+		const result = await tools.typecheckProject({ cwd: "/root" });
+
+		expect(result.success).toBe(true);
+		expect(result.diagnostics).toEqual([]);
+	});
+
+	it("compiles a project into the virtual filesystem and the output executes in NodeRuntime", async () => {
+		const { filesystem, tools } = createTools();
+		await filesystem.mkdir("/root/src");
+		await filesystem.writeFile(
+			"/root/tsconfig.json",
+			JSON.stringify({
+				compilerOptions: {
+					module: "commonjs",
+					target: "es2022",
+					outDir: "/root/dist",
+				},
+				include: ["src/**/*.ts"],
+			}),
+		);
+		await filesystem.writeFile(
+			"/root/src/index.ts",
+			"export const value: number = 7;\n",
+		);
+
+		const compileResult = await tools.compileProject({ cwd: "/root" });
+
+		expect(compileResult.success).toBe(true);
+		expect(compileResult.emitSkipped).toBe(false);
+		expect(compileResult.emittedFiles).toContain("/root/dist/index.js");
+		const emitted = await filesystem.readTextFile("/root/dist/index.js");
+		expect(emitted).toContain("exports.value = 7");
+
+		const runtime = new NodeRuntime({
+			systemDriver: createNodeDriver({
+				filesystem,
+				moduleAccess: { cwd: workspaceRoot },
+				permissions: allowAllFs,
+			}),
+			runtimeDriverFactory: createNodeRuntimeDriverFactory(),
+		});
+		const execution = await runtime.run("module.exports = require('./dist/index.js');", "/root/index.js");
+		runtime.dispose();
+
+		expect(execution.code).toBe(0);
+		expect(execution.exports).toEqual({ value: 7 });
+	});
+
+	it("typechecks a source string without mutating the filesystem", async () => {
+		const { tools } = createTools();
+
+		const result = await tools.typecheckSource({
+			sourceText: "const value: string = 1;\n",
+			filePath: "/root/input.ts",
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.diagnostics.some((diagnostic) => diagnostic.code === 2322)).toBe(
+			true,
+		);
+	});
+
+	it("compiles a source string to JavaScript text", async () => {
+		const { tools } = createTools();
+
+		const result = await tools.compileSource({
+			sourceText: "export const value: number = 3;\n",
+			filePath: "/root/input.ts",
+			compilerOptions: {
+				module: "commonjs",
+				target: "es2022",
+			},
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.outputText).toContain("exports.value = 3");
+	});
+
+	it("returns a deterministic failure when the compiler isolate exceeds its memory limit", async () => {
+		const { tools } = createTools(64);
+
+		const result = await tools.typecheckSource({
+			sourceText: "export const value = 1;\n",
+			filePath: "/root/input.ts",
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.diagnostics).toEqual([
+			expect.objectContaining({
+				category: "error",
+				code: 0,
+				message: expect.any(String),
+			}),
+		]);
+	});
+});

--- a/packages/secure-exec-typescript/tsconfig.json
+++ b/packages/secure-exec-typescript/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/secure-exec/package.json
+++ b/packages/secure-exec/package.json
@@ -35,7 +35,7 @@
     "test:test-suite": "pnpm run build:generated && vitest run tests/test-suite.test.ts tests/test-suite-python.test.ts",
     "test:runtime-driver": "pnpm run build:generated && vitest run tests/runtime-driver/*.test.ts",
     "test:integration:node": "pnpm run test:test-suite && pnpm run test:runtime-driver",
-    "test:integration:browser": "pnpm run build:generated && vitest run --config vitest.browser.config.ts tests/test-suite.test.ts tests/runtime-driver/browser.test.ts",
+    "test:integration:browser": "pnpm run build:generated && vitest run --config vitest.browser.config.ts tests/test-suite/node.test.ts tests/runtime-driver/browser/runtime.test.ts",
     "test:project-matrix": "pnpm run build:generated && vitest run tests/project-matrix.test.ts",
     "test": "pnpm run build:generated && vitest run",
     "test:watch": "pnpm run build:generated && vitest"

--- a/packages/secure-exec/src/browser/worker.ts
+++ b/packages/secure-exec/src/browser/worker.ts
@@ -333,7 +333,7 @@ async function initRuntime(payload: BrowserWorkerInitPayload): Promise<void> {
 			if (source === null) return null;
 			let code = source;
 			if (isESM(source, path)) {
-				code = transform(source, { transforms: ["imports"] }).code;
+				code = transform(code, { transforms: ["imports"] }).code;
 			}
 			return transformDynamicImport(code);
 		},
@@ -587,7 +587,7 @@ async function execScript(
 	try {
 		let transformed = code;
 		if (isESM(code, options?.filePath)) {
-			transformed = transform(code, { transforms: ["imports"] }).code;
+			transformed = transform(transformed, { transforms: ["imports"] }).code;
 		}
 		transformed = transformDynamicImport(transformed);
 

--- a/packages/secure-exec/src/node/execution-driver.ts
+++ b/packages/secure-exec/src/node/execution-driver.ts
@@ -534,31 +534,27 @@ export class NodeExecutionDriver implements RuntimeDriver {
 			return builtinSpecifier;
 		}
 
-		// Handle absolute paths - return as-is
+		const referrerDir = await this.resolveReferrerDirectory(referrerPath);
+
+		// Preserve direct path imports before falling back to node_modules
+		// resolution so missing relative modules report the resolved sandbox path.
 		if (specifier.startsWith("/")) {
 			return specifier;
 		}
-
-		const referrerDir = await this.resolveReferrerDirectory(referrerPath);
-
-		// Handle relative paths
 		if (specifier.startsWith("./") || specifier.startsWith("../")) {
-			// Resolve relative to referrer directory
 			const parts = referrerDir.split("/").filter(Boolean);
-			const specParts = specifier.split("/");
-
-			for (const part of specParts) {
+			for (const part of specifier.split("/")) {
 				if (part === "..") {
 					parts.pop();
-				} else if (part !== ".") {
+					continue;
+				}
+				if (part !== ".") {
 					parts.push(part);
 				}
 			}
-
 			return `/${parts.join("/")}`;
 		}
 
-		// Bare specifier - try to resolve from node_modules
 		return resolveModule(specifier, referrerDir, this.filesystem, "import");
 	}
 
@@ -1554,9 +1550,15 @@ export class NodeExecutionDriver implements RuntimeDriver {
 						jail,
 						onStdio ?? this.onStdio,
 					),
-				shouldRunAsESM: (code, filePath) => this.shouldRunAsESM(code, filePath),
+				shouldRunAsESM: (code, filePath) =>
+					this.shouldRunAsESM(code, filePath),
 				setupESMGlobals: (context, jail, timingMitigation, frozenTimeMs) =>
-					this.setupESMGlobals(context, jail, timingMitigation, frozenTimeMs),
+					this.setupESMGlobals(
+						context,
+						jail,
+						timingMitigation,
+						frozenTimeMs,
+					),
 				applyExecutionOverrides: (context, env, cwd, stdin) =>
 					this.applyExecutionOverrides(context, env, cwd, stdin),
 				precompileDynamicImports: (transformedCode, context, referrerPath) =>

--- a/packages/secure-exec/tests/runtime-driver/browser/runtime.test.ts
+++ b/packages/secure-exec/tests/runtime-driver/browser/runtime.test.ts
@@ -41,7 +41,7 @@ describe.skipIf(!IS_BROWSER_ENV)("runtime driver specific: browser", () => {
 			...options,
 			systemDriver,
 			runtimeDriverFactory: createBrowserRuntimeDriverFactory({
-				workerUrl: new URL("../../src/browser/worker.ts", import.meta.url),
+				workerUrl: new URL("../../../src/browser/worker.ts", import.meta.url),
 			}),
 		});
 		runtimes.add(runtime);
@@ -86,6 +86,22 @@ describe.skipIf(!IS_BROWSER_ENV)("runtime driver specific: browser", () => {
 			channel: "stdout",
 			message: "browser-ok",
 		});
+	});
+
+	it("treats TypeScript-only syntax as a JavaScript execution failure", async () => {
+		const runtime = await createRuntime();
+		const result = await runtime.exec(
+			`
+			const value: string = 123;
+			console.log("should-not-run");
+		`,
+			{
+				filePath: "/playground.ts",
+			},
+		);
+
+		expect(result.code).toBe(1);
+		expect(result.errorMessage).toBeDefined();
 	});
 
 	it("supports repeated exec calls on the same browser runtime", async () => {

--- a/packages/secure-exec/tests/runtime-driver/node/runtime.test.ts
+++ b/packages/secure-exec/tests/runtime-driver/node/runtime.test.ts
@@ -66,4 +66,17 @@ describe("runtime driver specific: node", () => {
 		});
 		expect(result.code).toBe(0);
 	});
+
+	it("treats TypeScript-only syntax as a JavaScript execution failure", async () => {
+		const runtime = createRuntime();
+		const result = await runtime.exec(
+			`
+			const value: string = 123;
+			console.log(value);
+		`,
+			{ filePath: "/entry.js" },
+		);
+		expect(result.code).toBe(1);
+		expect(result.errorMessage).toBeDefined();
+	});
 });

--- a/packages/secure-exec/tests/test-suite/node.test.ts
+++ b/packages/secure-exec/tests/test-suite/node.test.ts
@@ -23,8 +23,6 @@ type DisposableRuntime = {
 
 const RUNTIME_TARGETS: NodeRuntimeTarget[] = ["node", "browser"];
 const NODE_SUITES: NodeSharedSuite[] = [runNodeSuite, runNodeNetworkSuite];
-const NODE_ENTRYPOINT = "../../src/index.js";
-
 function isNodeTargetAvailable(): boolean {
 	return typeof process !== "undefined" && Boolean(process.versions?.node);
 }
@@ -41,7 +39,8 @@ function isTargetAvailable(target: NodeRuntimeTarget): boolean {
 }
 
 async function importNodeEntrypoint() {
-	return import(/* @vite-ignore */ NODE_ENTRYPOINT);
+	const entrypointUrl = new URL("../../src/index.js", import.meta.url).href;
+	return import(/* @vite-ignore */ entrypointUrl);
 }
 
 function createSuiteContext(target: NodeRuntimeTarget): NodeSuiteContext {

--- a/packages/secure-exec/vitest.browser.config.ts
+++ b/packages/secure-exec/vitest.browser.config.ts
@@ -9,8 +9,8 @@ export default defineConfig({
 	test: {
 		testTimeout: 15000,
 		include: [
-			"tests/test-suite.test.ts",
-			"tests/runtime-driver/browser.test.ts",
+			"tests/test-suite/node.test.ts",
+			"tests/runtime-driver/browser/runtime.test.ts",
 		],
 		browser: {
 			enabled: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,9 +113,22 @@ importers:
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.3)(@vitest/browser@2.1.9)
+
+  packages/secure-exec-typescript:
+    dependencies:
+      secure-exec:
+        specifier: workspace:*
+        version: link:../secure-exec
       typescript:
-        specifier: ^5.7.2
+        specifier: ^5.9.3
         version: 5.9.3
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.3
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.3)(@vitest/browser@2.1.9)
@@ -3236,7 +3249,6 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.3)(@vitest/browser@2.1.9)


### PR DESCRIPTION
## Summary

Extracts TypeScript compilation and type-checking from the core `secure-exec` runtime into a new companion package `@secure-exec/typescript`. The core runtime now executes JavaScript only, with compiler work sandboxed in a dedicated isolate to prevent untrusted type graphs from consuming host resources.

- New `createTypeScriptTools()` factory with `typecheckProject`, `compileProject`, `typecheckSource`, `compileSource` methods
- Core runtime cleanup: fixes variable consistency in browser worker transforms and adds regression tests for TypeScript-only syntax failures
- Comprehensive documentation and OpenSpec updates reflecting the JavaScript-only core contract
- Restored `typescript` devDependency to `secure-exec` package.json for its own build scripts