### PR TITLE
fix(example): native-client uses current CreateVmConfig (unblocks CI)

### DIFF
--- a/examples/native-client/src/index.ts
+++ b/examples/native-client/src/index.ts
@@ -12,8 +12,15 @@ try {
 	});
 	const vm = await client.createVm(session, {
 		runtime: "java_script",
-		metadata: {
-			example: "native-client",
+		config: {
+			env: {},
+			rootFilesystem: {
+				mode: "ephemeral",
+				disableDefaultBaseLayer: false,
+				lowers: [{ kind: "bundledBaseFilesystem" }],
+				bootstrapEntries: [],
+			},
+			loopbackExemptPorts: [],
 		},
 	});
 


### PR DESCRIPTION
## What

The `native-client` example failed to type-check after the "CreateVm → typed JSON config" migration:

```
examples/native-client/src/index.ts(15,3): error TS2353: Object literal may only specify known properties, and 'metadata' does not exist in type '{ runtime: GuestRuntimeKind; config: CreateVmConfig; }'
```

This is a pre-existing build break on `main`, surfaced by the pnpm CI fix that now actually type-checks the workspace examples.

## Why it broke

`createVm`'s second argument changed from a flat `{ runtime, metadata }` shape to `{ runtime, config: CreateVmConfig }`. The old per-VM `metadata` field no longer exists on `CreateVmConfig` — session metadata now lives on `authenticateAndOpenSession(metadata)`, which the example already passes (`{ example: "native-client" }`). The example was simply never updated to the new `config` shape.

## Change

Replace the stale `metadata` object on `createVm` with a minimal valid `CreateVmConfig` (ephemeral root filesystem over the bundled base filesystem, empty env, no loopback-exempt ports). Session metadata is unchanged and still passed to `authenticateAndOpenSession`. Diff is limited to the example.

## Verification

- `pnpm --filter @secure-exec/example-native-client build` (tsc) — green
- `pnpm check-types` across the workspace — 59/59 packages pass