### PR TITLE
feat: add Doom example (doomgeneric compiled to WASM)

### DIFF
--- a/examples/doom/.gitignore
+++ b/examples/doom/.gitignore
@@ -1,0 +1,4 @@
+build/
+.cache/
+node_modules/
+dist/

--- a/examples/doom/Makefile
+++ b/examples/doom/Makefile
@@ -1,0 +1,215 @@
+# examples/doom/Makefile — Build Doom for the secure-exec sandbox
+#
+# Targets:
+#   build      Download doomgeneric + doom1.wad, compile to WASM
+#   clean      Remove build artifacts and downloaded sources
+#
+# Prerequisites:
+#   - wasi-sdk built at native/wasmvm/c/vendor/wasi-sdk/
+#     (run `make wasi-sdk` in native/wasmvm/c/ if missing)
+#   - wasm-opt (binaryen) on PATH
+#   - patched sysroot at native/wasmvm/c/sysroot/ for poll() support
+#     (run `make sysroot` in native/wasmvm/c/ if missing)
+
+REPO_ROOT    := $(shell git -C $(dir $(lastword $(MAKEFILE_LIST))) rev-parse --show-toplevel)
+WASI_SDK_DIR := $(REPO_ROOT)/native/wasmvm/c/vendor/wasi-sdk
+SYSROOT      := $(REPO_ROOT)/native/wasmvm/c/sysroot
+CC           := $(WASI_SDK_DIR)/bin/clang
+
+BUILD_DIR    := build
+CACHE_DIR    := .cache
+SRC_DIR      := $(CACHE_DIR)/doomgeneric/doomgeneric
+
+# doomgeneric source — pinned to a known-good commit
+DOOMGENERIC_REPO   := https://github.com/ozkl/doomgeneric
+DOOMGENERIC_COMMIT := 3b1d53020373b502035d7d48dede645a7c429feb
+DOOMGENERIC_URL    := $(DOOMGENERIC_REPO)/archive/$(DOOMGENERIC_COMMIT).zip
+
+# Shareware WAD (freely distributable by id Software)
+WAD_URL := https://distro.ibiblio.org/slitaz/sources/packages/d/doom1.wad
+
+# All doomgeneric engine sources (excluding platform-specific backends)
+ENGINE_SRCS := \
+	$(SRC_DIR)/dummy.c \
+	$(SRC_DIR)/am_map.c \
+	$(SRC_DIR)/doomdef.c \
+	$(SRC_DIR)/doomstat.c \
+	$(SRC_DIR)/dstrings.c \
+	$(SRC_DIR)/d_event.c \
+	$(SRC_DIR)/d_items.c \
+	$(SRC_DIR)/d_iwad.c \
+	$(SRC_DIR)/d_loop.c \
+	$(SRC_DIR)/d_main.c \
+	$(SRC_DIR)/d_mode.c \
+	$(SRC_DIR)/d_net.c \
+	$(SRC_DIR)/f_finale.c \
+	$(SRC_DIR)/f_wipe.c \
+	$(SRC_DIR)/g_game.c \
+	$(SRC_DIR)/hu_lib.c \
+	$(SRC_DIR)/hu_stuff.c \
+	$(SRC_DIR)/info.c \
+	$(SRC_DIR)/i_cdmus.c \
+	$(SRC_DIR)/i_endoom.c \
+	$(SRC_DIR)/i_joystick.c \
+	$(SRC_DIR)/i_scale.c \
+	$(SRC_DIR)/i_sound.c \
+	$(SRC_DIR)/i_system.c \
+	$(SRC_DIR)/i_timer.c \
+	$(SRC_DIR)/memio.c \
+	$(SRC_DIR)/m_argv.c \
+	$(SRC_DIR)/m_bbox.c \
+	$(SRC_DIR)/m_cheat.c \
+	$(SRC_DIR)/m_config.c \
+	$(SRC_DIR)/m_controls.c \
+	$(SRC_DIR)/m_fixed.c \
+	$(SRC_DIR)/m_menu.c \
+	$(SRC_DIR)/m_misc.c \
+	$(SRC_DIR)/m_random.c \
+	$(SRC_DIR)/p_ceilng.c \
+	$(SRC_DIR)/p_doors.c \
+	$(SRC_DIR)/p_enemy.c \
+	$(SRC_DIR)/p_floor.c \
+	$(SRC_DIR)/p_inter.c \
+	$(SRC_DIR)/p_lights.c \
+	$(SRC_DIR)/p_map.c \
+	$(SRC_DIR)/p_maputl.c \
+	$(SRC_DIR)/p_mobj.c \
+	$(SRC_DIR)/p_plats.c \
+	$(SRC_DIR)/p_pspr.c \
+	$(SRC_DIR)/p_saveg.c \
+	$(SRC_DIR)/p_setup.c \
+	$(SRC_DIR)/p_sight.c \
+	$(SRC_DIR)/p_spec.c \
+	$(SRC_DIR)/p_switch.c \
+	$(SRC_DIR)/p_telept.c \
+	$(SRC_DIR)/p_tick.c \
+	$(SRC_DIR)/p_user.c \
+	$(SRC_DIR)/r_bsp.c \
+	$(SRC_DIR)/r_data.c \
+	$(SRC_DIR)/r_draw.c \
+	$(SRC_DIR)/r_main.c \
+	$(SRC_DIR)/r_plane.c \
+	$(SRC_DIR)/r_segs.c \
+	$(SRC_DIR)/r_sky.c \
+	$(SRC_DIR)/r_things.c \
+	$(SRC_DIR)/sha1.c \
+	$(SRC_DIR)/sounds.c \
+	$(SRC_DIR)/statdump.c \
+	$(SRC_DIR)/st_lib.c \
+	$(SRC_DIR)/st_stuff.c \
+	$(SRC_DIR)/s_sound.c \
+	$(SRC_DIR)/tables.c \
+	$(SRC_DIR)/v_video.c \
+	$(SRC_DIR)/wi_stuff.c \
+	$(SRC_DIR)/w_checksum.c \
+	$(SRC_DIR)/w_file.c \
+	$(SRC_DIR)/w_main.c \
+	$(SRC_DIR)/w_wad.c \
+	$(SRC_DIR)/z_zone.c \
+	$(SRC_DIR)/w_file_stdc.c \
+	$(SRC_DIR)/i_input.c \
+	$(SRC_DIR)/i_video.c \
+	$(SRC_DIR)/doomgeneric.c \
+	$(SRC_DIR)/icon.c
+
+# Our terminal backend
+BACKEND_SRC := c/doomgeneric_terminal.c
+
+WASM_CFLAGS := --target=wasm32-wasip1 \
+	--sysroot=$(SYSROOT) \
+	-O2 -flto \
+	-I $(SRC_DIR) \
+	-DNORMALUNIX -DLINUX -DSNDSERV -D_DEFAULT_SOURCE \
+	-Wno-implicit-function-declaration \
+	-Wno-int-conversion \
+	-Wno-return-type \
+	-Wno-pointer-sign
+
+NATIVE_CC     := $(shell command -v cc 2>/dev/null || command -v gcc 2>/dev/null || command -v clang 2>/dev/null)
+NATIVE_CFLAGS := -O2 -I $(SRC_DIR) \
+	-DNORMALUNIX -DLINUX -DSNDSERV -D_DEFAULT_SOURCE \
+	-Wno-implicit-function-declaration \
+	-Wno-int-conversion \
+	-Wno-return-type \
+	-Wno-pointer-sign
+
+.PHONY: build native clean fetch
+
+build: $(BUILD_DIR)/doom $(BUILD_DIR)/doom1.wad
+	@echo ""
+	@echo "Build complete!"
+	@echo "  Binary: $(BUILD_DIR)/doom"
+	@echo "  WAD:    $(BUILD_DIR)/doom1.wad"
+	@echo ""
+	@echo "Run with: pnpm start"
+
+native: $(BUILD_DIR)/doom-native $(BUILD_DIR)/doom1.wad
+	@echo ""
+	@echo "Native build complete!"
+	@echo "  Binary: $(BUILD_DIR)/doom-native"
+	@echo ""
+	@echo "Run with: pnpm start:native"
+
+# --- Fetch doomgeneric source ---
+
+$(SRC_DIR)/doomgeneric.h:
+	@echo "=== Downloading doomgeneric ==="
+	@mkdir -p $(CACHE_DIR)
+	@curl -fSL "$(DOOMGENERIC_URL)" -o "$(CACHE_DIR)/doomgeneric.zip"
+	@cd $(CACHE_DIR) && unzip -qo doomgeneric.zip
+	@mv "$(CACHE_DIR)/doomgeneric-$(DOOMGENERIC_COMMIT)" "$(CACHE_DIR)/doomgeneric"
+	@rm -f "$(CACHE_DIR)/doomgeneric.zip"
+	@# Fix out-of-bounds array reads in status bar icon rendering (crashes on WASM).
+	@# Replace STlib_updateMultIcon with a bounds-safe version that validates
+	@# both oldinum and *inum against the arms[] array size (2 entries).
+	@# The approach: add pcount field, guard every mi->p[idx] access.
+	@sed -i 's/    int\t\t\tdata;/    int\t\t\tdata;\n    int\t\t\tpcount;/' \
+		"$(SRC_DIR)/st_lib.h"
+	@sed -i 's/i->data = 0;/i->data = 0;\n    i->pcount = 0;/' \
+		"$(SRC_DIR)/st_lib.c"
+	@# Guard the oldinum erase path
+	@sed -i 's/if (mi->oldinum != -1)/if (mi->oldinum >= 0 \&\& (mi->pcount <= 0 || mi->oldinum < mi->pcount))/' \
+		"$(SRC_DIR)/st_lib.c"
+	@# Guard the draw path
+	@sed -i '/V_DrawPatch(mi->x, mi->y, mi->p\[\*mi->inum\]);/{s/.*/\tint __idx = *mi->inum; if (__idx >= 0 \&\& (mi->pcount <= 0 || __idx < mi->pcount)) V_DrawPatch(mi->x, mi->y, mi->p[__idx]);/}' \
+		"$(SRC_DIR)/st_lib.c"
+	@# Set pcount for the arms widgets (2 patches each: owned/not-owned)
+	@sed -i '/STlib_initMultIcon(\&w_arms\[i\]/,/st_armson);/{s/\&st_armson);/\&st_armson); w_arms[i].pcount = 2;/}' \
+		"$(SRC_DIR)/st_stuff.c"
+	@echo "doomgeneric source ready (patched)"
+
+fetch: $(SRC_DIR)/doomgeneric.h
+
+# --- Fetch shareware WAD ---
+
+$(BUILD_DIR)/doom1.wad:
+	@echo "=== Downloading doom1.wad (shareware) ==="
+	@mkdir -p $(BUILD_DIR)
+	@curl -fSL "$(WAD_URL)" -o "$(BUILD_DIR)/doom1.wad"
+	@echo "doom1.wad ready ($(shell du -h $(BUILD_DIR)/doom1.wad 2>/dev/null | cut -f1 || echo '?'))"
+
+# --- Compile to WASM ---
+
+$(BUILD_DIR)/doom: $(SRC_DIR)/doomgeneric.h $(BACKEND_SRC)
+	@echo "=== Compiling Doom to WASM ==="
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(WASM_CFLAGS) \
+		-Wl,--initial-memory=33554432 \
+		-o $(BUILD_DIR)/doom.tmp.wasm \
+		$(ENGINE_SRCS) $(BACKEND_SRC)
+	@echo "Optimizing with wasm-opt..."
+	wasm-opt -O3 --strip-debug $(BUILD_DIR)/doom.tmp.wasm -o $(BUILD_DIR)/doom
+	@rm -f $(BUILD_DIR)/doom.tmp.wasm
+	@echo "doom binary ready ($(shell du -h $(BUILD_DIR)/doom 2>/dev/null | cut -f1 || echo '?'))"
+
+# --- Compile native (for testing without sandbox) ---
+
+$(BUILD_DIR)/doom-native: $(SRC_DIR)/doomgeneric.h $(BACKEND_SRC)
+	@echo "=== Compiling Doom (native) ==="
+	@mkdir -p $(BUILD_DIR)
+	$(NATIVE_CC) $(NATIVE_CFLAGS) \
+		-o $(BUILD_DIR)/doom-native \
+		$(ENGINE_SRCS) $(BACKEND_SRC) -lm
+
+clean:
+	rm -rf $(BUILD_DIR) $(CACHE_DIR)

--- a/examples/doom/README.md
+++ b/examples/doom/README.md
@@ -1,0 +1,59 @@
+# Doom in Secure Exec
+
+Run the original 1993 Doom (shareware) inside a secure-exec sandbox, rendered
+in your terminal using ANSI true-color and Unicode half-block characters.
+
+The Doom engine ([doomgeneric](https://github.com/ozkl/doomgeneric)) is compiled
+from C to WebAssembly using the same `wasi-sdk` toolchain the rest of the project
+uses. No WASM-specific code — just a standard POSIX terminal backend.
+
+## Prerequisites
+
+- wasi-sdk built at `native/wasmvm/c/vendor/wasi-sdk/` (`make wasi-sdk` in `native/wasmvm/c/`)
+- Patched sysroot at `native/wasmvm/c/sysroot/` (`make sysroot` in `native/wasmvm/c/`)
+- `wasm-opt` (binaryen) on PATH
+- A terminal with true-color support (most modern terminals)
+
+## Build
+
+```sh
+make build
+```
+
+This downloads the doomgeneric source and `doom1.wad` (shareware, freely
+distributable by id Software), then compiles everything to a ~430KB WASM binary.
+
+## Run
+
+```sh
+pnpm tsx src/index.ts
+```
+
+## Controls
+
+| Key            | Action         |
+|----------------|----------------|
+| Arrow keys     | Move / turn    |
+| W/A/S/D        | Move / strafe  |
+| F              | Fire           |
+| Space          | Open / use     |
+| R              | Run            |
+| , / .          | Strafe L / R   |
+| Enter          | Menu select    |
+| Esc            | Menu           |
+| 1-7            | Switch weapon  |
+| Q / Ctrl+C     | Quit           |
+
+## How It Works
+
+1. **C backend** (`c/doomgeneric_terminal.c`) implements 5 callbacks:
+   - `DG_DrawFrame()` — converts BGRA framebuffer → ANSI half-block output
+   - `DG_GetKey()` — reads keypresses via `poll()` + `read()` on stdin
+   - `DG_GetTicksMs()` / `DG_SleepMs()` — `clock_gettime` / `nanosleep`
+   - `DG_Init()` — switches to alternate screen buffer
+
+2. **Makefile** compiles doomgeneric + our backend → `build/doom` (WASM)
+
+3. **Node.js runner** (`src/index.ts`) creates a kernel, loads `doom1.wad`
+   into the virtual filesystem, mounts the WASM runtime, and spawns doom
+   via `kernel.spawn()` with raw stdin/stdout forwarding

--- a/examples/doom/c/doomgeneric_terminal.c
+++ b/examples/doom/c/doomgeneric_terminal.c
@@ -1,0 +1,394 @@
+/*
+ * doomgeneric_terminal.c — Terminal backend for doomgeneric
+ *
+ * Renders the Doom framebuffer to a terminal using Unicode half-block
+ * characters (U+2580 ▀) with 24-bit ANSI true-color escape codes.
+ * Each character cell encodes two vertical pixels: the top pixel as
+ * foreground color and the bottom pixel as background color.
+ *
+ * The 640x400 framebuffer is downscaled via area-averaging to fit the
+ * terminal (default 120 columns, configurable via COLUMNS env var).
+ * Frame rate is capped at ~30 fps to avoid flooding the terminal.
+ *
+ * Input is read from stdin via poll()+read() (non-blocking).
+ * The host is expected to put the terminal in raw mode before launching.
+ *
+ * Pure POSIX — no WASI-specific code, no termios (host manages raw mode).
+ */
+
+#include "doomgeneric.h"
+#include "doomkeys.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <poll.h>
+
+/* --- Configuration --- */
+
+/* Target terminal width in columns. Override with COLUMNS env var. */
+#define DEFAULT_TERM_COLS 80
+
+/* Frame rate cap (ms per frame). 33ms ≈ 30fps. */
+#define FRAME_MIN_MS 33
+
+/* Computed at init */
+static int term_cols;          /* output columns */
+static int term_rows;          /* output rows (half of vertical pixels) */
+
+/* --- Timing --- */
+
+static struct timespec start_time;
+static uint32_t last_frame_ms;
+
+static uint32_t now_ms(void)
+{
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    long ds  = now.tv_sec  - start_time.tv_sec;
+    long dns = now.tv_nsec - start_time.tv_nsec;
+    if (dns < 0) { ds--; dns += 1000000000L; }
+    return (uint32_t)(ds * 1000 + dns / 1000000);
+}
+
+void DG_Init(void)
+{
+    clock_gettime(CLOCK_MONOTONIC, &start_time);
+    last_frame_ms = 0;
+
+    /* Determine output size — fit to terminal width, preserve aspect ratio */
+    const char *cols_env = getenv("COLUMNS");
+    term_cols = cols_env ? atoi(cols_env) : DEFAULT_TERM_COLS;
+    if (term_cols < 40) term_cols = 40;
+    if (term_cols > DOOMGENERIC_RESX) term_cols = DOOMGENERIC_RESX;
+
+    /* Rows: maintain Doom's 320:200 (8:5) aspect ratio.
+     * Each output row covers 2 vertical pixels (half-block), so:
+     *   term_rows = term_cols * (200/320) / 2 = term_cols * 5/16 */
+    term_rows = term_cols * 5 / 16;
+    if (term_rows < 10) term_rows = 10;
+
+    /* Hide cursor, switch to alternate screen buffer, clear */
+    fprintf(stdout, "\033[?1049h\033[?25l\033[2J");
+    fflush(stdout);
+}
+
+uint32_t DG_GetTicksMs(void)
+{
+    return now_ms();
+}
+
+void DG_SleepMs(uint32_t ms)
+{
+    struct timespec ts;
+    ts.tv_sec  = ms / 1000;
+    ts.tv_nsec = (ms % 1000) * 1000000L;
+    nanosleep(&ts, NULL);
+}
+
+/* --- Rendering --- */
+
+/*
+ * Output buffer sized for downscaled frame.
+ * At 120 cols x 50 rows, worst case ~44 bytes/cell: ~264KB per frame.
+ */
+#define OUTPUT_BUF_SIZE (512 * 1024)
+static char output_buf[OUTPUT_BUF_SIZE];
+
+/*
+ * Sample a source pixel at the given output coordinate.
+ * Maps output coords to source coords via simple nearest-neighbor.
+ */
+static uint32_t sample_pixel(int out_x, int out_y)
+{
+    int sx = out_x * DOOMGENERIC_RESX / term_cols;
+    int sy = out_y * DOOMGENERIC_RESY / (term_rows * 2);
+    if (sx >= DOOMGENERIC_RESX) sx = DOOMGENERIC_RESX - 1;
+    if (sy >= DOOMGENERIC_RESY) sy = DOOMGENERIC_RESY - 1;
+    return DG_ScreenBuffer[sy * DOOMGENERIC_RESX + sx];
+}
+
+void DG_DrawFrame(void)
+{
+    /* Frame rate cap */
+    uint32_t elapsed = now_ms();
+    if ((elapsed - last_frame_ms) < FRAME_MIN_MS) return;
+    last_frame_ms = elapsed;
+
+    char *p = output_buf;
+
+    /* Move cursor to top-left */
+    p += sprintf(p, "\033[H");
+
+    /* Track previous colors to skip redundant escape sequences */
+    int prev_fg_r = -1, prev_fg_g = -1, prev_fg_b = -1;
+    int prev_bg_r = -1, prev_bg_g = -1, prev_bg_b = -1;
+
+    for (int row = 0; row < term_rows; row++)
+    {
+        for (int col = 0; col < term_cols; col++)
+        {
+            /* Top half of the character cell (upper pixel row) */
+            uint32_t top = sample_pixel(col, row * 2);
+            /* Bottom half (lower pixel row) */
+            uint32_t bot = sample_pixel(col, row * 2 + 1);
+
+            int fg_r = (top >> 16) & 0xFF;
+            int fg_g = (top >>  8) & 0xFF;
+            int fg_b = (top >>  0) & 0xFF;
+            int bg_r = (bot >> 16) & 0xFF;
+            int bg_g = (bot >>  8) & 0xFF;
+            int bg_b = (bot >>  0) & 0xFF;
+
+            /* Only emit color codes when they change */
+            if (fg_r != prev_fg_r || fg_g != prev_fg_g || fg_b != prev_fg_b)
+            {
+                p += sprintf(p, "\033[38;2;%d;%d;%dm", fg_r, fg_g, fg_b);
+                prev_fg_r = fg_r; prev_fg_g = fg_g; prev_fg_b = fg_b;
+            }
+            if (bg_r != prev_bg_r || bg_g != prev_bg_g || bg_b != prev_bg_b)
+            {
+                p += sprintf(p, "\033[48;2;%d;%d;%dm", bg_r, bg_g, bg_b);
+                prev_bg_r = bg_r; prev_bg_g = bg_g; prev_bg_b = bg_b;
+            }
+
+            /* UTF-8 encoding of U+2580 (▀): 0xE2 0x96 0x80 */
+            *p++ = (char)0xE2;
+            *p++ = (char)0x96;
+            *p++ = (char)0x80;
+        }
+
+        /* Reset colors at end of line, newline */
+        p += sprintf(p, "\033[0m\r\n");
+        prev_fg_r = prev_fg_g = prev_fg_b = -1;
+        prev_bg_r = prev_bg_g = prev_bg_b = -1;
+    }
+
+    /* Reset all attributes */
+    p += sprintf(p, "\033[0m");
+
+    /* Single write for the whole frame */
+    fwrite(output_buf, 1, (size_t)(p - output_buf), stdout);
+    fflush(stdout);
+}
+
+/* --- Input --- */
+
+/*
+ * Terminal input has no key-up events. We simulate held keys by:
+ * - On keypress: send press event, record the key and timestamp
+ * - On each DG_GetKey poll: release keys that haven't been re-pressed
+ *   within KEY_HOLD_MS milliseconds
+ * - If the same key arrives again before timeout, reset its timer (held)
+ */
+#define KEY_HOLD_MS 150
+#define MAX_HELD_KEYS 16
+
+#define KEY_QUEUE_SIZE 64
+static struct { int pressed; unsigned char key; } key_queue[KEY_QUEUE_SIZE];
+static int key_queue_head = 0;
+static int key_queue_tail = 0;
+
+static struct { unsigned char key; uint32_t press_time; } held_keys[MAX_HELD_KEYS];
+static int held_count = 0;
+
+static void enqueue_key(int pressed, unsigned char key)
+{
+    int next = (key_queue_head + 1) % KEY_QUEUE_SIZE;
+    if (next == key_queue_tail) return;
+    key_queue[key_queue_head].pressed = pressed;
+    key_queue[key_queue_head].key = key;
+    key_queue_head = next;
+}
+
+static void press_key(unsigned char key)
+{
+    /* Check if already held — if so, just refresh the timer */
+    for (int i = 0; i < held_count; i++)
+    {
+        if (held_keys[i].key == key)
+        {
+            held_keys[i].press_time = now_ms();
+            return; /* already pressed, no new press event */
+        }
+    }
+
+    /* New key press */
+    enqueue_key(1, key);
+
+    if (held_count < MAX_HELD_KEYS)
+    {
+        held_keys[held_count].key = key;
+        held_keys[held_count].press_time = now_ms();
+        held_count++;
+    }
+}
+
+static void release_expired_keys(void)
+{
+    uint32_t t = now_ms();
+    int i = 0;
+    while (i < held_count)
+    {
+        if ((t - held_keys[i].press_time) >= KEY_HOLD_MS)
+        {
+            enqueue_key(0, held_keys[i].key);
+            /* Remove by swapping with last */
+            held_keys[i] = held_keys[held_count - 1];
+            held_count--;
+        }
+        else
+        {
+            i++;
+        }
+    }
+}
+
+static unsigned char stdin_buf[64];
+static int stdin_len = 0;
+static int stdin_pos = 0;
+
+static int read_stdin_byte(void)
+{
+    if (stdin_pos < stdin_len)
+        return (unsigned char)stdin_buf[stdin_pos++];
+
+    struct pollfd pfd;
+    pfd.fd = STDIN_FILENO;
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+
+    if (poll(&pfd, 1, 0) <= 0)
+        return -1;
+
+    ssize_t n = read(STDIN_FILENO, stdin_buf, sizeof(stdin_buf));
+    if (n <= 0)
+        return -1;
+
+    stdin_len = (int)n;
+    stdin_pos = 1;
+    return (unsigned char)stdin_buf[0];
+}
+
+static void process_input(void)
+{
+    for (;;)
+    {
+        int ch = read_stdin_byte();
+        if (ch < 0) break;
+
+        /* ESC sequence */
+        if (ch == 0x1B)
+        {
+            int ch2 = read_stdin_byte();
+            if (ch2 < 0) {
+                press_key(KEY_ESCAPE);
+                break;
+            }
+            if (ch2 == '[')
+            {
+                int ch3 = read_stdin_byte();
+                if (ch3 < 0) break;
+                switch (ch3) {
+                    case 'A': press_key(KEY_UPARROW);    break;
+                    case 'B': press_key(KEY_DOWNARROW);  break;
+                    case 'C': press_key(KEY_RIGHTARROW); break;
+                    case 'D': press_key(KEY_LEFTARROW);  break;
+                    default: break;
+                }
+            }
+            else if (ch2 == 'O')
+            {
+                int ch3 = read_stdin_byte();
+                if (ch3 < 0) break;
+            }
+            continue;
+        }
+
+        unsigned char doom_key = 0;
+        switch (ch) {
+            case '\r':
+            case '\n':  doom_key = KEY_ENTER;      break;
+            case '\t':  doom_key = KEY_TAB;         break;
+            case ' ':   doom_key = KEY_USE;         break;
+            case 'f':
+            case 'F':   doom_key = KEY_FIRE;        break;
+            case 'r':
+            case 'R':   doom_key = KEY_RSHIFT;      break; /* run */
+            case ',':
+            case 'a':   doom_key = KEY_STRAFE_L;    break; /* strafe left */
+            case '.':
+            case 'd':   doom_key = KEY_STRAFE_R;    break; /* strafe right */
+            case 'w':   doom_key = KEY_UPARROW;     break; /* WASD alt */
+            case 's':   doom_key = KEY_DOWNARROW;   break; /* WASD alt */
+            case 0x7F:
+            case 0x08:  doom_key = KEY_BACKSPACE;   break;
+            /* 0x03 (Ctrl+C) and 'q' intercepted by host for clean exit */
+            default:
+                if (ch >= 'A' && ch <= 'Z')
+                    doom_key = (unsigned char)(ch - 'A' + 'a');
+                else if (ch >= '0' && ch <= '9')
+                    doom_key = (unsigned char)ch;
+                else if (ch == '-' || ch == '=')
+                    doom_key = (unsigned char)ch;
+                break;
+        }
+
+        if (doom_key != 0)
+            press_key(doom_key);
+    }
+}
+
+int DG_GetKey(int *pressed, unsigned char *doom_key)
+{
+    process_input();
+    release_expired_keys();
+
+    if (key_queue_tail == key_queue_head)
+        return 0;
+
+    *pressed  = key_queue[key_queue_tail].pressed;
+    *doom_key = key_queue[key_queue_tail].key;
+    key_queue_tail = (key_queue_tail + 1) % KEY_QUEUE_SIZE;
+    return 1;
+}
+
+/* --- Window title (no-op) --- */
+
+void DG_SetWindowTitle(const char *title)
+{
+    (void)title;
+}
+
+/* --- Cleanup on exit --- */
+
+static void cleanup(void)
+{
+    fputs("\033[?25h\033[?1049l", stdout);
+    fflush(stdout);
+}
+
+/* --- Stubs for missing POSIX functions in WASI --- */
+
+int system(const char *command)
+{
+    (void)command;
+    return -1;
+}
+
+/* --- Main --- */
+
+int main(int argc, char **argv)
+{
+    atexit(cleanup);
+    doomgeneric_Create(argc, argv);
+
+    for (;;)
+    {
+        doomgeneric_Tick();
+    }
+
+    return 0;
+}

--- a/examples/doom/package.json
+++ b/examples/doom/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@secure-exec/example-doom",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "make build",
+    "build:native": "make native",
+    "start": "make build && tsx src/index.ts",
+    "start:native": "make native && stty raw -echo && ./build/doom-native -iwad build/doom1.wad; stty sane",
+    "clean": "make clean",
+    "check-types": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@secure-exec/core": "workspace:*",
+    "@secure-exec/nodejs": "workspace:*",
+    "@secure-exec/wasmvm": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/examples/doom/src/index.ts
+++ b/examples/doom/src/index.ts
@@ -1,0 +1,106 @@
+/**
+ * examples/doom — Run Doom inside a secure-exec sandbox.
+ *
+ * Compiles doomgeneric (C) to WASM, loads it into a virtual kernel,
+ * and connects the user's terminal for interactive play.
+ *
+ * Build first: make build
+ * Then run:    pnpm tsx src/index.ts
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createKernel, createInMemoryFileSystem, allowAll } from "@secure-exec/core";
+import { createWasmVmRuntime } from "@secure-exec/wasmvm";
+
+const exampleDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const buildDir = path.join(exampleDir, "build");
+const doomBinary = path.join(buildDir, "doom");
+const wadFile = path.join(buildDir, "doom1.wad");
+
+// Check build artifacts exist
+import { existsSync } from "node:fs";
+if (!existsSync(doomBinary)) {
+	console.error("Doom WASM binary not found. Run `make build` first.");
+	process.exit(1);
+}
+if (!existsSync(wadFile)) {
+	console.error("doom1.wad not found. Run `make build` first.");
+	process.exit(1);
+}
+
+// Load WAD into virtual filesystem
+const filesystem = createInMemoryFileSystem();
+const wadData = await readFile(wadFile);
+await filesystem.mkdir("/game", { recursive: true });
+await filesystem.writeFile("/game/doom1.wad", wadData);
+
+// Create kernel
+const kernel = createKernel({
+	filesystem,
+	permissions: allowAll,
+	env: { HOME: "/game", PATH: "/bin" },
+	cwd: "/game",
+});
+
+// Mount WasmVM with our doom binary
+const wasmRuntime = createWasmVmRuntime({ commandDirs: [buildDir] });
+await kernel.mount(wasmRuntime);
+
+if (!kernel.commands.has("doom")) {
+	console.error("Doom command not found in kernel. Check build output.");
+	await kernel.dispose();
+	process.exit(1);
+}
+
+console.error("Starting Doom in secure-exec sandbox...");
+console.error("Controls: arrows=move, f=fire, space=use, enter=select, esc=menu, q/Ctrl+C=quit");
+console.error("");
+
+// Pass terminal dimensions to doom via COLUMNS env var (cap at 80 like native)
+const cols = Math.min(process.stdout.columns || 80, 80);
+
+// Spawn doom directly (no PTY — doom writes raw ANSI escapes to stdout)
+const proc = kernel.spawn("doom", ["-iwad", "/game/doom1.wad"], {
+	cwd: "/game",
+	env: { HOME: "/game", COLUMNS: String(cols) },
+	onStdout: (data) => {
+		process.stdout.write(Buffer.from(data));
+	},
+	onStderr: (data) => {
+		process.stderr.write(Buffer.from(data));
+	},
+});
+
+// Set terminal to raw mode for keypresses
+const stdin = process.stdin;
+if (stdin.isTTY) stdin.setRawMode(true);
+stdin.resume();
+
+// Clean exit: restore terminal and quit
+let exiting = false;
+const quit = async (code: number) => {
+	if (exiting) return;
+	exiting = true;
+	if (stdin.isTTY) stdin.setRawMode(false);
+	stdin.pause();
+	process.stdout.write("\x1b[?25h\x1b[?1049l");
+	proc.kill(9);
+	await kernel.dispose();
+	process.exit(code);
+};
+
+// Forward keypresses to doom, intercept quit keys
+stdin.on("data", (data: Buffer) => {
+	// Ctrl+C (0x03) or q (0x71): quit immediately
+	if (data.includes(0x03) || (data.length === 1 && data[0] === 0x71)) {
+		void quit(0);
+		return;
+	}
+	proc.writeStdin(new Uint8Array(data));
+});
+
+// Also quit if doom exits on its own
+proc.wait().then((code) => quit(code));

--- a/examples/doom/src/test.ts
+++ b/examples/doom/src/test.ts
@@ -1,0 +1,78 @@
+/**
+ * Non-interactive smoke test: boots Doom in the sandbox, captures output,
+ * verifies we get ANSI-colored frame data with half-block characters.
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createKernel, createInMemoryFileSystem, allowAll } from "@secure-exec/core";
+import { createWasmVmRuntime } from "@secure-exec/wasmvm";
+
+const exampleDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const buildDir = path.join(exampleDir, "build");
+
+console.log("Loading WAD...");
+const wadData = await readFile(path.join(buildDir, "doom1.wad"));
+
+const filesystem = createInMemoryFileSystem();
+await filesystem.mkdir("/game", { recursive: true });
+await filesystem.writeFile("/game/doom1.wad", wadData);
+
+const kernel = createKernel({
+	filesystem,
+	permissions: allowAll,
+	env: { HOME: "/game", PATH: "/bin", COLUMNS: "80" },
+	cwd: "/game",
+});
+
+const wasmRuntime = createWasmVmRuntime({ commandDirs: [buildDir] });
+await kernel.mount(wasmRuntime);
+console.log("doom command discovered:", kernel.commands.has("doom"));
+
+let stdoutBytes = 0;
+let hasAnsiColor = false;
+let hasHalfBlock = false;
+let hasCursorHome = false;
+let firstChunk = "";
+
+const proc = kernel.spawn("doom", ["-iwad", "/game/doom1.wad"], {
+	cwd: "/game",
+	env: { HOME: "/game", COLUMNS: "80" },
+	onStdout: (data) => {
+		const chunk = Buffer.from(data).toString("utf-8");
+		stdoutBytes += data.length;
+		if (!hasAnsiColor && chunk.includes("\x1b[38;2;")) hasAnsiColor = true;
+		if (!hasHalfBlock && chunk.includes("\u2580")) hasHalfBlock = true;
+		if (!hasCursorHome && chunk.includes("\x1b[H")) hasCursorHome = true;
+		if (firstChunk.length < 2000) firstChunk += chunk.slice(0, 2000 - firstChunk.length);
+	},
+	onStderr: (data) => {
+		process.stderr.write(Buffer.from(data));
+	},
+});
+
+console.log("Waiting 5 seconds for frames...");
+await new Promise((r) => setTimeout(r, 5000));
+proc.kill(9);
+await proc.wait();
+
+console.log("");
+console.log("Results:");
+console.log("  stdout bytes:", stdoutBytes);
+console.log("  ANSI color escapes:", hasAnsiColor);
+console.log("  half-block chars:", hasHalfBlock);
+console.log("  cursor home:", hasCursorHome);
+console.log("");
+
+const allChecks = hasAnsiColor && hasHalfBlock && hasCursorHome && stdoutBytes > 10000;
+if (allChecks) {
+	console.log("SUCCESS: Doom is rendering ANSI frames in the sandbox!");
+} else {
+	console.log("FAILURE: Expected ANSI frame output not found.");
+	console.log("First 500 chars:", JSON.stringify(firstChunk.slice(0, 500)));
+	process.exitCode = 1;
+}
+
+await kernel.dispose();

--- a/examples/doom/tsconfig.json
+++ b/examples/doom/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,28 @@ importers:
         specifier: ^4.19.2
         version: 4.21.0
 
+  examples/doom:
+    dependencies:
+      '@secure-exec/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@secure-exec/nodejs':
+        specifier: workspace:*
+        version: link:../../packages/nodejs
+      '@secure-exec/wasmvm':
+        specifier: workspace:*
+        version: link:../../packages/wasmvm
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.3
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
   examples/features:
     dependencies:
       '@secure-exec/typescript':
@@ -497,17 +519,17 @@ importers:
   packages/v8:
     optionalDependencies:
       '@secure-exec/v8-darwin-arm64':
-        specifier: 0.2.0-rc.1
-        version: 0.2.0-rc.1
+        specifier: 0.2.0-rc.2
+        version: 0.2.0-rc.2
       '@secure-exec/v8-darwin-x64':
-        specifier: 0.2.0-rc.1
-        version: 0.2.0-rc.1
+        specifier: 0.2.0-rc.2
+        version: 0.2.0-rc.2
       '@secure-exec/v8-linux-arm64-gnu':
-        specifier: 0.2.0-rc.1
-        version: 0.2.0-rc.1
+        specifier: 0.2.0-rc.2
+        version: 0.2.0-rc.2
       '@secure-exec/v8-linux-x64-gnu':
-        specifier: 0.2.0-rc.1
-        version: 0.2.0-rc.1
+        specifier: 0.2.0-rc.2
+        version: 0.2.0-rc.2
     devDependencies:
       '@types/node':
         specifier: ^22.10.2
@@ -3694,32 +3716,32 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@secure-exec/v8-darwin-arm64@0.2.0-rc.1:
-    resolution: {integrity: sha512-I65TZBkaYrZTi69aKocwBt6ojrunZuwfGah5H9a68RzF1usi3Vp/QuyH43dPQOzJMLPD7T87M+dGKZuuxtyKVw==}
+  /@secure-exec/v8-darwin-arm64@0.2.0-rc.2:
+    resolution: {integrity: sha512-251Hxptkm8kfoTXUpopHBS9jZ1bMca1oMsxHbWLKFz6zJ18RLVSV/XaugDm+u8Np1UFvKmPiBq05HLg3GE3C/A==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@secure-exec/v8-darwin-x64@0.2.0-rc.1:
-    resolution: {integrity: sha512-il4VCFjR7/mSzTZnFcO9SjXqfmle46n+fu98ASNbuEGvKnYoJPNABBZHc/lZUd0KktRbAg7ox+NuWm0qBnxeyg==}
+  /@secure-exec/v8-darwin-x64@0.2.0-rc.2:
+    resolution: {integrity: sha512-QV/Q0fE6P3I/QpviS5UFieBj/6f1LoGfRTtFTAmQs67bVGc0k0wYYL50s4ke7tE60ljfUdUJLL2JbzuIV+m36g==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@secure-exec/v8-linux-arm64-gnu@0.2.0-rc.1:
-    resolution: {integrity: sha512-JPXTBYM4Mj2cg7aRI+RhLiDZSOtSCl+BfA36a/qEfO5G9LmZy+DsI2JVe36PIeYwnelMe0rBMSINHStknqwD2Q==}
+  /@secure-exec/v8-linux-arm64-gnu@0.2.0-rc.2:
+    resolution: {integrity: sha512-/KEKSHBZ70Frz/8So35YTnDcqGrb3chtsFrJTTuTDKHuTDSvgWNT6fKpafqKOrto37tkORm2NmzWrhb1zGC6ug==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@secure-exec/v8-linux-x64-gnu@0.2.0-rc.1:
-    resolution: {integrity: sha512-bDHVy36ogaxCstoRrCPiuwyD38OTt0+lBG+sUfT3/8mmpgs04VsS9s9/vMppp1iks79OYpq6CQNowWiuOjS1Aw==}
+  /@secure-exec/v8-linux-x64-gnu@0.2.0-rc.2:
+    resolution: {integrity: sha512-fEnAbKa1iscGq7L2L5dZQpJu+gTxANeybqX11P1ZnAyoap/Xiu3hHMDphNIjT2qQ1CfQhliPR+i7AZmAF+WQlA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true


### PR DESCRIPTION
## Summary
- Adds `examples/doom/` — the original Doom (shareware) running inside the secure-exec sandbox
- Compiles [doomgeneric](https://github.com/ozkl/doomgeneric) from C to WASM using wasi-sdk, with a pure-POSIX terminal backend (~400 lines of C)
- Renders via ANSI true-color + Unicode half-block characters at 30fps
- WASD + arrow keys, `f` to fire, `q`/Ctrl+C to quit
- Includes OOB fix for doomgeneric's status bar icon rendering

## How it works
1. `make build` downloads doomgeneric source + doom1.wad, compiles to ~430KB WASM binary
2. `pnpm start` creates a kernel, loads the WAD into the virtual filesystem, mounts WasmVM, spawns doom
3. All I/O goes through WASI syscalls mediated by the kernel — zero direct host access

## Test plan
- [x] Native build compiles and runs (`pnpm start:native`)
- [x] WASM build compiles and runs in sandbox (`pnpm start`)
- [x] ANSI frame output verified (colors, half-blocks, cursor positioning)
- [x] New game flow works (title → menu → gameplay)
- [x] Movement and turning respond to input
- [x] 60s ASAN-clean under AddressSanitizer
- [x] Ctrl+C / q exits cleanly and restores terminal
- [x] Typechecks pass