### PR TITLE
Fix nested export-star expansion in node loader

### DIFF
--- a/packages/nodejs/src/module-source.ts
+++ b/packages/nodejs/src/module-source.ts
@@ -67,16 +67,8 @@ function expandStarReExports(source: string, hostPath: string): string {
 		if (!targetPath || !existsSync(targetPath)) continue;
 
 		try {
-			const targetSource = readFileSync(targetPath, "utf-8");
-			const [, targetExports] = parse(targetSource, targetPath);
-			const names = targetExports
-				.map((e) => e.n)
-				.filter(
-					(n): n is string =>
-						typeof n === "string" &&
-						n !== "default" &&
-						!ownExportNames.has(n),
-				);
+			const names = collectNamedExportsForStarResolution(targetPath)
+				.filter((n) => n !== "default" && !ownExportNames.has(n));
 
 			if (names.length > 0) {
 				// Track these names so subsequent export * don't duplicate
@@ -94,6 +86,39 @@ function expandStarReExports(source: string, hostPath: string): string {
 	}
 
 	return result;
+}
+
+function collectNamedExportsForStarResolution(
+	filePath: string,
+	visited = new Set<string>(),
+): string[] {
+	if (visited.has(filePath) || !existsSync(filePath)) {
+		return [];
+	}
+
+	visited.add(filePath);
+
+	const source = readFileSync(filePath, "utf-8");
+	const starExportRegex = /export\s*\*\s*from\s*['"]([^'"]+)['"]\s*;?/g;
+	const [, ownExports] = parse(source, filePath);
+	const names = new Set(
+		ownExports
+			.map((e) => e.n)
+			.filter((n): n is string => typeof n === "string"),
+	);
+
+	let match: RegExpExecArray | null;
+	while ((match = starExportRegex.exec(source)) !== null) {
+		const specifier = match[1];
+		if (!specifier.startsWith(".")) continue;
+
+		const targetPath = pathJoin(pathDirname(filePath), specifier);
+		for (const name of collectNamedExportsForStarResolution(targetPath, visited)) {
+			names.add(name);
+		}
+	}
+
+	return Array.from(names);
 }
 
 function isValidIdentifier(value: string): boolean {

--- a/packages/nodejs/test/module-source.test.ts
+++ b/packages/nodejs/test/module-source.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	sourceHasModuleSyntax,
@@ -50,5 +53,31 @@ describe("module source transforms", () => {
 		const source = '\uFEFF#!/usr/bin/env node\nimport "./main.js";\n';
 
 		await expect(sourceHasModuleSyntax(source, "/pkg/dist/cli.js")).resolves.toBe(true);
+	});
+
+	it("expands nested star re-exports into named exports", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "secure-exec-module-source-"));
+		const webhooksDir = join(tempDir, "resources", "webhooks");
+		const entryPath = join(tempDir, "resources", "webhooks.mjs");
+
+		mkdirSync(webhooksDir, { recursive: true });
+		writeFileSync(entryPath, 'export * from "./webhooks/index.mjs";\n');
+		writeFileSync(
+			join(webhooksDir, "index.mjs"),
+			'export * from "./webhooks.mjs";\n',
+		);
+		writeFileSync(
+			join(webhooksDir, "webhooks.mjs"),
+			"export class Webhooks {}\n",
+		);
+
+		const transformed = transformSourceForImportSync(
+			readFileSync(entryPath, "utf8"),
+			entryPath,
+		);
+
+		expect(transformed).toContain(
+			"export { Webhooks } from './webhooks/index.mjs';",
+		);
 	});
 });


### PR DESCRIPTION
Fixes #68.

## Summary
- recursively collect named exports when expanding `export * from ...` chains in `packages/nodejs/src/module-source.ts`
- preserve named exports across nested star re-export hops instead of deleting the intermediate export
- add a regression test covering a three-file nested `export *` chain similar to the OpenAI SDK `webhooks` layout

## Why
The current loader only resolves one star-reexport hop. For packages that use nested `export *` chains, the intermediate module can appear to have no direct named exports, so the loader rewrites the export away entirely. In practice this breaks the OpenAI SDK `webhooks` modules and caused OpenRouter-backed Pi sessions under AgentOS to fail.

## Verification
- `pnpm --filter @secure-exec/core build`
- `pnpm --filter @secure-exec/v8 build`
- `pnpm --filter @secure-exec/nodejs exec vitest run test/module-source.test.ts`

## Notes
I also tried `pnpm --filter @secure-exec/nodejs test` locally after building `@secure-exec/core` and `@secure-exec/v8`; that still hit unrelated existing `kernel-runtime.test.ts` failures on my machine. The new `module-source` regression test passes.
