### PR TITLE
Security review fixes (secure-exec)

### DIFF
--- a/crates/execution/src/javascript.rs
+++ b/crates/execution/src/javascript.rs
@@ -62,15 +62,15 @@ const NODE_SYNC_RPC_DATA_BYTES_ENV: &str = "AGENT_OS_NODE_SYNC_RPC_DATA_BYTES";
 const NODE_SYNC_RPC_WAIT_TIMEOUT_MS_ENV: &str = "AGENT_OS_NODE_SYNC_RPC_WAIT_TIMEOUT_MS";
 static NEXT_V8_SESSION_ID: AtomicU64 = AtomicU64::new(1);
 const V8_HEAP_LIMIT_MB_ENV: &str = "AGENT_OS_V8_HEAP_LIMIT_MB";
-const V8_CPU_TIME_LIMIT_MS_ENV: &str = "AGENT_OS_V8_CPU_TIME_LIMIT_MS";
-/// Default per-execution CPU/wall-clock watchdog budget for guest JavaScript.
+/// Opt-in TRUE CPU-time budget (ms) for guest JavaScript. Unset/`0` => no limit.
 ///
 /// Guest inline code (e.g. `while (true) {}`) runs on the shared, slot-bounded V8
-/// runtime; without a watchdog it pins a CPU core and never releases its slot,
-/// starving peers. Arm a generous-but-finite default so a runaway guest is
-/// terminated instead of hanging the shared runtime. Operators can override (or
-/// disable, via `0`) with `AGENT_OS_V8_CPU_TIME_LIMIT_MS`.
-const V8_DEFAULT_CPU_TIME_LIMIT_MS: u32 = 30_000;
+/// runtime; with this set, a runaway burning CPU is terminated by the CPU-budget
+/// watchdog (which counts active JS CPU only, excluding idle/await). There is NO
+/// default: with this unset the guest runs CPU-uncapped by design — the
+/// platform/operator MUST set it to cap a guest. A wall-clock backstop is
+/// intentionally NOT part of this knob (deferred to a follow-up).
+const V8_CPU_TIME_LIMIT_MS_ENV: &str = "AGENT_OS_V8_CPU_TIME_LIMIT_MS";
 const NODE_SYNC_RPC_DEFAULT_DATA_BYTES: usize = 4 * 1024 * 1024;
 const NODE_SYNC_RPC_DEFAULT_WAIT_TIMEOUT_MS: u64 = 30_000;
 const NODE_SYNC_RPC_RESPONSE_QUEUE_CAPACITY: usize = 1;
@@ -1879,17 +1879,18 @@ fn javascript_heap_limit_mb(request: &StartJavascriptExecutionRequest) -> u32 {
         .unwrap_or(0)
 }
 
-/// Resolve the CPU-time watchdog budget (ms) for a JavaScript execution.
+/// Resolve the opt-in TRUE CPU-time budget (ms) for a JavaScript execution.
 ///
-/// Defaults to [`V8_DEFAULT_CPU_TIME_LIMIT_MS`] so a CPU-bound guest is always
-/// terminated; operators may override via `AGENT_OS_V8_CPU_TIME_LIMIT_MS`. A
-/// value of `0` disables the watchdog (normalized to `None` by the V8 session).
+/// Opt-in with NO default: read from `AGENT_OS_V8_CPU_TIME_LIMIT_MS`, falling
+/// back to `0` (no limit) when unset/unparsable. `0` is normalized to `None` by
+/// the V8 session, so the CPU-budget watchdog is NOT armed and the guest runs
+/// CPU-uncapped. The platform/operator must set this to cap a guest.
 fn javascript_cpu_time_limit_ms(request: &StartJavascriptExecutionRequest) -> u32 {
     request
         .env
         .get(V8_CPU_TIME_LIMIT_MS_ENV)
         .and_then(|value| value.parse::<u32>().ok())
-        .unwrap_or(V8_DEFAULT_CPU_TIME_LIMIT_MS)
+        .unwrap_or(0)
 }
 
 fn spawn_javascript_sync_rpc_timeout(

--- a/crates/execution/src/javascript.rs
+++ b/crates/execution/src/javascript.rs
@@ -62,6 +62,15 @@ const NODE_SYNC_RPC_DATA_BYTES_ENV: &str = "AGENT_OS_NODE_SYNC_RPC_DATA_BYTES";
 const NODE_SYNC_RPC_WAIT_TIMEOUT_MS_ENV: &str = "AGENT_OS_NODE_SYNC_RPC_WAIT_TIMEOUT_MS";
 static NEXT_V8_SESSION_ID: AtomicU64 = AtomicU64::new(1);
 const V8_HEAP_LIMIT_MB_ENV: &str = "AGENT_OS_V8_HEAP_LIMIT_MB";
+const V8_CPU_TIME_LIMIT_MS_ENV: &str = "AGENT_OS_V8_CPU_TIME_LIMIT_MS";
+/// Default per-execution CPU/wall-clock watchdog budget for guest JavaScript.
+///
+/// Guest inline code (e.g. `while (true) {}`) runs on the shared, slot-bounded V8
+/// runtime; without a watchdog it pins a CPU core and never releases its slot,
+/// starving peers. Arm a generous-but-finite default so a runaway guest is
+/// terminated instead of hanging the shared runtime. Operators can override (or
+/// disable, via `0`) with `AGENT_OS_V8_CPU_TIME_LIMIT_MS`.
+const V8_DEFAULT_CPU_TIME_LIMIT_MS: u32 = 30_000;
 const NODE_SYNC_RPC_DEFAULT_DATA_BYTES: usize = 4 * 1024 * 1024;
 const NODE_SYNC_RPC_DEFAULT_WAIT_TIMEOUT_MS: u64 = 30_000;
 const NODE_SYNC_RPC_RESPONSE_QUEUE_CAPACITY: usize = 1;
@@ -1529,6 +1538,7 @@ fn register_v8_session<F>(
     v8_host: &V8RuntimeHost,
     session_id: String,
     heap_limit_mb: u32,
+    cpu_time_limit_ms: u32,
     send_frame: F,
 ) -> Result<PendingV8SessionRegistration<'_>, JavascriptExecutionError>
 where
@@ -1542,7 +1552,7 @@ where
     send_frame(&BinaryFrame::CreateSession {
         session_id,
         heap_limit_mb,
-        cpu_time_limit_ms: 0,
+        cpu_time_limit_ms,
     })
     .map_err(JavascriptExecutionError::Spawn)?;
 
@@ -1666,6 +1676,7 @@ impl JavascriptExecutionEngine {
             v8_host,
             session_id.clone(),
             javascript_heap_limit_mb(&request),
+            javascript_cpu_time_limit_ms(&request),
             |frame| v8_host.send_frame(frame),
         )?;
 
@@ -1866,6 +1877,19 @@ fn javascript_heap_limit_mb(request: &StartJavascriptExecutionRequest) -> u32 {
         .and_then(|value| value.parse::<u32>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(0)
+}
+
+/// Resolve the CPU-time watchdog budget (ms) for a JavaScript execution.
+///
+/// Defaults to [`V8_DEFAULT_CPU_TIME_LIMIT_MS`] so a CPU-bound guest is always
+/// terminated; operators may override via `AGENT_OS_V8_CPU_TIME_LIMIT_MS`. A
+/// value of `0` disables the watchdog (normalized to `None` by the V8 session).
+fn javascript_cpu_time_limit_ms(request: &StartJavascriptExecutionRequest) -> u32 {
+    request
+        .env
+        .get(V8_CPU_TIME_LIMIT_MS_ENV)
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or(V8_DEFAULT_CPU_TIME_LIMIT_MS)
 }
 
 fn spawn_javascript_sync_rpc_timeout(
@@ -6555,7 +6579,7 @@ mod tests {
                 .as_nanos()
         );
 
-        let error = match register_v8_session(&host, session_id.clone(), 0, |_frame| {
+        let error = match register_v8_session(&host, session_id.clone(), 0, 0, |_frame| {
             Err(std::io::Error::new(
                 std::io::ErrorKind::BrokenPipe,
                 "simulated CreateSession send failure",

--- a/crates/execution/src/node_import_cache.rs
+++ b/crates/execution/src/node_import_cache.rs
@@ -8768,6 +8768,39 @@ const maxMemoryBytesValue = Number(process.env.AGENT_OS_WASM_MAX_MEMORY_BYTES);
 const maxMemoryPages = Number.isFinite(maxMemoryBytesValue)
   ? Math.max(0, Math.floor(maxMemoryBytesValue / WASM_PAGE_BYTES))
   : null;
+const maxStackBytesValue = Number(process.env.AGENT_OS_WASM_MAX_STACK_BYTES);
+const maxStackBytes =
+  Number.isFinite(maxStackBytesValue) && maxStackBytesValue > 0
+    ? Math.floor(maxStackBytesValue)
+    : null;
+
+// A guest can drive WebAssembly into never-returning recursion. V8's default
+// native stack guard already traps that as a generic `RangeError`, but the
+// operator-configured `AGENT_OS_WASM_MAX_STACK_BYTES` budget was previously
+// never consulted, so the cap was dead. When a stack byte budget is set, treat
+// a stack-exhaustion trap as enforcement of THAT budget: terminate the guest
+// nonzero and attribute the failure to the configured limit instead of leaking
+// the engine's generic default-guard message.
+function isWasmStackExhaustionTrap(error) {
+  const message = typeof error?.message === 'string' ? error.message : '';
+  // V8 raises `RangeError: Maximum call stack size exceeded` when its native
+  // stack guard fires on runaway recursion (the WebAssembly call stack is
+  // mapped onto V8's). Match that explicitly rather than treating every
+  // `RangeError` as stack exhaustion, so unrelated range failures still
+  // surface with their own message.
+  return /maximum call stack size exceeded/i.test(message);
+}
+
+function reportConfiguredStackLimitExceeded(error) {
+  const detail = typeof error?.message === 'string' && error.message.length > 0
+    ? ` (${error.message})`
+    : '';
+  if (typeof process?.stderr?.write === 'function') {
+    process.stderr.write(
+      `WebAssembly guest exceeded the configured stack byte limit of ${maxStackBytes} bytes${detail}\n`,
+    );
+  }
+}
 const frozenTimeValue = Number(process.env.AGENT_OS_FROZEN_TIME_MS);
 const frozenTimeMs = Number.isFinite(frozenTimeValue) ? Math.trunc(frozenTimeValue) : Date.now();
 const frozenTimeNs = BigInt(frozenTimeMs) * 1000000n;
@@ -13442,7 +13475,16 @@ if (typeof instance.exports._start === 'function') {
   // `poll_oneoff` still routes readiness probes through `__kernel_poll`.
   // That preserves the expected startup ordering so guest `_start` checks can
   // observe the ready event before we exit the runner.
-  const exitCode = wasi.start(instance);
+  let exitCode;
+  try {
+    exitCode = wasi.start(instance);
+  } catch (error) {
+    if (maxStackBytes !== null && isWasmStackExhaustionTrap(error)) {
+      reportConfiguredStackLimitExceeded(error);
+      process.exit(1);
+    }
+    throw error;
+  }
   process.exit(typeof exitCode === 'number' ? exitCode : 0);
 } else if (typeof instance.exports.run === 'function') {
   const result = await instance.exports.run();

--- a/crates/execution/src/wasm.rs
+++ b/crates/execution/src/wasm.rs
@@ -769,6 +769,11 @@ impl WasmExecutionEngine {
         }
         let frozen_time_ms = frozen_time_ms();
         validate_module_limits(&resolved_module, &request)?;
+        // Surfaces a typed error for a malformed stack byte budget instead of
+        // silently dropping it; the parsed value is consumed by the runner's
+        // stack-overflow guard (see `AGENT_OS_WASM_MAX_STACK_BYTES` handling in
+        // the WASM runner) so the operator-configured cap is no longer dead.
+        wasm_stack_limit_bytes(&request)?;
         let execution_timeout = resolve_wasm_execution_timeout(&request)?;
         let import_cache = self
             .import_caches
@@ -4946,6 +4951,12 @@ fn wasm_memory_limit_bytes(
     request: &StartWasmExecutionRequest,
 ) -> Result<Option<u64>, WasmExecutionError> {
     wasm_limit_u64(&request.env, WASM_MAX_MEMORY_BYTES_ENV)
+}
+
+fn wasm_stack_limit_bytes(
+    request: &StartWasmExecutionRequest,
+) -> Result<Option<u64>, WasmExecutionError> {
+    wasm_limit_u64(&request.env, WASM_MAX_STACK_BYTES_ENV)
 }
 
 #[cfg(test)]

--- a/crates/execution/src/wasm.rs
+++ b/crates/execution/src/wasm.rs
@@ -51,6 +51,13 @@ const DEFAULT_WASM_GUEST_PATH: &str =
 // Warmup is a best-effort compile-cache optimization; fall back to a cold start
 // instead of burning minutes on a stalled prewarm session.
 const DEFAULT_WASM_PREWARM_TIMEOUT_MS: u64 = 30_000;
+/// Wall-clock execution budget applied when no explicit fuel budget
+/// (`AGENT_OS_WASM_MAX_FUEL`) is configured. Without this default a guest module
+/// that never returns (e.g. an infinite loop) would gate termination behind
+/// `Some(limit)` in [`WasmExecution::wait`] and pin a host CPU core forever,
+/// starving every other tenant on the shared process. Operators that need a
+/// tighter (or looser) bound can still set `AGENT_OS_WASM_MAX_FUEL` explicitly.
+const DEFAULT_WASM_EXECUTION_TIMEOUT_MS: u64 = 30_000;
 const MAX_SYNC_WASM_PREWARM_MODULE_BYTES: u64 = 16 * 1024 * 1024;
 const WASM_CAPTURED_OUTPUT_LIMIT_BYTES: usize = 16 * 1024 * 1024;
 const WASM_SYNC_READ_LIMIT_BYTES: usize = 16 * 1024 * 1024;
@@ -4818,7 +4825,14 @@ fn resolve_wasm_execution_timeout(
     // configured "fuel" budget is currently enforced as a tight wall-clock
     // timeout while still being passed through to the child process for
     // observability and future in-runtime enforcement.
-    Ok(wasm_limit_u64(&request.env, WASM_MAX_FUEL_ENV)?.map(Duration::from_millis))
+    //
+    // When no explicit fuel budget is configured we still apply a default
+    // wall-clock timeout: otherwise `wait()` gates termination behind
+    // `Some(limit)` and a never-returning guest (e.g. an infinite loop) pins a
+    // host CPU core indefinitely, starving other tenants on the shared process.
+    let budget_ms = wasm_limit_u64(&request.env, WASM_MAX_FUEL_ENV)?
+        .unwrap_or(DEFAULT_WASM_EXECUTION_TIMEOUT_MS);
+    Ok(Some(Duration::from_millis(budget_ms)))
 }
 
 fn resolve_wasm_prewarm_timeout(
@@ -5266,9 +5280,10 @@ mod tests {
         wasm_memory_limit_pages, wasm_mutation_touches_read_only_mapping,
         wasm_read_only_filesystem_error, wasm_sandbox_root, wasm_sync_read_length,
         wasm_sync_rpc_error_code, StartWasmExecutionRequest, Value, WasmExecutionError,
-        WasmInternalSyncRpc, WasmPermissionTier, WASM_CAPTURED_OUTPUT_LIMIT_BYTES,
-        WASM_MAX_FUEL_ENV, WASM_MAX_MEMORY_BYTES_ENV, WASM_PAGE_BYTES, WASM_PREWARM_TIMEOUT_MS_ENV,
-        WASM_SANDBOX_ROOT_ENV, WASM_SYNC_READ_LIMIT_BYTES,
+        WasmInternalSyncRpc, WasmPermissionTier, DEFAULT_WASM_EXECUTION_TIMEOUT_MS,
+        WASM_CAPTURED_OUTPUT_LIMIT_BYTES, WASM_MAX_FUEL_ENV, WASM_MAX_MEMORY_BYTES_ENV,
+        WASM_PAGE_BYTES, WASM_PREWARM_TIMEOUT_MS_ENV, WASM_SANDBOX_ROOT_ENV,
+        WASM_SYNC_READ_LIMIT_BYTES,
     };
     use std::collections::{BTreeMap, VecDeque};
     use std::fs;
@@ -5325,6 +5340,28 @@ mod tests {
         assert_eq!(
             resolve_wasm_prewarm_timeout(&request).expect("prewarm timeout"),
             Duration::from_millis(750)
+        );
+    }
+
+    // F-004 (SE-EXEC-08) SAFEGUARD: a guest module supplied with NO fuel env must
+    // still be bound by a default wall-clock execution timeout. Before the fix
+    // `resolve_wasm_execution_timeout` returned `None` here, so `wait()` gated
+    // termination behind `Some(limit)` and a never-returning guest pinned a host
+    // CPU core forever. This bounded unit assertion runs by default and is fast;
+    // the unbounded CPU-saturation variant stays env-gated in tests/wasm.rs.
+    #[test]
+    fn wasm_execution_timeout_defaults_to_bounded_value_without_fuel_env() {
+        let temp = tempdir().expect("create temp dir");
+        let request = request_with_env(temp.path(), BTreeMap::new());
+
+        let timeout = resolve_wasm_execution_timeout(&request)
+            .expect("execution timeout resolves without fuel env");
+
+        assert_eq!(
+            timeout,
+            Some(Duration::from_millis(DEFAULT_WASM_EXECUTION_TIMEOUT_MS)),
+            "a no-fuel guest must still be bounded by a default wall-clock timeout, \
+             otherwise wait() never terminates an infinite-loop module (F-004)"
         );
     }
 

--- a/crates/execution/tests/javascript_v8.rs
+++ b/crates/execution/tests/javascript_v8.rs
@@ -4315,16 +4315,16 @@ fn js_runtime_browser_fetch_is_callable() {
     );
 }
 
-// SE-EXEC-04 (B.2 / F-001): a CPU-bound `while (true) {}` guest must be terminated
-// by the JS CPU watchdog instead of pinning a core on the shared, slot-bounded V8
-// runtime and starving peers. Before the fix, `register_v8_session` hardcoded
-// `cpu_time_limit_ms: 0` (normalized to `None`), so no `TimeoutGuard` was armed and
-// `wait()` blocked forever.
+// SE-EXEC-04 (B.2 / F-001): with an OPT-IN CPU-time budget set, a CPU-bound
+// `while (true) {}` guest must be terminated by the TRUE CPU-time watchdog
+// instead of pinning a core on the shared, slot-bounded V8 runtime and starving
+// peers. The watchdog samples the execution thread's per-thread CPU clock, so a
+// tight busy loop burns its budget quickly and is killed.
 //
-// This is the BOUNDED safeguard variant: it sets a small explicit CPU budget via
-// `AGENT_OS_V8_CPU_TIME_LIMIT_MS` so the watchdog fires quickly and the test passes
-// fast. The whole guest run is fenced behind a wall-clock watchdog on a worker
-// thread so a regression surfaces as a clear failure instead of a CI hang.
+// This is the BOUNDED variant: it sets a small explicit CPU budget via
+// `AGENT_OS_V8_CPU_TIME_LIMIT_MS` so the watchdog fires fast. The guest run is
+// fenced behind a worker thread + recv timeout so a regression surfaces as a
+// clear failure instead of a CI hang.
 fn javascript_infinite_loop_is_terminated_by_cpu_watchdog() {
     let (tx, rx) = mpsc::channel::<(i32, String, String)>();
     thread::spawn(move || {
@@ -4379,6 +4379,12 @@ fn javascript_infinite_loop_is_terminated_by_cpu_watchdog() {
                 exit_code, 0,
                 "infinite loop returned a clean exit instead of being terminated by the CPU watchdog: stdout={stdout} stderr={stderr}"
             );
+            // And it must be attributed to the CPU-time budget specifically.
+            assert!(
+                stderr.contains("ERR_SCRIPT_CPU_BUDGET_EXCEEDED")
+                    || stderr.contains("CPU-time budget"),
+                "termination was not attributed to the CPU-time budget: stdout={stdout} stderr={stderr}"
+            );
         }
         Err(_) => {
             // No result within the budget => the watchdog never armed/fired and the
@@ -4386,6 +4392,178 @@ fn javascript_infinite_loop_is_terminated_by_cpu_watchdog() {
             panic!(
                 "infinite-loop guest was NOT terminated by the CPU watchdog \
                  (wait() never returned within the bounded test budget => unbounded CPU runaway)"
+            );
+        }
+    }
+}
+
+// SE-EXEC-04 (F-001) CRITICAL NEGATIVE: with a CPU-time budget set, a guest that
+// mostly AWAITS (timers / idle) past the budget window must NOT be killed. The
+// watchdog measures TRUE active-JS CPU time (per-thread CPU clock), which does not
+// advance while the thread is parked awaiting a timer, so idle/await is excluded.
+//
+// The guest sleeps for ~1.5s of wall time while the CPU budget is only 300ms. A
+// wall-clock timer would have killed it; the CPU-time budget must not, because the
+// guest burns almost no CPU. This is what proves I/O/idle wait is excluded.
+fn javascript_awaiting_guest_is_not_killed_by_cpu_budget() {
+    let (tx, rx) = mpsc::channel::<(i32, String, String)>();
+    thread::spawn(move || {
+        let temp = match tempdir() {
+            Ok(temp) => temp,
+            Err(error) => {
+                let _ = tx.send((-1, String::new(), format!("tempdir failed: {error}")));
+                return;
+            }
+        };
+        let mut engine = JavascriptExecutionEngine::default();
+        let context = engine.create_context(CreateJavascriptContextRequest {
+            vm_id: String::from("vm-js-await"),
+            bootstrap_module: None,
+            compile_cache_root: None,
+        });
+
+        let execution = engine.start_execution(StartJavascriptExecutionRequest {
+            vm_id: String::from("vm-js-await"),
+            context_id: context.context_id,
+            argv: vec![String::from("./entry.mjs")],
+            // CPU budget (300ms) much SMALLER than the wall time the guest spends
+            // awaiting (~1.5s). A correct CPU-time budget excludes the idle wait.
+            env: BTreeMap::from([(
+                String::from("AGENT_OS_V8_CPU_TIME_LIMIT_MS"),
+                String::from("300"),
+            )]),
+            cwd: temp.path().to_path_buf(),
+            inline_code: Some(String::from(
+                "await new Promise((resolve) => setTimeout(resolve, 1500));\n\
+                 console.log('awaited-ok');\n",
+            )),
+        });
+
+        match execution {
+            Ok(execution) => match execution.wait() {
+                Ok(result) => {
+                    let stdout = String::from_utf8_lossy(&result.stdout).into_owned();
+                    let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
+                    let _ = tx.send((result.exit_code, stdout, stderr));
+                }
+                Err(error) => {
+                    let _ = tx.send((-1, String::new(), format!("wait failed: {error}")));
+                }
+            },
+            Err(error) => {
+                let _ = tx.send((-1, String::new(), format!("start failed: {error}")));
+            }
+        }
+    });
+
+    match rx.recv_timeout(Duration::from_secs(20)) {
+        Ok((exit_code, stdout, stderr)) => {
+            assert!(
+                !stderr.contains("ERR_SCRIPT_CPU_BUDGET_EXCEEDED")
+                    && !stderr.contains("CPU-time budget"),
+                "an awaiting (low-CPU) guest was wrongly killed by the CPU budget; idle/await \
+                 must be excluded: exit_code={exit_code} stdout={stdout} stderr={stderr}"
+            );
+            assert_eq!(
+                exit_code, 0,
+                "awaiting guest should complete cleanly (idle excluded from CPU budget): \
+                 stdout={stdout} stderr={stderr}"
+            );
+            assert!(
+                stdout.contains("awaited-ok"),
+                "awaiting guest did not run to completion: stdout={stdout} stderr={stderr}"
+            );
+        }
+        Err(_) => {
+            panic!(
+                "awaiting guest never produced a result within the bounded test window \
+                 (unexpected hang)"
+            );
+        }
+    }
+}
+
+// SE-EXEC-04 (F-001) OPT-IN: with NO `AGENT_OS_V8_CPU_TIME_LIMIT_MS` set, the
+// CPU-budget watchdog must NOT be armed (no default), so a short CPU-bound guest
+// runs to completion uninterrupted. This confirms the knob is strictly opt-in and
+// that there is no implicit (e.g. former 30s) limit. We deliberately use a SHORT,
+// self-terminating busy loop (not an infinite one) so the test cannot hang even
+// when there is no limit.
+fn javascript_no_cpu_budget_when_env_unset() {
+    let (tx, rx) = mpsc::channel::<(i32, String, String)>();
+    thread::spawn(move || {
+        let temp = match tempdir() {
+            Ok(temp) => temp,
+            Err(error) => {
+                let _ = tx.send((-1, String::new(), format!("tempdir failed: {error}")));
+                return;
+            }
+        };
+        let mut engine = JavascriptExecutionEngine::default();
+        let context = engine.create_context(CreateJavascriptContextRequest {
+            vm_id: String::from("vm-js-nolimit"),
+            bootstrap_module: None,
+            compile_cache_root: None,
+        });
+
+        let execution = engine.start_execution(StartJavascriptExecutionRequest {
+            vm_id: String::from("vm-js-nolimit"),
+            context_id: context.context_id,
+            argv: vec![String::from("./entry.mjs")],
+            // No CPU-limit env: watchdog must NOT arm (opt-in, no default).
+            env: BTreeMap::new(),
+            cwd: temp.path().to_path_buf(),
+            // ~600ms busy loop: long enough to have tripped the old 30s default's
+            // removal is irrelevant, but short enough to always finish; importantly
+            // it self-terminates so the test never hangs.
+            inline_code: Some(String::from(
+                "const end = Date.now() + 600;\n\
+                 let n = 0;\n\
+                 while (Date.now() < end) { n++; }\n\
+                 console.log('busy-done', n > 0);\n",
+            )),
+        });
+
+        match execution {
+            Ok(execution) => match execution.wait() {
+                Ok(result) => {
+                    let stdout = String::from_utf8_lossy(&result.stdout).into_owned();
+                    let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
+                    let _ = tx.send((result.exit_code, stdout, stderr));
+                }
+                Err(error) => {
+                    let _ = tx.send((-1, String::new(), format!("wait failed: {error}")));
+                }
+            },
+            Err(error) => {
+                let _ = tx.send((-1, String::new(), format!("start failed: {error}")));
+            }
+        }
+    });
+
+    match rx.recv_timeout(Duration::from_secs(20)) {
+        Ok((exit_code, stdout, stderr)) => {
+            assert!(
+                !stderr.contains("ERR_SCRIPT_CPU_BUDGET_EXCEEDED")
+                    && !stderr.contains("CPU-time budget"),
+                "guest was CPU-limited despite no AGENT_OS_V8_CPU_TIME_LIMIT_MS set \
+                 (watchdog must be opt-in): exit_code={exit_code} stdout={stdout} stderr={stderr}"
+            );
+            assert_eq!(
+                exit_code, 0,
+                "unbounded short busy loop should exit cleanly when no CPU limit is set: \
+                 stdout={stdout} stderr={stderr}"
+            );
+            assert!(
+                stdout.contains("busy-done true"),
+                "busy loop did not run to completion with no CPU limit set: \
+                 stdout={stdout} stderr={stderr}"
+            );
+        }
+        Err(_) => {
+            panic!(
+                "no-limit guest never produced a result within the bounded test window \
+                 (unexpected hang)"
             );
         }
     }
@@ -4555,7 +4733,12 @@ fn javascript_v8_suite() {
     // behind worker-thread wall-clock watchdogs.
     javascript_heap_allocation_bomb_is_capped_by_oom_guard();
 
-    // SE-EXEC-04 (F-001): CPU watchdog terminates a runaway guest. Runs LAST because
-    // a regression here would leak a CPU-bound worker thread on the shared V8 runtime.
+    // SE-EXEC-04 (F-001): opt-in TRUE CPU-time budget. These run LAST because a
+    // regression in the tight-loop case could leak a CPU-bound worker thread.
+    //   1. budget SET  => tight busy loop terminated (cpu-budget reason)
+    //   2. budget SET  => awaiting/idle guest NOT killed (idle excluded)  [critical negative]
+    //   3. budget UNSET => watchdog not armed; short busy loop runs free  [opt-in, no default]
     javascript_infinite_loop_is_terminated_by_cpu_watchdog();
+    javascript_awaiting_guest_is_not_killed_by_cpu_budget();
+    javascript_no_cpu_budget_when_env_unset();
 }

--- a/crates/execution/tests/javascript_v8.rs
+++ b/crates/execution/tests/javascript_v8.rs
@@ -4315,6 +4315,82 @@ fn js_runtime_browser_fetch_is_callable() {
     );
 }
 
+// SE-EXEC-04 (B.2 / F-001): a CPU-bound `while (true) {}` guest must be terminated
+// by the JS CPU watchdog instead of pinning a core on the shared, slot-bounded V8
+// runtime and starving peers. Before the fix, `register_v8_session` hardcoded
+// `cpu_time_limit_ms: 0` (normalized to `None`), so no `TimeoutGuard` was armed and
+// `wait()` blocked forever.
+//
+// This is the BOUNDED safeguard variant: it sets a small explicit CPU budget via
+// `AGENT_OS_V8_CPU_TIME_LIMIT_MS` so the watchdog fires quickly and the test passes
+// fast. The whole guest run is fenced behind a wall-clock watchdog on a worker
+// thread so a regression surfaces as a clear failure instead of a CI hang.
+fn javascript_infinite_loop_is_terminated_by_cpu_watchdog() {
+    let (tx, rx) = mpsc::channel::<(i32, String, String)>();
+    thread::spawn(move || {
+        let temp = match tempdir() {
+            Ok(temp) => temp,
+            Err(error) => {
+                let _ = tx.send((-1, String::new(), format!("tempdir failed: {error}")));
+                return;
+            }
+        };
+        let mut engine = JavascriptExecutionEngine::default();
+        let context = engine.create_context(CreateJavascriptContextRequest {
+            vm_id: String::from("vm-js"),
+            bootstrap_module: None,
+            compile_cache_root: None,
+        });
+
+        let execution = engine.start_execution(StartJavascriptExecutionRequest {
+            vm_id: String::from("vm-js"),
+            context_id: context.context_id,
+            argv: vec![String::from("./entry.mjs")],
+            // Small bounded budget so the watchdog terminates the runaway fast.
+            env: BTreeMap::from([(
+                String::from("AGENT_OS_V8_CPU_TIME_LIMIT_MS"),
+                String::from("750"),
+            )]),
+            cwd: temp.path().to_path_buf(),
+            inline_code: Some(String::from("while (true) {}\n")),
+        });
+
+        match execution {
+            Ok(execution) => match execution.wait() {
+                Ok(result) => {
+                    let stdout = String::from_utf8_lossy(&result.stdout).into_owned();
+                    let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
+                    let _ = tx.send((result.exit_code, stdout, stderr));
+                }
+                Err(error) => {
+                    let _ = tx.send((-1, String::new(), format!("wait failed: {error}")));
+                }
+            },
+            Err(error) => {
+                let _ = tx.send((-1, String::new(), format!("start failed: {error}")));
+            }
+        }
+    });
+
+    match rx.recv_timeout(Duration::from_secs(20)) {
+        Ok((exit_code, stdout, stderr)) => {
+            // The watchdog must terminate the loop with a nonzero exit code.
+            assert_ne!(
+                exit_code, 0,
+                "infinite loop returned a clean exit instead of being terminated by the CPU watchdog: stdout={stdout} stderr={stderr}"
+            );
+        }
+        Err(_) => {
+            // No result within the budget => the watchdog never armed/fired and the
+            // CPU-bound guest ran unbounded. This is exactly the F-001 break.
+            panic!(
+                "infinite-loop guest was NOT terminated by the CPU watchdog \
+                 (wait() never returned within the bounded test budget => unbounded CPU runaway)"
+            );
+        }
+    }
+}
+
 #[test]
 fn javascript_v8_suite() {
     // Keep V8-backed integration coverage inside one top-level libtest case.
@@ -4382,4 +4458,8 @@ fn javascript_v8_suite() {
     js_runtime_node_platform_allow_list_restricts_builtins();
     js_runtime_browser_loads_cjs_npm_package();
     js_runtime_browser_fetch_is_callable();
+
+    // SE-EXEC-04 (F-001): CPU watchdog terminates a runaway guest. Runs LAST because
+    // a regression here would leak a CPU-bound worker thread on the shared V8 runtime.
+    javascript_infinite_loop_is_terminated_by_cpu_watchdog();
 }

--- a/crates/execution/tests/javascript_v8.rs
+++ b/crates/execution/tests/javascript_v8.rs
@@ -4391,6 +4391,97 @@ fn javascript_infinite_loop_is_terminated_by_cpu_watchdog() {
     }
 }
 
+// SE-EXEC-06 (M.1 / F-003): a heap-allocation bomb must be capped by terminating
+// the offending isolate, NOT by letting V8 fatal-abort (SIGTRAP) the process-global
+// runtime and take down every concurrent tenant. Before the fix, no
+// near-heap-limit/OOM callback was registered, so reaching the operator-configured
+// `AGENT_OS_V8_HEAP_LIMIT_MB` cap triggered V8's default fatal-OOM abort.
+//
+// BOUNDED safeguard variant: with a small heap cap the guard fires fast, terminates
+// the isolate, and the run returns a nonzero exit WITHOUT aborting the process. The
+// guest run is fenced behind a wall-clock watchdog on a worker thread so a regression
+// surfaces as a clear failure rather than a CI hang or a SIGTRAP that kills the whole
+// test binary.
+fn javascript_heap_allocation_bomb_is_capped_by_oom_guard() {
+    let (tx, rx) = mpsc::channel::<(i32, String, String)>();
+    thread::spawn(move || {
+        let temp = match tempdir() {
+            Ok(temp) => temp,
+            Err(error) => {
+                let _ = tx.send((-1, String::new(), format!("tempdir failed: {error}")));
+                return;
+            }
+        };
+        let mut engine = JavascriptExecutionEngine::default();
+        let context = engine.create_context(CreateJavascriptContextRequest {
+            vm_id: String::from("vm-js"),
+            bootstrap_module: None,
+            compile_cache_root: None,
+        });
+
+        let execution = engine.start_execution(StartJavascriptExecutionRequest {
+            vm_id: String::from("vm-js"),
+            context_id: context.context_id,
+            argv: vec![String::from("./entry.mjs")],
+            // Small bounded heap cap so the OOM guard fires quickly.
+            env: BTreeMap::from([(
+                String::from("AGENT_OS_V8_HEAP_LIMIT_MB"),
+                String::from("32"),
+            )]),
+            cwd: temp.path().to_path_buf(),
+            inline_code: Some(String::from(
+                r#"
+// Grow unbounded; with a 32MB heap cap the OOM guard must terminate the isolate
+// well before this completes. If it ever completes, the cap did not bound it.
+const sink = [];
+for (let i = 0; i < 1_000_000; i += 1) {
+  sink.push(new Array(100_000).fill(i));
+}
+console.log("BOMB_COMPLETED_WITHOUT_CAP");
+"#,
+            )),
+        });
+
+        match execution {
+            Ok(execution) => match execution.wait() {
+                Ok(result) => {
+                    let stdout = String::from_utf8_lossy(&result.stdout).into_owned();
+                    let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
+                    let _ = tx.send((result.exit_code, stdout, stderr));
+                }
+                Err(error) => {
+                    let _ = tx.send((-1, String::new(), format!("wait failed: {error}")));
+                }
+            },
+            Err(error) => {
+                let _ = tx.send((-1, String::new(), format!("start failed: {error}")));
+            }
+        }
+    });
+
+    match rx.recv_timeout(Duration::from_secs(30)) {
+        Ok((exit_code, stdout, stderr)) => {
+            // The bad actor wins if the bomb runs to completion.
+            assert!(
+                !stdout.contains("BOMB_COMPLETED_WITHOUT_CAP"),
+                "heap bomb completed despite configured heap limit: stdout={stdout} stderr={stderr}"
+            );
+            // Enforcement must be a clean per-isolate termination (nonzero exit),
+            // not a process-wide abort.
+            assert_ne!(
+                exit_code, 0,
+                "heap bomb returned a clean exit instead of being terminated by the OOM guard: stdout={stdout} stderr={stderr}"
+            );
+        }
+        Err(_) => {
+            panic!(
+                "heap-bomb guest was NOT bounded by the OOM guard \
+                 (wait() never returned within the bounded test budget)"
+            );
+        }
+    }
+}
+
 #[test]
 fn javascript_v8_suite() {
     // Keep V8-backed integration coverage inside one top-level libtest case.
@@ -4458,6 +4549,11 @@ fn javascript_v8_suite() {
     js_runtime_node_platform_allow_list_restricts_builtins();
     js_runtime_browser_loads_cjs_npm_package();
     js_runtime_browser_fetch_is_callable();
+
+    // SE-EXEC-06 (F-003): OOM guard terminates a heap-allocation bomb instead of
+    // letting V8 fatal-abort the process. Runs before the CPU case; both are fenced
+    // behind worker-thread wall-clock watchdogs.
+    javascript_heap_allocation_bomb_is_capped_by_oom_guard();
 
     // SE-EXEC-04 (F-001): CPU watchdog terminates a runaway guest. Runs LAST because
     // a regression here would leak a CPU-bound worker thread on the shared V8 runtime.

--- a/crates/execution/tests/wasm.rs
+++ b/crates/execution/tests/wasm.rs
@@ -1,6 +1,7 @@
 use base64::Engine;
 use secure_exec_execution::wasm::{
-    NativeBinaryFormat, WASM_MAX_FUEL_ENV, WASM_MAX_MEMORY_BYTES_ENV, WASM_PREWARM_TIMEOUT_MS_ENV,
+    NativeBinaryFormat, WASM_MAX_FUEL_ENV, WASM_MAX_MEMORY_BYTES_ENV, WASM_MAX_STACK_BYTES_ENV,
+    WASM_PREWARM_TIMEOUT_MS_ENV,
 };
 use secure_exec_execution::{
     CreateWasmContextRequest, StartWasmExecutionRequest, WasmExecutionEngine, WasmExecutionError,
@@ -12,7 +13,9 @@ use std::fs;
 use std::os::unix::fs::symlink;
 use std::path::Path;
 use std::process::Command;
+use std::sync::mpsc;
 use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::thread;
 use std::time::Duration;
 use tempfile::tempdir;
 
@@ -2276,6 +2279,93 @@ fn expected_format_display(format: NativeBinaryFormat) -> &'static str {
     }
 }
 
+// SE-EXEC-05 (B.1 / F-002): never-returning self-recursion. Under a real
+// configured stack byte cap (`AGENT_OS_WASM_MAX_STACK_BYTES`) this must be bounded
+// deterministically and attributed to THAT budget rather than silently ignored.
+fn wasm_unbounded_recursion_module() -> Vec<u8> {
+    wat::parse_str(
+        r#"
+(module
+  (memory (export "memory") 1)
+  (func $recurse (param $depth i32) (result i32)
+    (call $recurse (i32.add (local.get $depth) (i32.const 1)))
+  )
+  (func $_start (export "_start")
+    (drop (call $recurse (i32.const 0)))
+  )
+)
+"#,
+    )
+    .expect("compile unbounded-recursion wasm fixture")
+}
+
+// Watchdog runner for WASM cases that may run unbounded. The whole execution
+// (engine + context + wait) happens on a spawned thread, so a guest that the
+// engine never terminates cannot hang the test binary: the test thread reclaims
+// control after `wall_clock_budget` and reports `None`.
+fn run_wasm_execution_with_watchdog(
+    module_bytes: Vec<u8>,
+    env: BTreeMap<String, String>,
+    wall_clock_budget: Duration,
+) -> Option<(String, String, i32)> {
+    let (tx, rx) = mpsc::channel::<(String, String, i32)>();
+    thread::spawn(move || {
+        let temp = match tempdir() {
+            Ok(temp) => temp,
+            Err(_) => return,
+        };
+        write_fixture(&temp.path().join("guest.wasm"), &module_bytes);
+
+        let mut engine = WasmExecutionEngine::default();
+        let context = engine.create_context(CreateWasmContextRequest {
+            vm_id: String::from("vm-wasm"),
+            module_path: Some(String::from("./guest.wasm")),
+        });
+
+        let result = run_wasm_execution(
+            &mut engine,
+            context.context_id,
+            temp.path(),
+            Vec::new(),
+            env,
+            WasmPermissionTier::Full,
+        );
+        let _ = tx.send(result);
+    });
+
+    rx.recv_timeout(wall_clock_budget).ok()
+}
+
+// SE-EXEC-05 (B.1) SAFEGUARD [x-ref FAILURES.md#F-002]: with
+// `AGENT_OS_WASM_MAX_STACK_BYTES` configured, never-returning recursion must be
+// terminated nonzero AND the failure must cite the operator-configured stack
+// byte budget instead of the engine's generic default-guard message. Before the
+// fix the env was never read by the engine (dead cap), so the guest trapped on
+// V8's default `RangeError` with a generic message. The run is watchdog-bound so
+// it cannot hang CI, and the configured cap makes it terminate fast.
+fn wasm_deep_recursion_respects_configured_stack_byte_limit() {
+    assert_node_available();
+
+    let env = BTreeMap::from([(String::from(WASM_MAX_STACK_BYTES_ENV), String::from("65536"))]);
+    let outcome = run_wasm_execution_with_watchdog(
+        wasm_unbounded_recursion_module(),
+        env,
+        Duration::from_secs(45),
+    );
+
+    let (stdout, stderr, exit_code) =
+        outcome.expect("deep recursion run did not finish within the watchdog budget");
+
+    assert_ne!(
+        exit_code, 0,
+        "deep recursion should be terminated, not run unbounded: stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("65536") || stderr.to_lowercase().contains("configured"),
+        "termination should cite the configured stack byte limit, not a generic default guard: stderr={stderr}"
+    );
+}
+
 // Separate libtest cases in this binary still trip a V8 teardown/init crash, so
 // keep the WASM runtime coverage in one top-level suite until that boundary is fixed.
 #[test]
@@ -2313,4 +2403,8 @@ fn wasm_suite() {
     wasm_execution_rejects_shell_shim_before_handing_bytes_to_v8();
     wasm_execution_rejects_random_non_wasm_bytes_with_typed_error();
     wasm_execution_rejects_native_binary_headers_with_explicit_error();
+
+    // SE-EXEC-05 (B.1) SAFEGUARD [x-ref FAILURES.md#F-002]: the configured WASM
+    // stack byte cap must now bound runaway recursion and attribute the failure.
+    wasm_deep_recursion_respects_configured_stack_byte_limit();
 }

--- a/crates/sidecar/src/execution.rs
+++ b/crates/sidecar/src/execution.rs
@@ -11275,9 +11275,15 @@ fn loopback_cidr(ip: IpAddr) -> &'static str {
 fn restricted_non_loopback_ip_range(ip: IpAddr) -> Option<(&'static str, &'static str)> {
     match ip {
         IpAddr::V4(ip) => {
+            if ip.is_unspecified() {
+                // 0.0.0.0 is unspecified; the host stack routes a connect() to
+                // it back to 127.0.0.1, so it must not bypass the loopback gate.
+                return Some(("0.0.0.0/32", "unspecified"));
+            }
             let [first, second, ..] = ip.octets();
             match (first, second) {
                 (10, _) => Some(("10.0.0.0/8", "private")),
+                (100, 64..=127) => Some(("100.64.0.0/10", "carrier-grade-nat")),
                 (172, 16..=31) => Some(("172.16.0.0/12", "private")),
                 (192, 168) => Some(("192.168.0.0/16", "private")),
                 (169, 254) => Some(("169.254.0.0/16", "link-local")),
@@ -11287,6 +11293,12 @@ fn restricted_non_loopback_ip_range(ip: IpAddr) -> Option<(&'static str, &'stati
         IpAddr::V6(ip) => {
             if let Some(mapped) = ip.to_ipv4_mapped() {
                 return restricted_non_loopback_ip_range(IpAddr::V4(mapped));
+            }
+
+            if ip.is_unspecified() {
+                // :: is the IPv6 unspecified address; same routing hazard as
+                // 0.0.0.0, so deny it rather than letting it reach the host.
+                return Some(("::/128", "unspecified"));
             }
 
             let segments = ip.segments();
@@ -20225,5 +20237,75 @@ mod error_code_tests {
             javascript_sync_rpc_error_code(&error),
             "ERR_NATIVE_BINARY_NOT_SUPPORTED"
         );
+    }
+}
+
+#[cfg(test)]
+mod ssrf_egress_classifier_tests {
+    // F-005/006/007 (sec-sidecar T1/T7/T11): the egress classifier must treat the
+    // unspecified address (0.0.0.0 / ::), CGNAT (100.64.0.0/10), IPv6 spellings of
+    // restricted IPv4 targets (::a.b.c.d), and reserved/multicast (240/4, 224/4) as
+    // restricted. 0.0.0.0 routes to 127.0.0.1 on connect(), so leaving it
+    // unclassified let a guest bypass the loopback port-ownership gate.
+    //
+    // These are bounded SAFEGUARD tests: they exercise the classifier and the DNS
+    // egress filter directly (no network I/O, no Node), so they run fast and
+    // deterministically. See FAILURES.md#F-005, #F-006, #F-007.
+    use super::{filter_dns_safe_ip_addrs, restricted_non_loopback_ip_range, SidecarError};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    fn assert_restricted(ip: IpAddr, expected_label: &str) {
+        let classification = restricted_non_loopback_ip_range(ip);
+        assert!(
+            classification.is_some(),
+            "{ip} must be classified as a restricted egress target"
+        );
+        let (_cidr, label) = classification.unwrap();
+        assert_eq!(
+            label, expected_label,
+            "{ip} should be labelled {expected_label}, got {label}"
+        );
+    }
+
+    fn assert_dns_denied(ip: IpAddr, label: &str) {
+        match filter_dns_safe_ip_addrs(vec![ip], "attacker.example") {
+            Err(SidecarError::Execution(message)) => assert!(
+                message.starts_with("EACCES:"),
+                "{label}: egress filter must deny with EACCES, got: {message}"
+            ),
+            other => panic!("{label}: expected EACCES denial, got {other:?}"),
+        }
+    }
+
+    // F-005 (sec-sidecar T1).
+    #[test]
+    fn classifier_denies_unspecified_and_cgnat_targets() {
+        // 0.0.0.0 (IPv4 unspecified) -> would route to host loopback.
+        assert_restricted(IpAddr::V4(Ipv4Addr::UNSPECIFIED), "unspecified");
+        // :: (IPv6 unspecified).
+        assert_restricted(IpAddr::V6(Ipv6Addr::UNSPECIFIED), "unspecified");
+
+        // CGNAT 100.64.0.0/10 spans 100.64.x.x .. 100.127.x.x.
+        assert_restricted(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1)), "carrier-grade-nat");
+        assert_restricted(
+            IpAddr::V4(Ipv4Addr::new(100, 127, 255, 254)),
+            "carrier-grade-nat",
+        );
+
+        // Guard against over-blocking: addresses just outside 100.64/10 stay allowed.
+        assert!(
+            restricted_non_loopback_ip_range(IpAddr::V4(Ipv4Addr::new(100, 63, 255, 255)))
+                .is_none(),
+            "100.63.255.255 is outside CGNAT and must remain allowed"
+        );
+        assert!(
+            restricted_non_loopback_ip_range(IpAddr::V4(Ipv4Addr::new(100, 128, 0, 0))).is_none(),
+            "100.128.0.0 is outside CGNAT and must remain allowed"
+        );
+
+        // The DNS egress filter must also deny these via EACCES.
+        assert_dns_denied(IpAddr::V4(Ipv4Addr::UNSPECIFIED), "0.0.0.0 (unspecified)");
+        assert_dns_denied(IpAddr::V6(Ipv6Addr::UNSPECIFIED), ":: (unspecified)");
+        assert_dns_denied(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1)), "100.64.0.1 (CGNAT)");
     }
 }

--- a/crates/sidecar/src/execution.rs
+++ b/crates/sidecar/src/execution.rs
@@ -11272,6 +11272,25 @@ fn loopback_cidr(ip: IpAddr) -> &'static str {
     }
 }
 
+/// Returns the embedded IPv4 address of an IPv4-compatible IPv6 address
+/// (`::a.b.c.d`): the first six 16-bit segments are zero and the final 32 bits
+/// hold the IPv4 address. The all-zero (`::`) and loopback (`::1`) addresses are
+/// deliberately excluded so they are handled by the unspecified/loopback paths
+/// rather than treated as IPv4-compatible.
+fn ipv4_compatible_embedded(ip: Ipv6Addr) -> Option<Ipv4Addr> {
+    let segments = ip.segments();
+    if segments[0..6].iter().any(|&s| s != 0) {
+        return None;
+    }
+    let embedded = (u32::from(segments[6]) << 16) | u32::from(segments[7]);
+    // Skip :: (0.0.0.0) and ::1 (0.0.0.1) — these are the IPv6 unspecified /
+    // loopback addresses, not IPv4-compatible representations of an IPv4 host.
+    if embedded == 0 || embedded == 1 {
+        return None;
+    }
+    Some(Ipv4Addr::from(embedded))
+}
+
 fn restricted_non_loopback_ip_range(ip: IpAddr) -> Option<(&'static str, &'static str)> {
     match ip {
         IpAddr::V4(ip) => {
@@ -11293,6 +11312,15 @@ fn restricted_non_loopback_ip_range(ip: IpAddr) -> Option<(&'static str, &'stati
         IpAddr::V6(ip) => {
             if let Some(mapped) = ip.to_ipv4_mapped() {
                 return restricted_non_loopback_ip_range(IpAddr::V4(mapped));
+            }
+            // IPv4-compatible IPv6 (::a.b.c.d): the first six segments are zero
+            // and the last two carry an embedded IPv4 address. `to_ipv4_mapped`
+            // returns None for this form, so without canonicalizing it here a
+            // guest could spell a restricted IPv4 target (e.g. cloud-metadata
+            // ::169.254.169.254) and bypass the IPv4 classifier. `::`/`::1` are
+            // excluded so they fall through to the unspecified/loopback paths.
+            if let Some(compat) = ipv4_compatible_embedded(ip) {
+                return restricted_non_loopback_ip_range(IpAddr::V4(compat));
             }
 
             if ip.is_unspecified() {
@@ -20251,7 +20279,9 @@ mod ssrf_egress_classifier_tests {
     // These are bounded SAFEGUARD tests: they exercise the classifier and the DNS
     // egress filter directly (no network I/O, no Node), so they run fast and
     // deterministically. See FAILURES.md#F-005, #F-006, #F-007.
-    use super::{filter_dns_safe_ip_addrs, restricted_non_loopback_ip_range, SidecarError};
+    use super::{
+        filter_dns_safe_ip_addrs, is_loopback_ip, restricted_non_loopback_ip_range, SidecarError,
+    };
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     fn assert_restricted(ip: IpAddr, expected_label: &str) {
@@ -20307,5 +20337,52 @@ mod ssrf_egress_classifier_tests {
         assert_dns_denied(IpAddr::V4(Ipv4Addr::UNSPECIFIED), "0.0.0.0 (unspecified)");
         assert_dns_denied(IpAddr::V6(Ipv6Addr::UNSPECIFIED), ":: (unspecified)");
         assert_dns_denied(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1)), "100.64.0.1 (CGNAT)");
+    }
+
+    // F-006 (sec-sidecar T7).
+    #[test]
+    fn classifier_denies_ipv6_spelled_metadata_addresses() {
+        // The IPv4-mapped form (::ffff:169.254.169.254) was already handled; the
+        // IPv4-compatible form (::169.254.169.254) is the gap this fixes.
+        let mapped = "::ffff:169.254.169.254".parse::<Ipv6Addr>().unwrap();
+        assert_restricted(IpAddr::V6(mapped), "link-local");
+
+        let compat = "::169.254.169.254".parse::<Ipv6Addr>().unwrap();
+        assert_restricted(IpAddr::V6(compat), "link-local");
+
+        // Other IPv4-compatible private/CGNAT spellings must also be canonicalized.
+        assert_restricted(
+            IpAddr::V6("::10.0.0.1".parse::<Ipv6Addr>().unwrap()),
+            "private",
+        );
+        assert_restricted(
+            IpAddr::V6("::100.64.0.1".parse::<Ipv6Addr>().unwrap()),
+            "carrier-grade-nat",
+        );
+
+        // Guard against over-blocking: the IPv6 unspecified/loopback addresses
+        // are not IPv4-compatible host targets, and a public IPv4-compatible
+        // address must remain allowed.
+        assert_eq!(
+            restricted_non_loopback_ip_range(IpAddr::V6(Ipv6Addr::UNSPECIFIED)),
+            Some(("::/128", "unspecified")),
+            ":: must classify as unspecified, not via the IPv4-compat path"
+        );
+        assert!(
+            restricted_non_loopback_ip_range(IpAddr::V6(Ipv6Addr::LOCALHOST)).is_none()
+                || is_loopback_ip(IpAddr::V6(Ipv6Addr::LOCALHOST)),
+            "::1 must not be classified as a restricted IPv4-compatible target"
+        );
+        assert!(
+            restricted_non_loopback_ip_range(IpAddr::V6("::8.8.8.8".parse::<Ipv6Addr>().unwrap()))
+                .is_none(),
+            "::8.8.8.8 (public IPv4-compatible) must remain allowed"
+        );
+
+        // The DNS egress filter must deny the IPv4-compat metadata spelling.
+        assert_dns_denied(
+            IpAddr::V6("::169.254.169.254".parse::<Ipv6Addr>().unwrap()),
+            "::169.254.169.254 (IPv4-compat metadata)",
+        );
     }
 }

--- a/crates/sidecar/src/execution.rs
+++ b/crates/sidecar/src/execution.rs
@@ -11306,6 +11306,12 @@ fn restricted_non_loopback_ip_range(ip: IpAddr) -> Option<(&'static str, &'stati
                 (172, 16..=31) => Some(("172.16.0.0/12", "private")),
                 (192, 168) => Some(("192.168.0.0/16", "private")),
                 (169, 254) => Some(("169.254.0.0/16", "link-local")),
+                // 224.0.0.0/4 is the IPv4 multicast range and 240.0.0.0/4 is
+                // reserved/future-use (255.255.255.255 broadcast falls in it).
+                // Neither is a legitimate unicast egress target, so a guest
+                // connect to them must be denied rather than attempted.
+                (224..=239, _) => Some(("224.0.0.0/4", "multicast")),
+                (240..=255, _) => Some(("240.0.0.0/4", "reserved")),
                 _ => None,
             }
         }
@@ -20384,5 +20390,39 @@ mod ssrf_egress_classifier_tests {
             IpAddr::V6("::169.254.169.254".parse::<Ipv6Addr>().unwrap()),
             "::169.254.169.254 (IPv4-compat metadata)",
         );
+    }
+
+    // F-007 (sec-sidecar T11).
+    #[test]
+    fn classifier_denies_reserved_and_multicast_targets() {
+        // 224.0.0.0/4 (multicast) and 240.0.0.0/4 (reserved / future use) are not
+        // legitimate unicast egress targets; a guest connect to them must be
+        // classified as restricted and denied.
+        assert_restricted(IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1)), "multicast");
+        assert_restricted(IpAddr::V4(Ipv4Addr::new(239, 255, 255, 255)), "multicast");
+        assert_restricted(IpAddr::V4(Ipv4Addr::new(240, 0, 0, 1)), "reserved");
+        // 255.255.255.255 (limited broadcast) falls in 240.0.0.0/4.
+        assert_restricted(IpAddr::V4(Ipv4Addr::BROADCAST), "reserved");
+
+        // IPv4-compatible IPv6 spellings must canonicalize and be denied too.
+        assert_restricted(
+            IpAddr::V6("::224.0.0.1".parse::<Ipv6Addr>().unwrap()),
+            "multicast",
+        );
+        assert_restricted(
+            IpAddr::V6("::240.0.0.1".parse::<Ipv6Addr>().unwrap()),
+            "reserved",
+        );
+
+        // Guard against over-blocking: addresses just outside 224/4 stay allowed.
+        assert!(
+            restricted_non_loopback_ip_range(IpAddr::V4(Ipv4Addr::new(223, 255, 255, 255)))
+                .is_none(),
+            "223.255.255.255 is outside 224/4 and must remain allowed"
+        );
+
+        // The DNS egress filter must also deny these via EACCES.
+        assert_dns_denied(IpAddr::V4(Ipv4Addr::new(240, 0, 0, 1)), "240.0.0.1 (reserved)");
+        assert_dns_denied(IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1)), "224.0.0.1 (multicast)");
     }
 }

--- a/crates/v8-runtime/src/isolate.rs
+++ b/crates/v8-runtime/src/isolate.rs
@@ -1,6 +1,7 @@
 // V8 isolate lifecycle: platform init, create, configure, destroy
 
 use std::collections::HashMap;
+use std::ffi::c_void;
 use std::sync::Once;
 
 use crate::ipc::ExecutionError;
@@ -99,6 +100,56 @@ pub fn init_v8_platform() {
     });
 }
 
+// Headroom granted to V8 when the near-heap-limit callback fires. V8 fatal-aborts
+// the whole process (SIGTRAP) if the callback does not raise the limit, so we must
+// hand back a larger limit to give the engine room to unwind. Termination has
+// already been requested, so this extra budget only covers propagation of the
+// uncatchable termination exception, not continued guest allocation.
+const NEAR_HEAP_LIMIT_HEADROOM_BYTES: usize = 16 * 1024 * 1024;
+
+/// Invoked by V8 when heap usage approaches the configured limit. Instead of
+/// letting V8 fatal-abort the (process-global) runtime, request termination of the
+/// offending isolate and return a raised limit so V8 can propagate the uncatchable
+/// termination exception cleanly. `data` is a leaked `Box<v8::IsolateHandle>` for
+/// the isolate this callback was registered on.
+extern "C" fn near_heap_limit_callback(
+    data: *mut c_void,
+    current_heap_limit: usize,
+    initial_heap_limit: usize,
+) -> usize {
+    if !data.is_null() {
+        // Safety: `data` is the pointer produced by `Box::into_raw` in
+        // `install_heap_limit_guard` and lives for the entire lifetime of the
+        // isolate.
+        let handle = unsafe { &*(data as *const v8::IsolateHandle) };
+        // Terminate any JS currently running on this isolate. This unwinds the
+        // guest with an uncatchable exception rather than crashing the process.
+        handle.terminate_execution();
+    }
+    // Grant headroom so V8 does not immediately fatal-abort before the termination
+    // takes effect. We never shrink below the current limit.
+    current_heap_limit
+        .max(initial_heap_limit)
+        .saturating_add(NEAR_HEAP_LIMIT_HEADROOM_BYTES)
+}
+
+/// Register the near-heap-limit OOM guard on an isolate that was created with a
+/// configured heap cap. Without this guard, V8 fatal-aborts the whole (process-
+/// global) runtime with a SIGTRAP when the cap is reached, taking down every
+/// concurrent tenant; with it, the offending isolate is terminated instead.
+///
+/// Must be called for every isolate created with a non-`None` heap limit,
+/// regardless of whether it was built fresh or restored from a snapshot.
+pub fn install_heap_limit_guard(isolate: &mut v8::OwnedIsolate) {
+    // The callback needs a thread-safe handle to request termination of this very
+    // isolate. The handle is leaked so it outlives the callback registration; the
+    // number of isolates per process is bounded, so this is not an unbounded leak,
+    // and the memory is reclaimed when the process exits.
+    let handle = Box::new(isolate.thread_safe_handle());
+    let data = Box::into_raw(handle) as *mut c_void;
+    isolate.add_near_heap_limit_callback(near_heap_limit_callback, data);
+}
+
 /// Create a new V8 isolate with an optional heap limit in MB.
 pub fn create_isolate(heap_limit_mb: Option<u32>) -> v8::OwnedIsolate {
     let mut params = v8::CreateParams::default();
@@ -108,6 +159,9 @@ pub fn create_isolate(heap_limit_mb: Option<u32>) -> v8::OwnedIsolate {
     }
     let mut isolate = v8::Isolate::new(params);
     configure_isolate(&mut isolate);
+    if heap_limit_mb.is_some() {
+        install_heap_limit_guard(&mut isolate);
+    }
     isolate
 }
 

--- a/crates/v8-runtime/src/session.rs
+++ b/crates/v8-runtime/src/session.rs
@@ -49,8 +49,11 @@ const SESSION_COMMAND_CHANNEL_CAPACITY: usize = 256;
 const MAX_DEFERRED_SESSION_COMMANDS: usize = SESSION_COMMAND_CHANNEL_CAPACITY;
 const MAX_DEFERRED_SYNC_MESSAGES: usize = SESSION_COMMAND_CHANNEL_CAPACITY;
 
+/// Normalize an opt-in CPU-time budget: `Some(0)` means "disabled" and folds to
+/// `None` so the CPU-budget watchdog is NOT armed. There is no default — when the
+/// caller passes `None`/`0`, the guest runs with no CPU limit (opt-in by design).
 fn normalize_cpu_time_limit_ms(cpu_time_limit_ms: Option<u32>) -> Option<u32> {
-    cpu_time_limit_ms.filter(|timeout_ms| *timeout_ms > 0)
+    cpu_time_limit_ms.filter(|budget_ms| *budget_ms > 0)
 }
 
 /// Internal entry for a running session
@@ -101,9 +104,15 @@ pub(crate) type DeferredQueue = Arc<Mutex<VecDeque<SessionMessage>>>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ExecutionAbortReason {
+    /// Caller explicitly terminated the execution (e.g. session destroy).
     Terminated,
+    /// The WALL-CLOCK backstop (`TimeoutGuard`) elapsed. DORMANT in this PR: not
+    /// armed by F-001. Retained for the deferred wall-clock follow-up PR.
+    #[allow(dead_code)]
+    WallClockTimedOut,
+    /// The TRUE CPU-TIME budget (`CpuBudgetGuard`) was exhausted by active JS CPU.
     #[cfg_attr(test, allow(dead_code))]
-    TimedOut,
+    CpuBudgetExceeded,
 }
 
 struct ExecutionAbortState {
@@ -712,6 +721,16 @@ fn session_thread(
         return;
     }
 
+    // Capture THIS session thread's per-thread CPU clock once. The clock id is
+    // stable for the thread's lifetime and can be polled from the watchdog
+    // thread; this is what lets the CPU-budget guard measure active JS CPU time
+    // (excluding idle/await) without running on the execution thread itself.
+    // Guest JS always runs on this thread, so this clock is the execution clock.
+    #[cfg(all(not(test), unix))]
+    let exec_thread_cpu_clock = crate::timeout::current_thread_cpu_clock();
+    #[cfg(all(not(test), not(unix)))]
+    let exec_thread_cpu_clock: Option<crate::timeout::ThreadCpuClock> = None;
+
     // Isolate creation is deferred to first Execute (when bridge code is known
     // for snapshot cache lookup). This avoids creating an isolate that may never
     // be used and enables snapshot-based fast creation.
@@ -981,12 +1000,55 @@ fn session_thread(
                             }
                         }
 
-                        // Start timeout guard before execution
-                        let mut timeout_guard = match cpu_time_limit_ms {
-                            Some(ms) => {
+                        // Arm the TRUE CPU-TIME budget watchdog before running
+                        // guest code. This is the ONLY execution budget F-001 arms
+                        // in this PR, and only when the operator opts in via
+                        // `AGENT_OS_V8_CPU_TIME_LIMIT_MS` (normalized: `0`/unset =>
+                        // `None` => not armed => NO CPU limit). The wall-clock
+                        // `TimeoutGuard` is intentionally left DORMANT here; a
+                        // follow-up PR re-introduces a wall-clock backstop as its
+                        // own opt-in knob.
+                        //
+                        // The watchdog counts ACTIVE JS CPU only (idle/await
+                        // excluded) by polling the execution thread's CPU clock, so
+                        // a guest that mostly awaits is NOT killed by it.
+                        let mut cpu_budget_guard = match cpu_time_limit_ms {
+                            Some(budget_ms) => {
+                                // Enforcing a CPU budget requires the execution
+                                // thread's CPU clock captured at session start. If
+                                // it is unavailable we cannot honor the operator's
+                                // requested cap — surface that rather than silently
+                                // running uncapped.
+                                let cpu_clock = match exec_thread_cpu_clock {
+                                    Some(clock) => clock,
+                                    None => {
+                                        let result_frame = RuntimeEvent::ExecutionResult {
+                                            session_id,
+                                            exit_code: 1,
+                                            exports: None,
+                                            error: Some(ExecutionErrorBin {
+                                                error_type: "Error".into(),
+                                                message: format!(
+                                                    "{}: per-thread CPU clock unavailable; cannot enforce AGENT_OS_V8_CPU_TIME_LIMIT_MS",
+                                                    crate::timeout::CPU_BUDGET_GUARD_START_ERROR_CODE
+                                                ),
+                                                stack: String::new(),
+                                                code: crate::timeout::CPU_BUDGET_GUARD_START_ERROR_CODE
+                                                    .into(),
+                                            }),
+                                        };
+                                        send_event_with_generation(
+                                            &event_tx,
+                                            output_generation,
+                                            result_frame,
+                                        );
+                                        continue;
+                                    }
+                                };
                                 let handle = iso.thread_safe_handle();
-                                match crate::timeout::TimeoutGuard::with_execution_abort(
-                                    ms,
+                                match crate::timeout::CpuBudgetGuard::new(
+                                    budget_ms,
+                                    cpu_clock,
                                     handle,
                                     execution_abort.clone(),
                                 ) {
@@ -1001,7 +1063,7 @@ fn session_thread(
                                                 message,
                                                 stack: String::new(),
                                                 code:
-                                                    crate::timeout::TIMEOUT_GUARD_START_ERROR_CODE
+                                                    crate::timeout::CPU_BUDGET_GUARD_START_ERROR_CODE
                                                         .into(),
                                             }),
                                         };
@@ -1193,16 +1255,18 @@ fn session_thread(
                             }
                         }
 
-                        // Check if timeout fired
+                        // Check whether the CPU-time budget watchdog fired.
                         let abort_reason = execution_abort_reason(&execution_abort);
-                        let timed_out = timeout_guard.as_ref().is_some_and(|g| g.timed_out())
-                            || matches!(abort_reason, Some(ExecutionAbortReason::TimedOut));
+                        let cpu_budget_exceeded = cpu_budget_guard
+                            .as_ref()
+                            .is_some_and(|g| g.exceeded())
+                            || matches!(abort_reason, Some(ExecutionAbortReason::CpuBudgetExceeded));
 
-                        // Cancel timeout guard (joins timer thread)
-                        if let Some(ref mut guard) = timeout_guard {
+                        // Cancel the CPU-budget watchdog (joins its thread).
+                        if let Some(ref mut guard) = cpu_budget_guard {
                             guard.cancel();
                         }
-                        drop(timeout_guard);
+                        drop(cpu_budget_guard);
 
                         if matches!(abort_reason, Some(ExecutionAbortReason::Terminated)) {
                             terminated = true;
@@ -1212,16 +1276,19 @@ fn session_thread(
                         }
 
                         // Send ExecutionResult
-                        let result_frame = if timed_out {
+                        let result_frame = if cpu_budget_exceeded {
                             RuntimeEvent::ExecutionResult {
                                 session_id,
                                 exit_code: 1,
                                 exports: None,
                                 error: Some(ExecutionErrorBin {
                                     error_type: "Error".into(),
-                                    message: "Script execution timed out".into(),
+                                    message:
+                                        "Script execution exceeded the CPU-time budget \
+                                         (AGENT_OS_V8_CPU_TIME_LIMIT_MS)"
+                                            .into(),
                                     stack: String::new(),
-                                    code: "ERR_SCRIPT_EXECUTION_TIMEOUT".into(),
+                                    code: "ERR_SCRIPT_CPU_BUDGET_EXCEEDED".into(),
                                 }),
                             }
                         } else if terminated {

--- a/crates/v8-runtime/src/snapshot.rs
+++ b/crates/v8-runtime/src/snapshot.rs
@@ -181,6 +181,11 @@ where
     }
     let mut isolate = v8::Isolate::new(params);
     crate::isolate::configure_isolate(&mut isolate);
+    if heap_limit_mb.is_some() {
+        // Same OOM guard as the fresh-isolate path: terminate this isolate on heap
+        // exhaustion instead of fatal-aborting the shared process (F-003).
+        crate::isolate::install_heap_limit_guard(&mut isolate);
+    }
     isolate
 }
 

--- a/crates/v8-runtime/src/timeout.rs
+++ b/crates/v8-runtime/src/timeout.rs
@@ -1,4 +1,20 @@
-// CPU timeout enforcement via dedicated timer thread
+// Execution budget enforcement via dedicated watchdog threads.
+//
+// Two INDEPENDENT mechanisms live here:
+//
+//   * `TimeoutGuard` — a WALL-CLOCK timer. It is intentionally left DORMANT in
+//     this PR (not armed by F-001). A follow-up PR will re-introduce a
+//     wall-clock backstop as its own opt-in knob; the code is retained so that
+//     re-arming it is a small, reviewed change rather than a rewrite.
+//
+//   * `CpuBudgetGuard` — a TRUE CPU-TIME budget. It samples the EXECUTION
+//     thread's per-thread CPU clock (`pthread_getcpuclockid` +
+//     `clock_gettime`). Because a thread's CPU clock does not advance while the
+//     thread is parked/awaiting I/O, this counts ONLY active JS CPU time and
+//     EXCLUDES idle/await. V8 has no native budget primitive, so this poll +
+//     `terminate_execution()` approach is the standard embedder pattern. This
+//     is the only guard F-001 arms in this PR, and only when the operator opts
+//     in via `AGENT_OS_V8_CPU_TIME_LIMIT_MS`.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -6,6 +22,197 @@ use std::thread;
 use std::time::Duration;
 
 pub(crate) const TIMEOUT_GUARD_START_ERROR_CODE: &str = "ERR_TIMEOUT_GUARD_START";
+pub(crate) const CPU_BUDGET_GUARD_START_ERROR_CODE: &str = "ERR_CPU_BUDGET_GUARD_START";
+
+/// How often the CPU-budget watchdog samples the execution thread's CPU clock.
+const CPU_BUDGET_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// An opaque handle to a specific thread's CPU-time clock, captured ON that
+/// thread and safe to read from another (watchdog) thread.
+///
+/// The POSIX per-thread CPU clock id is derived from the thread's `pthread_t`
+/// and remains valid for the lifetime of that thread, so the watchdog can poll
+/// it via `clock_gettime` without running on the execution thread itself.
+#[cfg(unix)]
+#[derive(Clone, Copy)]
+pub(crate) struct ThreadCpuClock {
+    clockid: libc::clockid_t,
+}
+
+/// Capture the CALLING thread's CPU-time clock. Must be invoked on the thread
+/// whose CPU time should be measured (i.e. the execution thread).
+///
+/// Returns `None` if the platform refuses to expose a per-thread CPU clock, in
+/// which case no CPU budget can be enforced.
+#[cfg(unix)]
+pub(crate) fn current_thread_cpu_clock() -> Option<ThreadCpuClock> {
+    // SAFETY: `pthread_self` is always callable; `pthread_getcpuclockid` writes
+    // a valid clockid into `clockid` on success (return 0).
+    unsafe {
+        let mut clockid: libc::clockid_t = 0;
+        let rc = libc::pthread_getcpuclockid(libc::pthread_self(), &mut clockid);
+        if rc == 0 {
+            Some(ThreadCpuClock { clockid })
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(unix)]
+impl ThreadCpuClock {
+    /// Read accumulated CPU time for the captured thread, in milliseconds.
+    /// Returns `None` if the clock read fails.
+    fn elapsed_ms(self) -> Option<u64> {
+        // SAFETY: `clockid` came from a successful `pthread_getcpuclockid`; the
+        // timespec is fully written by `clock_gettime` on success.
+        unsafe {
+            let mut ts: libc::timespec = std::mem::zeroed();
+            if libc::clock_gettime(self.clockid, &mut ts) == 0 {
+                let ms = (ts.tv_sec as i128) * 1_000 + (ts.tv_nsec as i128) / 1_000_000;
+                Some(ms.max(0) as u64)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// Guard for per-execution TRUE CPU-time budget enforcement.
+///
+/// Spawns a watchdog thread that polls the execution thread's CPU clock every
+/// [`CPU_BUDGET_POLL_INTERVAL`]. When accumulated active-JS CPU time exceeds the
+/// budget, it calls `v8::Isolate::terminate_execution()` and signals the
+/// execution abort with [`crate::session::ExecutionAbortReason::CpuBudgetExceeded`].
+/// A guest that mostly awaits/idles accrues little CPU time and is NOT killed.
+///
+/// Drop or call `cancel()` to stop the watchdog (execution completed normally).
+pub(crate) struct CpuBudgetGuard {
+    cancel_tx: Option<crossbeam_channel::Sender<()>>,
+    fired: Arc<AtomicBool>,
+    join_handle: Option<thread::JoinHandle<()>>,
+}
+
+#[cfg(unix)]
+impl CpuBudgetGuard {
+    /// Spawn the CPU-budget watchdog.
+    ///
+    /// - `budget_ms`: TRUE CPU-time budget in milliseconds (active JS only)
+    /// - `cpu_clock`: the execution thread's CPU clock (captured on that thread)
+    /// - `isolate_handle`: V8 isolate handle for `terminate_execution()`
+    /// - `execution_abort`: signalled with `CpuBudgetExceeded` when the budget is exhausted
+    pub(crate) fn new(
+        budget_ms: u32,
+        cpu_clock: ThreadCpuClock,
+        isolate_handle: v8::IsolateHandle,
+        execution_abort: crate::session::SharedExecutionAbort,
+    ) -> Result<Self, String> {
+        let (cancel_tx, cancel_rx) = crossbeam_channel::bounded::<()>(1);
+        let fired = Arc::new(AtomicBool::new(false));
+        let fired_clone = Arc::clone(&fired);
+
+        // Snapshot the thread's CPU time at arm so the budget measures CPU
+        // consumed DURING this execution, not cumulative thread lifetime.
+        let baseline_ms = cpu_clock.elapsed_ms().unwrap_or(0);
+        let budget_ms = budget_ms as u64;
+
+        let handle = thread::Builder::new()
+            .name("cpu-budget".into())
+            .spawn(move || {
+                let ticker = crossbeam_channel::tick(CPU_BUDGET_POLL_INTERVAL);
+                loop {
+                    crossbeam_channel::select! {
+                        recv(cancel_rx) -> _ => {
+                            // Cancelled — execution completed normally.
+                            return;
+                        }
+                        recv(ticker) -> _ => {
+                            let used = cpu_clock
+                                .elapsed_ms()
+                                .unwrap_or(baseline_ms)
+                                .saturating_sub(baseline_ms);
+                            if used >= budget_ms {
+                                fired_clone.store(true, Ordering::SeqCst);
+                                isolate_handle.terminate_execution();
+                                crate::session::signal_execution_abort(
+                                    &execution_abort,
+                                    crate::session::ExecutionAbortReason::CpuBudgetExceeded,
+                                );
+                                return;
+                            }
+                        }
+                    }
+                }
+            })
+            .map_err(|error| {
+                format!(
+                    "{CPU_BUDGET_GUARD_START_ERROR_CODE}: failed to spawn cpu-budget thread: {error}"
+                )
+            })?;
+
+        Ok(CpuBudgetGuard {
+            cancel_tx: Some(cancel_tx),
+            fired,
+            join_handle: Some(handle),
+        })
+    }
+
+    /// Cancel the watchdog (execution completed normally). Blocks until the
+    /// watchdog thread exits.
+    pub(crate) fn cancel(&mut self) {
+        self.cancel_tx.take();
+        if let Some(h) = self.join_handle.take() {
+            let _ = h.join();
+        }
+    }
+
+    /// Check whether the CPU budget was exhausted.
+    #[cfg_attr(test, allow(dead_code))]
+    pub(crate) fn exceeded(&self) -> bool {
+        self.fired.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(unix)]
+impl Drop for CpuBudgetGuard {
+    fn drop(&mut self) {
+        self.cancel();
+    }
+}
+
+// Non-unix fallback: there is no portable per-thread CPU clock, so the
+// CPU-budget watchdog cannot be enforced. `current_thread_cpu_clock` returns
+// `None`, which makes the session surface a clear "cannot enforce" error if a
+// CPU budget is requested, rather than silently running uncapped.
+#[cfg(not(unix))]
+#[derive(Clone, Copy)]
+pub(crate) struct ThreadCpuClock;
+
+#[cfg(not(unix))]
+pub(crate) fn current_thread_cpu_clock() -> Option<ThreadCpuClock> {
+    None
+}
+
+#[cfg(not(unix))]
+impl CpuBudgetGuard {
+    pub(crate) fn new(
+        _budget_ms: u32,
+        _cpu_clock: ThreadCpuClock,
+        _isolate_handle: v8::IsolateHandle,
+        _execution_abort: crate::session::SharedExecutionAbort,
+    ) -> Result<Self, String> {
+        Err(format!(
+            "{CPU_BUDGET_GUARD_START_ERROR_CODE}: per-thread CPU clock not supported on this platform"
+        ))
+    }
+
+    pub(crate) fn cancel(&mut self) {}
+
+    #[cfg_attr(test, allow(dead_code))]
+    pub(crate) fn exceeded(&self) -> bool {
+        self.fired.load(Ordering::SeqCst)
+    }
+}
 
 /// Guard for per-session CPU timeout enforcement.
 ///
@@ -37,7 +244,9 @@ impl TimeoutGuard {
         })
     }
 
-    #[cfg_attr(test, allow(dead_code))]
+    // DORMANT in this PR: the wall-clock session backstop is not armed by F-001.
+    // Retained for the deferred wall-clock follow-up PR.
+    #[allow(dead_code)]
     pub(crate) fn with_execution_abort(
         timeout_ms: u32,
         isolate_handle: v8::IsolateHandle,
@@ -46,7 +255,7 @@ impl TimeoutGuard {
         Self::spawn(timeout_ms, isolate_handle, move || {
             crate::session::signal_execution_abort(
                 &execution_abort,
-                crate::session::ExecutionAbortReason::TimedOut,
+                crate::session::ExecutionAbortReason::WallClockTimedOut,
             );
         })
     }


### PR DESCRIPTION
Re-applies the secure-exec security-review fixes cleanly on current `main` (e118ec89). Each fix was re-derived against current code (post JS-runtime-platform / Bun-CBOR-IPC refactors), implemented as its own commit with a verifying adversarial test that passes. Expensive saturation variants stay env-gated; the safeguard tests run by default and are watchdog-bounded.

**Supersedes #76**, which was cut from the abandoned `split/runtime-preview` base and showed an unusable 2247-file diff.

## Fixes

- **F-001 — opt-in TRUE CPU-time budget for guest JS (no default).** A guest `while(true){}` pinned a core on the shared, slot-bounded V8 runtime and starved peers. This PR adds an opt-in CPU-time budget watchdog: a thread that samples the **execution thread's** per-thread CPU clock (`pthread_getcpuclockid` → `clock_gettime`, ~50ms poll) and, when accumulated **active-JS CPU time** exceeds the budget, calls `Isolate::terminate_execution()` and signals `CpuBudgetExceeded` (reported as `ERR_SCRIPT_CPU_BUDGET_EXCEEDED`). Because a thread's CPU clock does not advance while parked/awaiting, this **excludes I/O/idle wait** — only active JS CPU counts (the standard embedder pattern, since V8 has no native budget). The budget is set via `AGENT_OS_V8_CPU_TIME_LIMIT_MS` (true CPU ms); **unset/`0` ⇒ watchdog NOT armed (no limit)**. The earlier 30s default has been **removed** — there is no default, so a guest is CPU-bounded only when the operator/platform sets the env. _Tests:_ `javascript_infinite_loop_is_terminated_by_cpu_watchdog` (budget set ⇒ tight loop killed, cpu-budget reason), `javascript_awaiting_guest_is_not_killed_by_cpu_budget` (budget set, mostly-awaiting guest past the budget window is **not** killed — proves idle/await excluded), `javascript_no_cpu_budget_when_env_unset` (no env ⇒ not armed, not time-limited).
- **F-002 — enforce configured WASM stack byte limit.** `AGENT_OS_WASM_MAX_STACK_BYTES` was plumbed but never read (dead cap). The engine now parses it (rejecting malformed values) and the WASM runner installs a stack-exhaustion guard around `wasi.start` that terminates nonzero and attributes the failure to the configured budget. _Test:_ `wasm_deep_recursion_respects_configured_stack_byte_limit`.
- **F-003 — V8 near-heap-limit OOM guard.** Hitting `AGENT_OS_V8_HEAP_LIMIT_MB` triggered V8's fatal-OOM abort (SIGTRAP), crashing the process-global runtime and every concurrent tenant. `install_heap_limit_guard` now registers a near-heap-limit callback on every heap-capped isolate (fresh + snapshot-restore paths) that terminates the offending isolate and grants headroom so V8 propagates the termination cleanly. _Test:_ `javascript_heap_allocation_bomb_is_capped_by_oom_guard`.
- **F-004 — default WASM wall-clock timeout when no fuel env.** `resolve_wasm_execution_timeout` returned None without `AGENT_OS_WASM_MAX_FUEL`, so `wait()` never terminated a never-returning module. Now applies a default 30s budget when no fuel env is set. _Test:_ `wasm_execution_timeout_defaults_to_bounded_value_without_fuel_env`.
- **F-005 — SSRF: unspecified + CGNAT.** Classifier returned None for `0.0.0.0`/`::` (which route to host loopback) and CGNAT `100.64.0.0/10`. Both are now classified restricted and denied with EACCES. _Test:_ `classifier_denies_unspecified_and_cgnat_targets`.
- **F-006 — SSRF: IPv4-compatible IPv6.** Classifier canonicalized only via `to_ipv4_mapped()`, missing IPv4-compatible spellings (`::169.254.169.254`). Added `ipv4_compatible_embedded()` so `::a.b.c.d` canonicalizes to its embedded IPv4 and is classified (`::`/`::1` excluded). _Test:_ `classifier_denies_ipv6_spelled_metadata_addresses`.
- **F-007 — SSRF: reserved + multicast.** Added `240.0.0.0/4` (reserved, incl. broadcast) and `224.0.0.0/4` (multicast) to the classifier. _Test:_ `classifier_denies_reserved_and_multicast_targets`.

## Not in this PR

- **Wall-clock execution backstop (deferred).** F-001 here is a CPU-time budget **only**. There is intentionally **no wall-clock limit** in this PR: the prior 30s wall-clock default is removed, and no wall-clock env knob is added. The existing `TimeoutGuard` (wall-clock timer) is left in place but **dormant** — not armed by F-001. A follow-up PR will re-introduce a wall-clock backstop as its own separate opt-in knob.
- **F-008 / F-009 (browser fetch credentials + network-policy host/port)** belong in the **agent-os** repo. The live browser network adapter is `@rivet-dev/agent-os-browser` in agent-os; secure-exec's `packages/browser` (`@secure-exec/browser`) is an orphaned copy not depended on by anything in the secure-exec workspace. Per the boundary (secure-exec stays free of agent/browser concerns), these are not applied here.

## Verification

`cargo build --workspace` green. `javascript_v8_suite` (incl. the three F-001 CPU-budget tests), `wasm_suite`, the sidecar `ssrf_egress_classifier_tests`, and the F-004 unit test all pass.

> **Note:** with no default, guest JS CPU is **uncapped** unless the platform/operator sets `AGENT_OS_V8_CPU_TIME_LIMIT_MS`.