### PR TITLE
fix(ci): resolve pnpm/action-setup version conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
## Problem

CI fails on **every** commit (including `main`) at the `pnpm/action-setup` step, before any build runs:

```
ERR_PNPM_BAD_PM_VERSION  Multiple versions of pnpm specified
```

`pnpm/action-setup@v4` refuses to run when the pnpm version is specified in **two** places:

1. `.github/workflows/ci.yml` — the action's `version: latest` input
2. root `package.json` — `"packageManager": "pnpm@10.13.1"`

When both are present, the action errors out rather than guessing which to honor.

## Fix

Remove the `version:` input from the `pnpm/action-setup` step in `ci.yml` so the action reads the version solely from `packageManager` in `package.json` — the recommended single-source-of-truth configuration.

```diff
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
       - uses: actions/setup-node@v4
```

This un-breaks CI repo-wide.

## Notes

- The `publish.yaml` workflow's `pnpm/action-setup` steps already have no `version:` input, so they were never affected and are left untouched.
- There is no `.npmrc` or other competing pnpm-version source; `packageManager` is now the only place the version is declared.