### PR TITLE
feat: remove UDS auth

### DIFF
--- a/crates/v8-runtime/src/main.rs
+++ b/crates/v8-runtime/src/main.rs
@@ -107,43 +107,6 @@ fn cleanup(socket_path: &PathBuf, tmpdir: &PathBuf) {
     let _ = fs::remove_dir(tmpdir);
 }
 
-/// Constant-time byte comparison to prevent timing oracle on auth token.
-/// Returns true if both slices have equal length and identical contents.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
-}
-
-/// Authenticate a new connection by reading the first message as an Authenticate token.
-/// Returns true if authentication succeeds, false otherwise.
-fn authenticate_connection(stream: &mut UnixStream, expected_token: &str) -> bool {
-    // Connection is blocking — read the first message
-    match ipc_binary::read_frame(stream) {
-        Ok(BinaryFrame::Authenticate { token }) => {
-            if constant_time_eq(token.as_bytes(), expected_token.as_bytes()) {
-                true
-            } else {
-                eprintln!("auth failed: invalid token");
-                false
-            }
-        }
-        Ok(_) => {
-            eprintln!("auth failed: first message must be Authenticate");
-            false
-        }
-        Err(e) => {
-            eprintln!("auth failed: read error: {}", e);
-            false
-        }
-    }
-}
-
 /// Dedicated writer thread per connection: drains the frame channel and
 /// writes complete frames atomically to the socket. Session threads send
 /// pre-serialized byte vectors through the channel, so no shared mutex
@@ -160,7 +123,7 @@ fn ipc_writer_thread(rx: crossbeam_channel::Receiver<Vec<u8>>, mut writer: UnixS
 /// Global connection ID counter
 static NEXT_CONNECTION_ID: AtomicU64 = AtomicU64::new(1);
 
-/// Handle an authenticated connection: read messages and dispatch to sessions.
+/// Handle a connection: read messages and dispatch to sessions.
 fn handle_connection(
     mut stream: UnixStream,
     connection_id: u64,
@@ -184,13 +147,6 @@ fn handle_connection(
 
         // Dispatch frame
         match frame {
-            BinaryFrame::Authenticate { .. } => {
-                eprintln!(
-                    "connection {}: unexpected Authenticate after handshake",
-                    connection_id
-                );
-                break;
-            }
             BinaryFrame::CreateSession {
                 session_id,
                 heap_limit_mb,
@@ -325,10 +281,6 @@ fn main() {
     // Shared snapshot cache for fast isolate creation across all connections/sessions
     let snapshot_cache = Arc::new(SnapshotCache::new(4));
 
-    // Read auth token from environment
-    let auth_token = std::env::var("SECURE_EXEC_V8_TOKEN")
-        .expect("SECURE_EXEC_V8_TOKEN environment variable must be set");
-
     // Determine max concurrency from env or default to available CPUs
     let max_concurrency = std::env::var("SECURE_EXEC_V8_MAX_SESSIONS")
         .ok()
@@ -414,17 +366,9 @@ fn main() {
         // Listener readable — accept new connection
         if pollfds[0].revents & libc::POLLIN != 0 {
             match listener.accept() {
-                Ok((mut stream, _addr)) => {
+                Ok((stream, _addr)) => {
                     // Set CLOEXEC on accepted connection
                     set_cloexec(stream.as_raw_fd()).expect("failed to set CLOEXEC on connection");
-
-                    // Accepted stream is already blocking (listener is blocking)
-
-                    // Require authentication as the first message
-                    if !authenticate_connection(&mut stream, &auth_token) {
-                        drop(stream);
-                        continue;
-                    }
 
                     // Create per-connection writer thread and IPC channel
                     let writer_stream = stream.try_clone().expect("failed to clone UDS stream");
@@ -451,7 +395,7 @@ fn main() {
                         Arc::clone(&snapshot_cache),
                     )));
 
-                    // Authenticated — spawn connection handler thread
+                    // Spawn connection handler thread
                     let mgr = Arc::clone(&session_mgr);
                     let snap = Arc::clone(&snapshot_cache);
                     std::thread::Builder::new()
@@ -594,86 +538,6 @@ mod tests {
     }
 
     #[test]
-    fn auth_accepts_valid_token() {
-        let (listener, socket_path, tmpdir) = temp_listener();
-        let token = "test-secret-token-abc123";
-
-        // Client connects and sends valid Authenticate
-        let mut client = UnixStream::connect(&socket_path).expect("connect");
-        let (mut server_stream, _) = listener.accept().expect("accept");
-
-        ipc_binary::write_frame(
-            &mut client,
-            &BinaryFrame::Authenticate {
-                token: token.into(),
-            },
-        )
-        .expect("write auth");
-
-        assert!(authenticate_connection(&mut server_stream, token));
-
-        cleanup(&socket_path, &tmpdir);
-    }
-
-    #[test]
-    fn auth_rejects_wrong_token() {
-        let (listener, socket_path, tmpdir) = temp_listener();
-
-        let mut client = UnixStream::connect(&socket_path).expect("connect");
-        let (mut server_stream, _) = listener.accept().expect("accept");
-
-        ipc_binary::write_frame(
-            &mut client,
-            &BinaryFrame::Authenticate {
-                token: "wrong-token".into(),
-            },
-        )
-        .expect("write auth");
-
-        assert!(!authenticate_connection(&mut server_stream, "correct-token"));
-
-        cleanup(&socket_path, &tmpdir);
-    }
-
-    #[test]
-    fn auth_rejects_non_authenticate_message() {
-        let (listener, socket_path, tmpdir) = temp_listener();
-
-        let mut client = UnixStream::connect(&socket_path).expect("connect");
-        let (mut server_stream, _) = listener.accept().expect("accept");
-
-        // Send a CreateSession instead of Authenticate
-        ipc_binary::write_frame(
-            &mut client,
-            &BinaryFrame::CreateSession {
-                session_id: "1".into(),
-                heap_limit_mb: 0,
-                cpu_time_limit_ms: 0,
-            },
-        )
-        .expect("write");
-
-        assert!(!authenticate_connection(&mut server_stream, "any-token"));
-
-        cleanup(&socket_path, &tmpdir);
-    }
-
-    #[test]
-    fn auth_rejects_empty_connection() {
-        let (listener, socket_path, tmpdir) = temp_listener();
-
-        let client = UnixStream::connect(&socket_path).expect("connect");
-        let (mut server_stream, _) = listener.accept().expect("accept");
-
-        // Drop client immediately — server will get EOF
-        drop(client);
-
-        assert!(!authenticate_connection(&mut server_stream, "any-token"));
-
-        cleanup(&socket_path, &tmpdir);
-    }
-
-    #[test]
     fn self_pipe_creation_and_wakeup() {
         let (read_fd, write_fd) = create_self_pipe().expect("create self-pipe");
 
@@ -726,28 +590,6 @@ mod tests {
         let _client = handle.join().expect("client thread");
 
         cleanup(&socket_path, &tmpdir);
-    }
-
-    #[test]
-    fn constant_time_eq_matches_equal_strings() {
-        assert!(constant_time_eq(b"hello", b"hello"));
-        assert!(constant_time_eq(b"", b""));
-        assert!(constant_time_eq(b"abc123xyz", b"abc123xyz"));
-    }
-
-    #[test]
-    fn constant_time_eq_rejects_different_strings() {
-        assert!(!constant_time_eq(b"hello", b"world"));
-        assert!(!constant_time_eq(b"hello", b"hellx"));
-        // Single-bit difference
-        assert!(!constant_time_eq(b"\x00", b"\x01"));
-    }
-
-    #[test]
-    fn constant_time_eq_rejects_different_lengths() {
-        assert!(!constant_time_eq(b"hello", b"hell"));
-        assert!(!constant_time_eq(b"", b"x"));
-        assert!(!constant_time_eq(b"abc", b"abcd"));
     }
 
     #[test]

--- a/crates/v8-runtime/src/session.rs
+++ b/crates/v8-runtime/src/session.rs
@@ -497,6 +497,10 @@ fn session_thread(
                         mode,
                         file_path,
                     } => {
+                        let _trace = std::env::var("SECURE_EXEC_TRACE_IPC").is_ok();
+                        let _trace_sid: String = if session_id.len() > 8 { session_id[..8].to_string() } else { session_id.clone() };
+                        let _t0 = std::time::Instant::now();
+
                         // Use cached bridge code when host sends empty (0-length = use cached)
                         let effective_bridge_code = if bridge_code.is_empty() {
                             last_bridge_code.as_deref().unwrap_or("").to_string()
@@ -529,6 +533,7 @@ fn session_thread(
                             v8_isolate = Some(iso);
                         }
 
+                        let _t_isolate = std::time::Instant::now();
                         let iso = v8_isolate.as_mut().unwrap();
 
                         // Create execution context: Context::new on a snapshot-restored
@@ -536,6 +541,7 @@ fn session_thread(
                         // (bridge IIFE already executed, all infrastructure set up).
                         // On a non-snapshot isolate, this gives a blank context.
                         let exec_context = isolate::create_context(iso);
+                        let _t_ctx = std::time::Instant::now();
 
                         // Inject globals from last InjectGlobals payload
                         if let Some(ref payload) = last_globals_payload {
@@ -544,6 +550,8 @@ fn session_thread(
                             let scope = &mut v8::ContextScope::new(scope, ctx);
                             execution::inject_globals_from_payload(scope, payload);
                         }
+
+                        let _t_globals = std::time::Instant::now();
 
                         // Create abort channel for timeout enforcement
                         let (maybe_abort_tx, maybe_abort_rx) = if cpu_time_limit_ms.is_some() {
@@ -585,6 +593,8 @@ fn session_thread(
                             );
                         }
 
+                        let _t_bridge_fns = std::time::Instant::now();
+
                         // Run post-restore init script (config, mutable state reset)
                         // after bridge fn replacement but before user code
                         if !post_restore_script.is_empty() {
@@ -618,6 +628,8 @@ fn session_thread(
                             _ => None,
                         };
 
+                        let _t_post_restore = std::time::Instant::now();
+
                         // On snapshot-restored context, skip bridge IIFE (already in
                         // snapshot) and run user code only. On fresh context, run full
                         // bridge code + user code as before.
@@ -643,6 +655,8 @@ fn session_thread(
                                 &mut bridge_cache,
                             )
                         };
+
+                        let _t_exec = std::time::Instant::now();
 
                         // Run event loop if there are pending async promises
                         let terminated = if pending.len() > 0 {
@@ -701,6 +715,21 @@ fn session_thread(
                                 }),
                             }
                         };
+
+                        if _trace {
+                            let sid = &_trace_sid;
+                            eprintln!(
+                                "[v8:{}] isolate={:.2}ms ctx={:.2}ms globals={:.2}ms bridge_fns={:.2}ms post_restore={:.2}ms exec={:.2}ms total={:.2}ms",
+                                sid,
+                                _t_isolate.duration_since(_t0).as_secs_f64() * 1000.0,
+                                _t_ctx.duration_since(_t_isolate).as_secs_f64() * 1000.0,
+                                _t_globals.duration_since(_t_ctx).as_secs_f64() * 1000.0,
+                                _t_bridge_fns.duration_since(_t_globals).as_secs_f64() * 1000.0,
+                                _t_post_restore.duration_since(_t_bridge_fns).as_secs_f64() * 1000.0,
+                                _t_exec.duration_since(_t_post_restore).as_secs_f64() * 1000.0,
+                                _t_exec.duration_since(_t0).as_secs_f64() * 1000.0,
+                            );
+                        }
 
                         send_message(&ipc_tx, &result_frame, &mut msg_frame_buf);
                     }

--- a/docs/process-isolation.mdx
+++ b/docs/process-isolation.mdx
@@ -45,9 +45,14 @@ import {
   createNodeRuntimeDriverFactory,
 } from "secure-exec";
 
+// Reuse the driver and factory across runtimes — createNodeDriver() scans
+// node_modules on each call, so creating it once avoids repeated filesystem work.
+const driver = createNodeDriver();
+const factory = createNodeRuntimeDriverFactory();
+
 const rt = new NodeRuntime({
-  systemDriver: createNodeDriver(),
-  runtimeDriverFactory: createNodeRuntimeDriverFactory(),
+  systemDriver: driver,
+  runtimeDriverFactory: factory,
 });
 ```
 
@@ -62,25 +67,21 @@ NodeRuntime C ──── Tenant 2 Process (sessions: C1)
 ```
 
 ```ts
-import { createNodeV8Runtime } from "secure-exec";
 import {
   NodeRuntime,
   createNodeDriver,
   createNodeRuntimeDriverFactory,
+  createNodeV8Runtime,
 } from "secure-exec";
+
+const driver = createNodeDriver();
 
 // Create a dedicated process for this tenant
 const tenantProcess = await createNodeV8Runtime({ maxSessions: 10 });
+const factory = createNodeRuntimeDriverFactory({ v8Runtime: tenantProcess });
 
-const rt1 = new NodeRuntime({
-  systemDriver: createNodeDriver(),
-  runtimeDriverFactory: createNodeRuntimeDriverFactory({ v8Runtime: tenantProcess }),
-});
-
-const rt2 = new NodeRuntime({
-  systemDriver: createNodeDriver(),
-  runtimeDriverFactory: createNodeRuntimeDriverFactory({ v8Runtime: tenantProcess }),
-});
+const rt1 = new NodeRuntime({ systemDriver: driver, runtimeDriverFactory: factory });
+const rt2 = new NodeRuntime({ systemDriver: driver, runtimeDriverFactory: factory });
 
 // rt1 and rt2 share tenantProcess, isolated from the global process
 ```
@@ -95,23 +96,24 @@ NodeRuntime B ──── Process B (session: B1)
 ```
 
 ```ts
-import { createNodeV8Runtime } from "secure-exec";
 import {
   NodeRuntime,
   createNodeDriver,
   createNodeRuntimeDriverFactory,
+  createNodeV8Runtime,
 } from "secure-exec";
 
+const driver = createNodeDriver();
 const processA = await createNodeV8Runtime();
 const processB = await createNodeV8Runtime();
 
 const rtA = new NodeRuntime({
-  systemDriver: createNodeDriver(),
+  systemDriver: driver,
   runtimeDriverFactory: createNodeRuntimeDriverFactory({ v8Runtime: processA }),
 });
 
 const rtB = new NodeRuntime({
-  systemDriver: createNodeDriver(),
+  systemDriver: driver,
   runtimeDriverFactory: createNodeRuntimeDriverFactory({ v8Runtime: processB }),
 });
 ```
@@ -133,17 +135,12 @@ Choose based on your isolation requirements. The shared topology is the most mem
 ```ts
 // This process allows up to 5 concurrent sessions
 const process = await createNodeV8Runtime({ maxSessions: 5 });
+const driver = createNodeDriver();
+const factory = createNodeRuntimeDriverFactory({ v8Runtime: process });
 
 // Both runtimes share the 5-session budget
-const rt1 = new NodeRuntime({
-  systemDriver: createNodeDriver(),
-  runtimeDriverFactory: createNodeRuntimeDriverFactory({ v8Runtime: process }),
-});
-
-const rt2 = new NodeRuntime({
-  systemDriver: createNodeDriver(),
-  runtimeDriverFactory: createNodeRuntimeDriverFactory({ v8Runtime: process }),
-});
+const rt1 = new NodeRuntime({ systemDriver: driver, runtimeDriverFactory: factory });
+const rt2 = new NodeRuntime({ systemDriver: driver, runtimeDriverFactory: factory });
 ```
 
 Per-execution resource limits (`memoryLimit`, `cpuTimeLimitMs`) still apply per-session regardless of topology. See [Resource Limits](/features/resource-limits) for details.
@@ -158,10 +155,11 @@ When a V8 process crashes (OOM, segfault, panic):
 
 ```ts
 const process = await createNodeV8Runtime();
+const driver = createNodeDriver();
 const factory = createNodeRuntimeDriverFactory({ v8Runtime: process });
 
 const rt = new NodeRuntime({
-  systemDriver: createNodeDriver(),
+  systemDriver: driver,
   runtimeDriverFactory: factory,
   memoryLimit: 8, // small heap to trigger OOM
 });
@@ -179,10 +177,9 @@ Cold-starting a new session costs ~6ms (thread spawn + isolate creation from sna
 
 ```ts
 const process = await createNodeV8Runtime({
-  warmupBridgeCode: bridgeCode,
-  warmPoolSize: 3,           // default: 3 when bridgeCode provided, 0 otherwise
-  defaultWarmHeapLimitMb: 128,
-  waitForWarmPool: true,     // default: true — block until pool is ready
+  warmPoolSize: 5,             // default: 5, set to 0 to disable
+  defaultWarmHeapLimitMb: 128, // default: 128
+  waitForWarmPool: true,       // default: true — block until pool is ready
 });
 ```
 

--- a/docs/system-drivers/node.mdx
+++ b/docs/system-drivers/node.mdx
@@ -17,6 +17,10 @@ import { createNodeDriver } from "secure-exec";
 const driver = createNodeDriver();
 ```
 
+<Tip>
+**Reuse the driver across runtimes.** `createNodeDriver()` scans `node_modules` for symlinks on each call, which can take 10-15ms in large monorepos. Create it once and pass the same instance to all `NodeRuntime` constructors.
+</Tip>
+
 ## Configuring capabilities
 
 Pass options to enable and configure specific host capabilities.

--- a/packages/secure-exec-node/src/execution-driver.ts
+++ b/packages/secure-exec-node/src/execution-driver.ts
@@ -9,7 +9,7 @@ export interface NodeV8RuntimeOptions {
 	binaryPath?: string;
 	/** Maximum concurrent sessions. */
 	maxSessions?: number;
-	/** Number of pre-warmed sessions. Default 3 (warm claim ~2ms vs ~6ms cold). */
+	/** Number of pre-warmed sessions. Default 5 (warm claim ~2ms vs ~6ms cold). */
 	warmPoolSize?: number;
 	/** Default heap limit (MB) for warm pool sessions. Default 128. */
 	defaultWarmHeapLimitMb?: number;
@@ -24,7 +24,7 @@ export interface NodeV8RuntimeOptions {
  *
  * This is the recommended way to create a V8 runtime — it automatically
  * provides the bridge code for snapshot warmup and configures a warm pool
- * of 3 pre-created isolates (~2ms claim vs ~6ms cold start).
+ * of 5 pre-created isolates (~2ms claim vs ~6ms cold start).
  */
 export async function createNodeV8Runtime(
 	options?: NodeV8RuntimeOptions,

--- a/packages/secure-exec-node/src/module-access.ts
+++ b/packages/secure-exec-node/src/module-access.ts
@@ -89,6 +89,10 @@ function isNativeAddonPath(pathValue: string): boolean {
  * symlink targets to build the full set of allowed host paths. This prevents
  * symlink-based escapes from the overlay projection.
  */
+// Expensive: readdirSync + realpathSync on every symlink in node_modules
+// (~20ms in a large pnpm monorepo with ~700 entries). Called once per
+// ModuleAccessFileSystem — reuse the createNodeDriver() instance to avoid
+// paying this cost repeatedly.
 function collectOverlayAllowedRoots(hostNodeModulesRoot: string): string[] {
 	const roots = new Set<string>([hostNodeModulesRoot]);
 	const symlinkScanRoots = [hostNodeModulesRoot, path.join(hostNodeModulesRoot, ".pnpm", "node_modules")];

--- a/packages/secure-exec-v8/src/ipc-client.ts
+++ b/packages/secure-exec-v8/src/ipc-client.ts
@@ -86,11 +86,6 @@ export class IpcClient {
 		});
 	}
 
-	/** Send the auth token as the first message after connecting. */
-	authenticate(token: string): void {
-		this.send({ type: "Authenticate", token });
-	}
-
 	/** Send a binary frame to the Rust process. */
 	send(frame: BinaryFrame): void {
 		if (!this.socket || !this.connected) {

--- a/packages/secure-exec-v8/src/runtime.ts
+++ b/packages/secure-exec-v8/src/runtime.ts
@@ -94,21 +94,17 @@ function resolveBinaryPath(): string {
 /**
  * Spawn the Rust V8 runtime process and return a handle.
  *
- * Generates a 128-bit auth token, passes it via SECURE_EXEC_V8_TOKEN,
- * reads the socket path from stdout, connects over UDS, and authenticates.
+ * Reads the socket path from stdout, connects over UDS, and optionally
+ * initializes the warm pool.
  */
 export async function createV8Runtime(
 	options?: V8RuntimeOptions,
 ): Promise<V8Runtime> {
 	const binaryPath = options?.binaryPath ?? resolveBinaryPath();
 
-	// Generate 128-bit random auth token
-	const authToken = randomBytes(16).toString("hex");
-
 	// Build child environment
 	const childEnv: Record<string, string> = {
 		...process.env as Record<string, string>,
-		SECURE_EXEC_V8_TOKEN: authToken,
 	};
 	if (options?.maxSessions != null) {
 		childEnv.SECURE_EXEC_V8_MAX_SESSIONS = String(options.maxSessions);
@@ -196,7 +192,6 @@ export async function createV8Runtime(
 
 	try {
 		await ipcClient.connect();
-		ipcClient.authenticate(authToken);
 
 		// Send Init to configure warm pool + snapshot cache.
 		// Warm pool defaults to 3 when bridge code is provided (snapshot-based

--- a/packages/secure-exec-v8/src/runtime.ts
+++ b/packages/secure-exec-v8/src/runtime.ts
@@ -33,7 +33,7 @@ export interface V8RuntimeOptions {
 	maxSessions?: number;
 	/** Bridge code to pre-warm the snapshot cache with (fire-and-forget). Skipped if SECURE_EXEC_NO_SNAPSHOT_WARMUP=1. */
 	warmupBridgeCode?: string;
-	/** Number of pre-warmed sessions to maintain. Default 3, 0 to disable. */
+	/** Number of pre-warmed sessions to maintain. Default 5, 0 to disable. */
 	warmPoolSize?: number;
 	/** Default heap limit (MB) for warm pool sessions. Default 128. */
 	defaultWarmHeapLimitMb?: number;
@@ -199,7 +199,7 @@ export async function createV8Runtime(
 		// pool is disabled since there's no snapshot to pre-create from.
 		const warmPoolSize = process.env.SECURE_EXEC_NO_SNAPSHOT_WARMUP === "1"
 			? 0
-			: (options?.warmPoolSize ?? (options?.warmupBridgeCode ? 3 : 0));
+			: (options?.warmPoolSize ?? (options?.warmupBridgeCode ? 5 : 0));
 		if (warmPoolSize > 0) {
 			const initReady = new Promise<void>((resolve, reject) => {
 				const timeout = setTimeout(() => {

--- a/packages/secure-exec-v8/src/runtime.ts
+++ b/packages/secure-exec-v8/src/runtime.ts
@@ -101,6 +101,9 @@ export async function createV8Runtime(
 	options?: V8RuntimeOptions,
 ): Promise<V8Runtime> {
 	const binaryPath = options?.binaryPath ?? resolveBinaryPath();
+	if (process.env.SECURE_EXEC_TRACE_IPC) {
+		console.error(`[trace] binary: ${binaryPath}`);
+	}
 
 	// Build child environment
 	const childEnv: Record<string, string> = {
@@ -139,9 +142,12 @@ export async function createV8Runtime(
 	});
 
 	// Collect stderr for error reporting
+	const traceIpc = !!process.env.SECURE_EXEC_TRACE_IPC;
 	let stderrBuf = "";
 	child.stderr!.on("data", (chunk: Buffer) => {
-		stderrBuf += chunk.toString();
+		const str = chunk.toString();
+		if (traceIpc) process.stderr.write(str);
+		stderrBuf += str;
 		// Cap buffer to avoid unbounded growth
 		if (stderrBuf.length > 8192) {
 			stderrBuf = stderrBuf.slice(-4096);
@@ -306,19 +312,27 @@ export async function createV8Runtime(
 						throw new Error("IPC client is not connected");
 					}
 
+					const _t0 = performance.now();
+
 					// Inject globals — V8-serialize { processConfig, osConfig }
 					const globalsPayload = v8.serialize({
 						processConfig: execOptions.processConfig,
 						osConfig: execOptions.osConfig,
 					});
+
+					const _tSerialize = performance.now();
+
 					client.send({
 						type: "InjectGlobals",
 						sessionId,
 						payload: globalsPayload,
 					});
 
+					const _tInjectSent = performance.now();
+
 					// Set up result promise
 					return new Promise((resolve, _reject) => {
+						const _tPromiseStart = performance.now();
 						// Register session message handler
 						sessionHandlers.set(sessionId, (frame) => {
 							switch (frame.type) {
@@ -389,6 +403,11 @@ export async function createV8Runtime(
 								case "ExecutionResult": {
 									// Clean up handler and resolve
 									sessionHandlers.delete(sessionId);
+									const _tResult = performance.now();
+									if (process.env.SECURE_EXEC_TRACE_IPC) {
+										const sid = sessionId.slice(0, 8);
+										console.error(`[ipc:${sid}] serialize=${(_tSerialize - _t0).toFixed(2)}ms inject_send=${(_tInjectSent - _tSerialize).toFixed(2)}ms ipc_wait=${(_tResult - _tPromiseStart).toFixed(2)}ms total=${(_tResult - _t0).toFixed(2)}ms`);
+									}
 									resolve({
 										code: frame.exitCode,
 										exports: frame.exports,

--- a/packages/secure-exec-v8/test/ipc-roundtrip.test.ts
+++ b/packages/secure-exec-v8/test/ipc-roundtrip.test.ts
@@ -1,7 +1,7 @@
 /**
  * Integration tests for the full V8 runtime IPC round-trip.
  *
- * Exercises: spawn Rust process, authenticate, create session,
+ * Exercises: spawn Rust process, create session,
  * inject globals, execute code with sync and async bridge calls,
  * and destroy/cleanup.
  */
@@ -85,7 +85,7 @@ describe.skipIf(skipUnlessBinary)("V8 IPC round-trip", () => {
 
 	// --- Lifecycle ---
 
-	it("spawns the Rust binary, authenticates, and disposes cleanly", async () => {
+	it("spawns the Rust binary and disposes cleanly", async () => {
 		const rt = await createRuntime();
 		// If we got here, spawn + auth succeeded
 		await rt.dispose();

--- a/packages/secure-exec-v8/test/ipc-security.test.ts
+++ b/packages/secure-exec-v8/test/ipc-security.test.ts
@@ -11,7 +11,6 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
 import { spawn, type ChildProcess } from "node:child_process";
-import { randomBytes } from "node:crypto";
 import { createInterface } from "node:readline";
 import net from "node:net";
 import v8 from "node:v8";
@@ -64,19 +63,14 @@ function defaultExecOptions(
 	};
 }
 
-/** Spawn the Rust binary and return the child, socket path, and auth token. */
+/** Spawn the Rust binary and return the child and socket path. */
 async function spawnRustBinary(): Promise<{
 	child: ChildProcess;
 	socketPath: string;
-	authToken: string;
 }> {
-	const authToken = randomBytes(16).toString("hex");
 	const child = spawn(BINARY_PATH!, [], {
 		stdio: ["ignore", "pipe", "pipe"],
-		env: {
-			...process.env,
-			SECURE_EXEC_V8_TOKEN: authToken,
-		},
+		env: { ...process.env },
 	});
 
 	// Read socket path from first stdout line
@@ -108,7 +102,7 @@ async function spawnRustBinary(): Promise<{
 		});
 	});
 
-	return { child, socketPath, authToken };
+	return { child, socketPath };
 }
 
 /** Kill child process and wait for exit. */
@@ -202,72 +196,10 @@ describe.skipIf(skipUnlessBinary)("V8 IPC security", () => {
 		children.length = 0;
 	});
 
-	// --- Auth token rejection ---
-
-	it("rejects connection with wrong auth token", async () => {
-		const { child, socketPath } = await spawnRustBinary();
-		children.push(child);
-
-		const messages: BinaryFrame[] = [];
-		let connectionClosed = false;
-
-		const client = new IpcClient({
-			socketPath,
-			onMessage: (msg) => messages.push(msg),
-			onClose: () => {
-				connectionClosed = true;
-			},
-		});
-		await client.connect();
-		clients.push(client);
-
-		// Send wrong token
-		client.authenticate("wrong-token-0000000000000000");
-
-		// Wait for Rust to close the connection
-		await new Promise((r) => setTimeout(r, 500));
-
-		expect(connectionClosed).toBe(true);
-		// No valid messages should have been received
-		expect(messages.length).toBe(0);
-	});
-
-	it("rejects connection without auth token (non-Authenticate message first)", async () => {
-		const { child, socketPath } = await spawnRustBinary();
-		children.push(child);
-
-		const messages: BinaryFrame[] = [];
-		let connectionClosed = false;
-
-		const client = new IpcClient({
-			socketPath,
-			onMessage: (msg) => messages.push(msg),
-			onClose: () => {
-				connectionClosed = true;
-			},
-		});
-		await client.connect();
-		clients.push(client);
-
-		// Send a CreateSession instead of Authenticate
-		client.send({
-			type: "CreateSession",
-			sessionId: randomBytes(16).toString("hex"),
-			heapLimitMb: 0,
-			cpuTimeLimitMs: 0,
-		});
-
-		// Wait for Rust to close the connection
-		await new Promise((r) => setTimeout(r, 500));
-
-		expect(connectionClosed).toBe(true);
-		expect(messages.length).toBe(0);
-	});
-
 	// --- Cross-session access prevention ---
 
 	it("connection B cannot send messages to connection A's sessions", async () => {
-		const { child, socketPath, authToken } = await spawnRustBinary();
+		const { child, socketPath } = await spawnRustBinary();
 		children.push(child);
 
 		// Connect client A
@@ -276,7 +208,6 @@ describe.skipIf(skipUnlessBinary)("V8 IPC security", () => {
 			messagesA.push(msg),
 		);
 		clients.push(clientA);
-		clientA.authenticate(authToken);
 
 		// Connect client B
 		const messagesB: BinaryFrame[] = [];
@@ -284,10 +215,9 @@ describe.skipIf(skipUnlessBinary)("V8 IPC security", () => {
 			messagesB.push(msg),
 		);
 		clients.push(clientB);
-		clientB.authenticate(authToken);
 
 		// Client A creates a session
-		const sessionId = randomBytes(16).toString("hex");
+		const sessionId = "test-session-cross-conn";
 		clientA.send({
 			type: "CreateSession",
 			sessionId,
@@ -401,19 +331,11 @@ describe.skipIf(skipUnlessBinary)("V8 IPC security", () => {
 	});
 
 	it("Rust process rejects oversized message length prefix", async () => {
-		const { child, socketPath, authToken } = await spawnRustBinary();
+		const { child, socketPath } = await spawnRustBinary();
 		children.push(child);
 
-		// First authenticate properly
 		const socket = net.createConnection(socketPath);
 		await new Promise<void>((r) => socket.on("connect", r));
-
-		// Send valid auth message using binary frame format
-		const authFrame = encodeFrame({ type: "Authenticate", token: authToken });
-		socket.write(authFrame);
-
-		// Wait for auth to be processed
-		await new Promise((r) => setTimeout(r, 200));
 
 		// Send a frame with length prefix > 64MB (but no actual payload)
 		const oversizedHeader = Buffer.alloc(4);
@@ -443,7 +365,7 @@ describe.skipIf(skipUnlessBinary)("V8 IPC security", () => {
 	// --- Duplicate BridgeResponse callId integrity ---
 
 	it("duplicate BridgeResponse callId does not crash or corrupt state", async () => {
-		const { child, socketPath, authToken } = await spawnRustBinary();
+		const { child, socketPath } = await spawnRustBinary();
 		children.push(child);
 
 		const messages: BinaryFrame[] = [];
@@ -451,10 +373,9 @@ describe.skipIf(skipUnlessBinary)("V8 IPC security", () => {
 			messages.push(msg),
 		);
 		clients.push(client);
-		client.authenticate(authToken);
 
 		// Create a session
-		const sessionId = randomBytes(16).toString("hex");
+		const sessionId = "test-session-dup-callid";
 		client.send({
 			type: "CreateSession",
 			sessionId,

--- a/packages/secure-exec/benchmarks/bench-utils.ts
+++ b/packages/secure-exec/benchmarks/bench-utils.ts
@@ -15,44 +15,34 @@ export const TRIVIAL_CODE = `export const x = 1;`;
 // Cap concurrency below available parallelism to leave headroom for the bench harness itself.
 export const MAX_CONCURRENCY = Math.max(1, os.availableParallelism() - 4);
 
-// Shared V8 process — spawned once via initSharedV8(), reused by all bench runtimes.
-let sharedV8: V8Runtime | null = null;
+// Shared bench infrastructure — V8 process, driver, factory created once.
+let bench: {
+	v8: V8Runtime;
+	driver: ReturnType<typeof createNodeDriver>;
+	factory: ReturnType<typeof createNodeRuntimeDriverFactory>;
+} | null = null;
 
-export async function initSharedV8(warmPoolSize?: number): Promise<V8Runtime> {
-	if (!sharedV8) {
-		sharedV8 = await createNodeV8Runtime({
-			...(warmPoolSize != null ? { warmPoolSize } : {}),
-		});
-	}
-	return sharedV8;
+export async function setupBench(warmPoolSize?: number): Promise<void> {
+	if (bench) return;
+	const v8 = await createNodeV8Runtime({
+		...(warmPoolSize != null ? { warmPoolSize } : {}),
+	});
+	const driver = createNodeDriver();
+	const factory = createNodeRuntimeDriverFactory({ v8Runtime: v8 });
+	bench = { v8, driver, factory };
 }
 
-export async function shutdownSharedV8(): Promise<void> {
-	if (sharedV8) {
-		await sharedV8.dispose();
-		sharedV8 = null;
-		sharedDriver = null;
-		sharedFactory = null;
-	}
+export async function teardownBench(): Promise<void> {
+	if (!bench) return;
+	await bench.v8.dispose();
+	bench = null;
 }
-
-// Shared driver and factory — reuse across all bench runtimes.
-// createNodeDriver() scans node_modules for symlinks on every call (~15ms),
-// so creating it once eliminates the main source of cold-start variance.
-let sharedDriver: ReturnType<typeof createNodeDriver> | null = null;
-let sharedFactory: ReturnType<typeof createNodeRuntimeDriverFactory> | null = null;
 
 export function createBenchRuntime(): NodeRuntime {
-	if (!sharedV8) {
-		throw new Error("Call initSharedV8() before createBenchRuntime()");
-	}
-	if (!sharedDriver) {
-		sharedDriver = createNodeDriver();
-		sharedFactory = createNodeRuntimeDriverFactory({ v8Runtime: sharedV8 });
-	}
+	if (!bench) throw new Error("Call setupBench() first");
 	return new NodeRuntime({
-		systemDriver: sharedDriver,
-		runtimeDriverFactory: sharedFactory!,
+		systemDriver: bench.driver,
+		runtimeDriverFactory: bench.factory,
 	});
 }
 

--- a/packages/secure-exec/benchmarks/bench-utils.ts
+++ b/packages/secure-exec/benchmarks/bench-utils.ts
@@ -31,16 +31,28 @@ export async function shutdownSharedV8(): Promise<void> {
 	if (sharedV8) {
 		await sharedV8.dispose();
 		sharedV8 = null;
+		sharedDriver = null;
+		sharedFactory = null;
 	}
 }
+
+// Shared driver and factory — reuse across all bench runtimes.
+// createNodeDriver() scans node_modules for symlinks on every call (~15ms),
+// so creating it once eliminates the main source of cold-start variance.
+let sharedDriver: ReturnType<typeof createNodeDriver> | null = null;
+let sharedFactory: ReturnType<typeof createNodeRuntimeDriverFactory> | null = null;
 
 export function createBenchRuntime(): NodeRuntime {
 	if (!sharedV8) {
 		throw new Error("Call initSharedV8() before createBenchRuntime()");
 	}
+	if (!sharedDriver) {
+		sharedDriver = createNodeDriver();
+		sharedFactory = createNodeRuntimeDriverFactory({ v8Runtime: sharedV8 });
+	}
 	return new NodeRuntime({
-		systemDriver: createNodeDriver(),
-		runtimeDriverFactory: createNodeRuntimeDriverFactory({ v8Runtime: sharedV8 }),
+		systemDriver: sharedDriver,
+		runtimeDriverFactory: sharedFactory!,
 	});
 }
 

--- a/packages/secure-exec/benchmarks/bench-utils.ts
+++ b/packages/secure-exec/benchmarks/bench-utils.ts
@@ -18,9 +18,11 @@ export const MAX_CONCURRENCY = Math.max(1, os.availableParallelism() - 4);
 // Shared V8 process — spawned once via initSharedV8(), reused by all bench runtimes.
 let sharedV8: V8Runtime | null = null;
 
-export async function initSharedV8(): Promise<V8Runtime> {
+export async function initSharedV8(warmPoolSize?: number): Promise<V8Runtime> {
 	if (!sharedV8) {
-		sharedV8 = await createNodeV8Runtime();
+		sharedV8 = await createNodeV8Runtime({
+			...(warmPoolSize != null ? { warmPoolSize } : {}),
+		});
 	}
 	return sharedV8;
 }

--- a/packages/secure-exec/benchmarks/burst.bench.ts
+++ b/packages/secure-exec/benchmarks/burst.bench.ts
@@ -1,0 +1,115 @@
+/**
+ * Burst TTI benchmark — fires N runtimes simultaneously.
+ *
+ * Matches the computesdk "concurrent/burst" pattern: all sandbox creates
+ * launch at once, measuring per-sandbox TTI and wall-clock time to all-ready.
+ *
+ * Usage: npx tsx benchmarks/burst.bench.ts
+ */
+
+import {
+	TRIVIAL_CODE,
+	MAX_CONCURRENCY,
+	createBenchRuntime,
+	initSharedV8,
+	shutdownSharedV8,
+	getHardware,
+	printTable,
+	round,
+	stats,
+} from "./bench-utils.js";
+
+const BURST_SIZES = [1, 5, 10, 25, 50];
+const ITERATIONS = 3;
+const WARMUP_ITERATIONS = 1;
+
+interface BurstResult {
+	burstSize: number;
+	perSandboxTti: ReturnType<typeof stats>;
+	wallClockMs: number;
+	timeToFirstReadyMs: number;
+}
+
+async function measureOne(): Promise<number> {
+	const t0 = performance.now();
+	const rt = createBenchRuntime();
+	await rt.run(TRIVIAL_CODE);
+	const ttiMs = performance.now() - t0;
+	await rt.terminate();
+	return ttiMs;
+}
+
+async function benchBurst(burstSize: number): Promise<BurstResult> {
+	const allTtis: number[] = [];
+	let bestWallClock = Infinity;
+	let bestFirstReady = Infinity;
+
+	for (let iter = 0; iter < WARMUP_ITERATIONS + ITERATIONS; iter++) {
+		const wallStart = performance.now();
+
+		// Fire all at once
+		const promises = Array.from({ length: burstSize }, () => measureOne());
+		const ttis = await Promise.all(promises);
+
+		const wallClockMs = performance.now() - wallStart;
+		const firstReady = Math.min(...ttis);
+
+		if (iter >= WARMUP_ITERATIONS) {
+			allTtis.push(...ttis);
+			if (wallClockMs < bestWallClock) bestWallClock = wallClockMs;
+			if (firstReady < bestFirstReady) bestFirstReady = firstReady;
+		}
+	}
+
+	return {
+		burstSize,
+		perSandboxTti: stats(allTtis),
+		wallClockMs: round(bestWallClock),
+		timeToFirstReadyMs: round(bestFirstReady),
+	};
+}
+
+async function main() {
+	const hardware = getHardware();
+	console.error("=== Burst TTI Benchmark ===");
+	console.error(`CPU: ${hardware.cpu}`);
+	console.error(`Cores: ${hardware.cores} | Max concurrency: ${MAX_CONCURRENCY}`);
+	console.error(`RAM: ${hardware.ram} | Node: ${hardware.node}`);
+	console.error(`Iterations: ${ITERATIONS} (+ ${WARMUP_ITERATIONS} warmup)`);
+	console.error(`Burst sizes: ${BURST_SIZES.join(", ")}`);
+
+	console.error("\nSpawning shared V8 process...");
+	await initSharedV8();
+	console.error("V8 process ready.\n");
+
+	const results: BurstResult[] = [];
+
+	for (const burstSize of BURST_SIZES) {
+		console.error(`--- burst=${burstSize} ---`);
+		const result = await benchBurst(burstSize);
+		results.push(result);
+		console.error(
+			`  TTI median=${result.perSandboxTti.p50}ms p95=${result.perSandboxTti.p95}ms | wall=${result.wallClockMs}ms | first=${result.timeToFirstReadyMs}ms`,
+		);
+	}
+
+	printTable(
+		["burst", "TTI median", "TTI p95", "TTI p99", "wall clock", "first ready"],
+		results.map((r) => [
+			r.burstSize,
+			`${r.perSandboxTti.p50}ms`,
+			`${r.perSandboxTti.p95}ms`,
+			`${r.perSandboxTti.p99}ms`,
+			`${r.wallClockMs}ms`,
+			`${r.timeToFirstReadyMs}ms`,
+		]),
+	);
+
+	console.log(JSON.stringify({ hardware, results }, null, 2));
+	await shutdownSharedV8();
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/packages/secure-exec/benchmarks/burst.bench.ts
+++ b/packages/secure-exec/benchmarks/burst.bench.ts
@@ -11,8 +11,8 @@ import {
 	TRIVIAL_CODE,
 	MAX_CONCURRENCY,
 	createBenchRuntime,
-	initSharedV8,
-	shutdownSharedV8,
+	setupBench,
+	teardownBench,
 	getHardware,
 	printTable,
 	round,
@@ -79,7 +79,7 @@ async function main() {
 	console.error(`Burst sizes: ${BURST_SIZES.join(", ")}`);
 
 	console.error("\nSpawning shared V8 process...");
-	await initSharedV8();
+	await setupBench();
 	console.error("V8 process ready.\n");
 
 	const results: BurstResult[] = [];
@@ -106,7 +106,7 @@ async function main() {
 	);
 
 	console.log(JSON.stringify({ hardware, results }, null, 2));
-	await shutdownSharedV8();
+	await teardownBench();
 }
 
 main().catch((err) => {

--- a/packages/secure-exec/benchmarks/coldstart.bench.ts
+++ b/packages/secure-exec/benchmarks/coldstart.bench.ts
@@ -7,7 +7,7 @@
  *   - Both sequential and concurrent modes at various batch sizes
  *
  * NOTE: The shared V8 process is spawned before the benchmark loop
- * (initSharedV8), so these numbers do NOT include V8 process startup.
+ * (setupBench), so these numbers do NOT include V8 process startup.
  * They measure only isolate/session creation + execution latency.
  *
  * With the warm pool enabled (default), "cold start" actually claims a
@@ -26,8 +26,8 @@ import {
 	TRIVIAL_CODE,
 	WARMUP_ITERATIONS,
 	createBenchRuntime,
-	initSharedV8,
-	shutdownSharedV8,
+	setupBench,
+	teardownBench,
 	getHardware,
 	printTable,
 	round,
@@ -136,7 +136,7 @@ async function main() {
 
 	// Pre-spawn the shared V8 process so the bench loop only measures isolate creation
 	console.error(`\nSpawning shared V8 process...`);
-	await initSharedV8();
+	await setupBench();
 	console.error(`V8 process ready.\n`);
 
 	const results: ColdStartEntry[] = [];
@@ -181,7 +181,7 @@ async function main() {
 	// JSON to stdout
 	console.log(JSON.stringify({ hardware, results }, null, 2));
 
-	await shutdownSharedV8();
+	await teardownBench();
 }
 
 main().catch((err) => {

--- a/packages/secure-exec/benchmarks/memory.bench.ts
+++ b/packages/secure-exec/benchmarks/memory.bench.ts
@@ -13,8 +13,8 @@ import {
 	MEMORY_ITERATIONS,
 	TRIVIAL_CODE,
 	createBenchRuntime,
-	initSharedV8,
-	shutdownSharedV8,
+	setupBench,
+	teardownBench,
 	forceGC,
 	formatBytes,
 	getHardware,
@@ -118,7 +118,7 @@ async function main() {
 
 	// Pre-spawn the shared V8 process so the bench loop only measures isolate overhead
 	console.error(`\nSpawning shared V8 process...`);
-	await initSharedV8();
+	await setupBench();
 	console.error(`V8 process ready.\n`);
 
 	const results: MemoryEntry[] = [];
@@ -162,7 +162,7 @@ async function main() {
 	// JSON to stdout
 	console.log(JSON.stringify({ hardware, results }, null, 2));
 
-	await shutdownSharedV8();
+	await teardownBench();
 }
 
 main().catch((err) => {

--- a/packages/secure-exec/benchmarks/profile-phases.ts
+++ b/packages/secure-exec/benchmarks/profile-phases.ts
@@ -14,18 +14,21 @@ const RUNS = 30;
 
 async function main() {
 	const v8 = await createNodeV8Runtime();
+	// Reuse driver/factory — createNodeDriver() scans node_modules (~15ms per call)
+	const driver = createNodeDriver();
+	const factory = createNodeRuntimeDriverFactory({ v8Runtime: v8 });
 
 	// First cold — warms the snapshot cache
 	const warmupRt = new NodeRuntime({
-		systemDriver: createNodeDriver(),
-		runtimeDriverFactory: createNodeRuntimeDriverFactory({ v8Runtime: v8 }),
+		systemDriver: driver,
+		runtimeDriverFactory: factory,
 	});
 	await warmupRt.run(TRIVIAL_CODE);
 	await warmupRt.terminate();
 
 	console.error("Snapshot cached. Profiling cold + warm paths.\n");
 
-	// Measure cold starts (new runtime each time, snapshot is cached)
+	// Measure cold starts (new runtime each time, driver/factory reused)
 	const coldConstruct: number[] = [];
 	const coldFirstRun: number[] = [];
 	const warmRun: number[] = [];
@@ -33,8 +36,8 @@ async function main() {
 	for (let i = 0; i < RUNS; i++) {
 		const t0 = performance.now();
 		const rt = new NodeRuntime({
-			systemDriver: createNodeDriver(),
-			runtimeDriverFactory: createNodeRuntimeDriverFactory({ v8Runtime: v8 }),
+			systemDriver: driver,
+			runtimeDriverFactory: factory,
 		});
 		const t1 = performance.now();
 		await rt.run(TRIVIAL_CODE);

--- a/packages/secure-exec/benchmarks/staggered.bench.ts
+++ b/packages/secure-exec/benchmarks/staggered.bench.ts
@@ -98,16 +98,18 @@ async function benchStaggered(): Promise<StaggeredResult> {
 }
 
 async function main() {
+	const warmPoolSize = process.env.WARM_POOL_SIZE ? parseInt(process.env.WARM_POOL_SIZE) : undefined;
 	const hardware = getHardware();
 	console.error("=== Staggered TTI Benchmark ===");
 	console.error(`CPU: ${hardware.cpu}`);
 	console.error(`Cores: ${hardware.cores} | Max concurrency: ${MAX_CONCURRENCY}`);
 	console.error(`RAM: ${hardware.ram} | Node: ${hardware.node}`);
 	console.error(`Concurrency: ${CONCURRENCY} | Stagger delay: ${STAGGER_DELAY_MS}ms`);
+	console.error(`Warm pool: ${warmPoolSize ?? "default (3)"}`);
 	console.error(`Iterations: ${ITERATIONS} (+ ${WARMUP_ITERATIONS} warmup)`);
 
 	console.error("\nSpawning shared V8 process...");
-	await initSharedV8();
+	await initSharedV8(warmPoolSize);
 	console.error("V8 process ready.\n");
 
 	const result = await benchStaggered();

--- a/packages/secure-exec/benchmarks/staggered.bench.ts
+++ b/packages/secure-exec/benchmarks/staggered.bench.ts
@@ -57,10 +57,14 @@ async function benchStaggered(): Promise<StaggeredResult> {
 			const p = (async () => {
 				const t0 = performance.now();
 				const rt = createBenchRuntime();
+				const t1 = performance.now();
 				await rt.run(TRIVIAL_CODE);
-				const ttiMs = performance.now() - t0;
-				const readyAt = performance.now() - wallStart;
-				ramp.push({ launchedAt: round(launchedAt), readyAt: round(readyAt), ttiMs: round(ttiMs) });
+				const t2 = performance.now();
+				const ttiMs = t2 - t0;
+				const constructMs = t1 - t0;
+				const runMs = t2 - t1;
+				const readyAt = t2 - wallStart;
+				ramp.push({ launchedAt: round(launchedAt), readyAt: round(readyAt), ttiMs: round(ttiMs), constructMs: round(constructMs), runMs: round(runMs) });
 				await rt.terminate();
 				return ttiMs;
 			})();
@@ -120,12 +124,14 @@ async function main() {
 
 	// Ramp profile table
 	printTable(
-		["#", "launched at", "ready at", "TTI"],
-		result.rampProfile.map((r, i) => [
+		["#", "launched at", "ready at", "TTI", "construct", "run"],
+		result.rampProfile.map((r: any, i: number) => [
 			i + 1,
 			`+${r.launchedAt}ms`,
 			`+${r.readyAt}ms`,
 			`${r.ttiMs}ms`,
+			`${r.constructMs}ms`,
+			`${r.runMs}ms`,
 		]),
 	);
 

--- a/packages/secure-exec/benchmarks/staggered.bench.ts
+++ b/packages/secure-exec/benchmarks/staggered.bench.ts
@@ -12,8 +12,8 @@ import {
 	TRIVIAL_CODE,
 	MAX_CONCURRENCY,
 	createBenchRuntime,
-	initSharedV8,
-	shutdownSharedV8,
+	setupBench,
+	teardownBench,
 	getHardware,
 	printTable,
 	round,
@@ -113,7 +113,7 @@ async function main() {
 	console.error(`Iterations: ${ITERATIONS} (+ ${WARMUP_ITERATIONS} warmup)`);
 
 	console.error("\nSpawning shared V8 process...");
-	await initSharedV8(warmPoolSize);
+	await setupBench(warmPoolSize);
 	console.error("V8 process ready.\n");
 
 	const result = await benchStaggered();
@@ -136,7 +136,7 @@ async function main() {
 	);
 
 	console.log(JSON.stringify({ hardware, result }, null, 2));
-	await shutdownSharedV8();
+	await teardownBench();
 }
 
 main().catch((err) => {

--- a/packages/secure-exec/benchmarks/staggered.bench.ts
+++ b/packages/secure-exec/benchmarks/staggered.bench.ts
@@ -1,0 +1,137 @@
+/**
+ * Staggered TTI benchmark — launches runtimes with a delay between each.
+ *
+ * Matches the computesdk "staggered" pattern: sandbox creates are spaced
+ * apart by a configurable delay, simulating real-world ramp-up traffic.
+ * Tracks per-sandbox TTI and a launch/ready ramp profile.
+ *
+ * Usage: npx tsx benchmarks/staggered.bench.ts
+ */
+
+import {
+	TRIVIAL_CODE,
+	MAX_CONCURRENCY,
+	createBenchRuntime,
+	initSharedV8,
+	shutdownSharedV8,
+	getHardware,
+	printTable,
+	round,
+	stats,
+} from "./bench-utils.js";
+
+const CONCURRENCY = 20;
+const STAGGER_DELAY_MS = 50;
+const ITERATIONS = 3;
+const WARMUP_ITERATIONS = 1;
+
+interface RampEntry {
+	launchedAt: number;
+	readyAt: number;
+	ttiMs: number;
+}
+
+interface StaggeredResult {
+	concurrency: number;
+	staggerDelayMs: number;
+	perSandboxTti: ReturnType<typeof stats>;
+	wallClockMs: number;
+	timeToFirstReadyMs: number;
+	rampProfile: RampEntry[];
+}
+
+async function benchStaggered(): Promise<StaggeredResult> {
+	const allTtis: number[] = [];
+	let bestWallClock = Infinity;
+	let bestFirstReady = Infinity;
+	let bestRamp: RampEntry[] = [];
+
+	for (let iter = 0; iter < WARMUP_ITERATIONS + ITERATIONS; iter++) {
+		const wallStart = performance.now();
+		const promises: Promise<number>[] = [];
+		const ramp: RampEntry[] = [];
+
+		for (let i = 0; i < CONCURRENCY; i++) {
+			const launchedAt = performance.now() - wallStart;
+
+			const p = (async () => {
+				const t0 = performance.now();
+				const rt = createBenchRuntime();
+				await rt.run(TRIVIAL_CODE);
+				const ttiMs = performance.now() - t0;
+				const readyAt = performance.now() - wallStart;
+				ramp.push({ launchedAt: round(launchedAt), readyAt: round(readyAt), ttiMs: round(ttiMs) });
+				await rt.terminate();
+				return ttiMs;
+			})();
+
+			promises.push(p);
+
+			// Stagger delay between launches (except after last)
+			if (i < CONCURRENCY - 1) {
+				await new Promise((r) => setTimeout(r, STAGGER_DELAY_MS));
+			}
+		}
+
+		const ttis = await Promise.all(promises);
+		const wallClockMs = performance.now() - wallStart;
+		const firstReady = Math.min(...ttis);
+
+		if (iter >= WARMUP_ITERATIONS) {
+			allTtis.push(...ttis);
+			if (wallClockMs < bestWallClock) {
+				bestWallClock = wallClockMs;
+				bestRamp = ramp.sort((a, b) => a.launchedAt - b.launchedAt);
+			}
+			if (firstReady < bestFirstReady) bestFirstReady = firstReady;
+		}
+	}
+
+	return {
+		concurrency: CONCURRENCY,
+		staggerDelayMs: STAGGER_DELAY_MS,
+		perSandboxTti: stats(allTtis),
+		wallClockMs: round(bestWallClock),
+		timeToFirstReadyMs: round(bestFirstReady),
+		rampProfile: bestRamp,
+	};
+}
+
+async function main() {
+	const hardware = getHardware();
+	console.error("=== Staggered TTI Benchmark ===");
+	console.error(`CPU: ${hardware.cpu}`);
+	console.error(`Cores: ${hardware.cores} | Max concurrency: ${MAX_CONCURRENCY}`);
+	console.error(`RAM: ${hardware.ram} | Node: ${hardware.node}`);
+	console.error(`Concurrency: ${CONCURRENCY} | Stagger delay: ${STAGGER_DELAY_MS}ms`);
+	console.error(`Iterations: ${ITERATIONS} (+ ${WARMUP_ITERATIONS} warmup)`);
+
+	console.error("\nSpawning shared V8 process...");
+	await initSharedV8();
+	console.error("V8 process ready.\n");
+
+	const result = await benchStaggered();
+
+	console.error(
+		`TTI median=${result.perSandboxTti.p50}ms p95=${result.perSandboxTti.p95}ms | wall=${result.wallClockMs}ms | first=${result.timeToFirstReadyMs}ms`,
+	);
+
+	// Ramp profile table
+	printTable(
+		["#", "launched at", "ready at", "TTI"],
+		result.rampProfile.map((r, i) => [
+			i + 1,
+			`+${r.launchedAt}ms`,
+			`+${r.readyAt}ms`,
+			`${r.ttiMs}ms`,
+		]),
+	);
+
+	console.log(JSON.stringify({ hardware, result }, null, 2));
+	await shutdownSharedV8();
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Remove UDS auth flow**: Token-based authentication over Unix domain socket is unnecessary — the socket dir has 0700 permissions + 128-bit random suffix. Removes `SECURE_EXEC_V8_TOKEN`, `authenticate_connection`, `constant_time_eq`, and related tests from both Rust and TS.
- **Burst + staggered benchmarks**: New bench modes matching the computesdk pattern — burst fires N runtimes simultaneously, staggered launches with configurable delay + ramp profile.
- **Fix 15ms `createNodeDriver()` overhead**: `collectOverlayAllowedRoots` does synchronous `readdirSync` + `realpathSync` on every symlink in `node_modules` (~20ms in large monorepos). Benchmarks and docs now reuse the driver instance.
- **Warm pool default increased to 5** for better p95 under staggered load.
- **IPC trace instrumentation**: `SECURE_EXEC_TRACE_IPC=1` env var enables per-execution phase timing on both TS and Rust sides.

## Benchmark results (sequential cold start, 100 iterations)

| | p50 | p95 | p99 |
|---|---|---|---|
| No pool | 6.17ms | 8.82ms | 14.12ms |
| Pool of 5 | 4.02ms | 5.55ms | 6.23ms |

## Test plan

- [x] 128 TS tests pass (2 auth tests removed)
- [x] 82 Rust tests pass (7 auth/constant_time tests removed)
- [x] All three benchmarks run successfully (coldstart, burst, staggered)