### PR TITLE
Security review: close coverage gaps (DNS rebinding, supply chain, builtin desync, browser isolation)

### DIFF
--- a/crates/execution/tests/javascript_v8.rs
+++ b/crates/execution/tests/javascript_v8.rs
@@ -4660,6 +4660,66 @@ console.log("BOMB_COMPLETED_WITHOUT_CAP");
     }
 }
 
+// Adversarial coverage for the builtin allow/deny desync (VECTORS.md A.2).
+// A denied builtin must stay denied on EVERY guest resolution path. The most
+// likely desync is a sub-path specifier (`dns/promises`) leaking on one path
+// while its root (`dns`) is denied on another. The live guest-JS path is the
+// shared V8 runtime, whose single `loadBuiltinModule` funnel gates by root
+// name (`split('/')[0]`) for require / createRequire / process.getBuiltinModule
+// / dynamic import alike. With an allow-list that excludes `dns`, every path
+// must reject both `dns` and `dns/promises`.
+fn javascript_execution_denies_dns_and_subpaths_on_every_resolution_path() {
+    assert_js_runtime_guest_ok(
+        // node platform, allow-list excludes `dns` (only `path`/`module`).
+        js_runtime_env(&[("AGENT_OS_JS_BUILTIN_ALLOWLIST", "[\"path\",\"module\"]")]),
+        r#"
+        import { createRequire } from "node:module";
+        const require = createRequire(import.meta.url);
+
+        function assertDeniedSync(label, fn) {
+          let denied = false;
+          let detail = "no error";
+          try {
+            const mod = fn();
+            const keys = mod && typeof mod === "object" ? Object.keys(mod).slice(0, 4).join(",") : typeof mod;
+            detail = "resolved to " + keys;
+          } catch (error) {
+            detail = String(error && error.message);
+            denied = !!error;
+          }
+          if (!denied) throw new Error(label + " was not denied: " + detail);
+        }
+
+        async function assertDeniedAsync(label, promise) {
+          let denied = false;
+          let detail = "no error";
+          try { await promise; detail = "import resolved"; }
+          catch (error) { detail = String(error && error.message); denied = !!error; }
+          if (!denied) throw new Error(label + " was not denied: " + detail);
+        }
+
+        // Positive control: an allowed builtin still resolves.
+        const path = await import("node:path");
+        if (typeof path.join !== "function") throw new Error("node:path should be allowed");
+
+        for (const specifier of ["dns", "node:dns", "dns/promises", "node:dns/promises"]) {
+          assertDeniedSync("require(" + specifier + ")", () => require(specifier));
+          assertDeniedSync(
+            "createRequire(" + specifier + ")",
+            () => createRequire(import.meta.url)(specifier),
+          );
+          if (typeof process.getBuiltinModule === "function") {
+            assertDeniedSync(
+              "process.getBuiltinModule(" + specifier + ")",
+              () => process.getBuiltinModule(specifier),
+            );
+          }
+          await assertDeniedAsync("import(" + specifier + ")", import(specifier));
+        }
+        "#,
+    );
+}
+
 #[test]
 fn javascript_v8_suite() {
     // Keep V8-backed integration coverage inside one top-level libtest case.
@@ -4683,6 +4743,7 @@ fn javascript_v8_suite() {
     javascript_execution_imports_node_fs_promises_without_hanging();
     javascript_execution_imports_node_perf_hooks_without_hanging();
     javascript_execution_exposes_compatibility_shims_and_denies_escape_builtins();
+    javascript_execution_denies_dns_and_subpaths_on_every_resolution_path();
     javascript_execution_v8_util_format_with_options_matches_node();
     javascript_execution_provides_async_hooks_and_diagnostics_channel_stubs();
     javascript_execution_supports_require_resolve_for_guest_code();

--- a/crates/sidecar/src/execution.rs
+++ b/crates/sidecar/src/execution.rs
@@ -4540,8 +4540,14 @@ where
                 NetworkOperation::Http,
                 format_tcp_resource(host, port),
             )?;
-            let addresses = if host.parse::<IpAddr>().is_ok() {
-                Vec::new()
+            // Pin the outbound connection to the IP addresses that pass the
+            // egress range guard at resolution time. A literal IP is validated
+            // directly; a hostname is resolved once here and the resulting
+            // address set is pinned into the HTTP client's resolver below so a
+            // rebinding DNS server cannot make the second (TLS/TCP) lookup land
+            // on a private/link-local/metadata IP that this check rejected.
+            let pinned_addresses = if let Ok(literal_ip) = host.parse::<IpAddr>() {
+                filter_dns_safe_ip_addrs(vec![literal_ip], host)?
             } else {
                 filter_dns_safe_ip_addrs(
                     resolve_dns_ip_addrs(
@@ -4555,22 +4561,9 @@ where
                     host,
                 )?
             };
-            let mut request_url = url.clone();
             let mut headers = BTreeMap::new();
             for (name, value) in &request.headers {
                 headers.insert(name.clone(), Value::String(value.clone()));
-            }
-            if url.scheme() == "http" && !addresses.is_empty() {
-                request_url
-                    .set_host(Some(&addresses[0].to_string()))
-                    .map_err(|_| {
-                        SidecarError::Execution(String::from(
-                            "ERR_INVALID_URL: failed to rewrite host for python httpRequest",
-                        ))
-                    })?;
-                headers
-                    .entry(String::from("host"))
-                    .or_insert_with(|| Value::String(host.to_owned()));
             }
             let options = JavascriptHttpRequestOptions {
                 method: Some(
@@ -4592,7 +4585,8 @@ where
             };
             let headers =
                 parse_http_header_collection(&options.headers, "python httpRequest headers")?;
-            let response = issue_outbound_http_request(&request_url, &options, &headers)?;
+            let response =
+                issue_outbound_http_request(&url, &options, &headers, &pinned_addresses)?;
             let payload_json = response.as_str().ok_or_else(|| {
                 SidecarError::Execution(String::from(
                     "python httpRequest returned a non-string response payload",
@@ -16164,13 +16158,60 @@ fn outbound_http_response_json(url: &Url, response: ureq::Response) -> Result<Va
     .map_err(|error| SidecarError::Execution(format!("ERR_AGENT_OS_NODE_SYNC_RPC: {error}")))
 }
 
+/// Split a ureq resolver `netloc` (`host:port`, with optional `[..]` IPv6
+/// brackets) into its host and port components. Returns `None` if the port is
+/// missing or unparseable.
+fn split_netloc(netloc: &str) -> Option<(&str, u16)> {
+    let (host, port) = netloc.rsplit_once(':')?;
+    let port: u16 = port.parse().ok()?;
+    let host = host
+        .strip_prefix('[')
+        .and_then(|rest| rest.strip_suffix(']'))
+        .unwrap_or(host);
+    Some((host, port))
+}
+
 fn issue_outbound_http_request(
     url: &Url,
     options: &JavascriptHttpRequestOptions,
     headers: &HttpHeaderCollection,
+    pinned_addresses: &[IpAddr],
 ) -> Result<Value, SidecarError> {
     let method = options.method.as_deref().unwrap_or("GET");
+    // Pin the underlying resolver to the egress-vetted addresses. ureq performs
+    // its own DNS resolution for the TCP/TLS connect; without this override an
+    // https:// request would re-resolve the hostname through the host resolver
+    // (a rebinding DNS server could then return a private/metadata IP that the
+    // earlier range check would have rejected). The pinned resolver returns only
+    // the vetted addresses and refuses any host it was not vetted for, while the
+    // request URL keeps the original hostname so TLS SNI and the Host header stay
+    // correct.
+    let pinned_host = url.host_str().map(str::to_owned);
+    let pinned: Vec<IpAddr> = pinned_addresses.to_vec();
+    let resolver = move |netloc: &str| -> std::io::Result<Vec<SocketAddr>> {
+        let (host, port) = split_netloc(netloc).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("invalid network location: {netloc}"),
+            )
+        })?;
+        let expected_host = pinned_host.as_deref();
+        if expected_host != Some(host) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!("EACCES: outbound HTTP resolver pinned to {expected_host:?}, refusing {host}"),
+            ));
+        }
+        if pinned.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "EACCES: no egress-vetted address available for outbound HTTP request",
+            ));
+        }
+        Ok(pinned.iter().map(|ip| SocketAddr::new(*ip, port)).collect())
+    };
     let mut agent_builder = ureq::AgentBuilder::new()
+        .resolver(resolver)
         .timeout_connect(Duration::from_secs(5))
         .timeout_read(Duration::from_secs(15))
         .timeout_write(Duration::from_secs(15));
@@ -20273,7 +20314,6 @@ mod error_code_tests {
         );
     }
 }
-
 #[cfg(test)]
 mod ssrf_egress_classifier_tests {
     // F-005/006/007 (sec-sidecar T1/T7/T11): the egress classifier must treat the
@@ -20424,5 +20464,92 @@ mod ssrf_egress_classifier_tests {
         // The DNS egress filter must also deny these via EACCES.
         assert_dns_denied(IpAddr::V4(Ipv4Addr::new(240, 0, 0, 1)), "240.0.0.1 (reserved)");
         assert_dns_denied(IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1)), "224.0.0.1 (multicast)");
+    }
+}
+
+/// Adversarial coverage for the DNS-rebinding gap (VECTORS.md D.3) on the
+/// Python/Pyodide `httpRequestSync` outbound HTTP path. The egress range guard
+/// (`filter_dns_safe_ip_addrs`) runs at resolution time, but `ureq` performs its
+/// own DNS resolution for the TCP/TLS connect, so a rebinding DNS server could
+/// previously make the second lookup land on a private/link-local/metadata IP
+/// the first check rejected. The fix pins `ureq`'s resolver to the vetted
+/// address set; these tests prove the connect is pinned and refuses any other
+/// host or an empty (fully-rejected) address set.
+#[cfg(test)]
+mod dns_rebinding_pin_tests {
+    use super::{issue_outbound_http_request, split_netloc, JavascriptHttpRequestOptions};
+    use std::collections::BTreeMap;
+    use std::io::{Read, Write};
+    use std::net::{IpAddr, Ipv4Addr, TcpListener};
+    use std::thread;
+    use url::Url;
+
+    fn empty_headers() -> super::HttpHeaderCollection {
+        super::parse_http_header_collection(&BTreeMap::new(), "test headers")
+            .expect("empty header collection")
+    }
+
+    fn options() -> JavascriptHttpRequestOptions {
+        JavascriptHttpRequestOptions {
+            method: Some(String::from("GET")),
+            headers: BTreeMap::new(),
+            body: None,
+            reject_unauthorized: None,
+        }
+    }
+
+    #[test]
+    fn split_netloc_handles_hostnames_and_bracketed_ipv6() {
+        assert_eq!(split_netloc("attacker.example:80"), Some(("attacker.example", 80)));
+        assert_eq!(split_netloc("[::1]:443"), Some(("::1", 443)));
+        assert_eq!(split_netloc("10.0.0.1:8080"), Some(("10.0.0.1", 8080)));
+        assert_eq!(split_netloc("no-port"), None);
+        assert_eq!(split_netloc("host:notaport"), None);
+    }
+
+    /// A loopback HTTP server stands in for the egress-vetted target. The
+    /// request URL uses a *different* hostname (`attacker.example`) whose real
+    /// DNS would resolve elsewhere; pinning forces the connect onto the vetted
+    /// IP only. If the resolver were unpinned, the request would fail to reach
+    /// this server (and on a real host could land on a private/metadata IP).
+    #[test]
+    fn outbound_http_connect_is_pinned_to_vetted_ip() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind loopback server");
+        let port = listener.local_addr().expect("local addr").port();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf);
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi")
+                .expect("write response");
+            let _ = stream.flush();
+        });
+
+        let url = Url::parse(&format!("http://attacker.example:{port}/")).expect("url");
+        let pinned = vec![IpAddr::V4(Ipv4Addr::LOCALHOST)];
+        let result = issue_outbound_http_request(&url, &options(), &empty_headers(), &pinned)
+            .expect("pinned request should reach the vetted loopback target");
+        let payload = result.as_str().expect("string payload");
+        assert!(
+            payload.contains("\"status\":200"),
+            "expected 200 from pinned target, got: {payload}"
+        );
+        server.join().expect("server thread");
+    }
+
+    /// With no vetted address (every resolved IP was rejected by the range
+    /// guard, or the literal IP was a blocked range), the pinned resolver must
+    /// refuse rather than fall back to the host resolver.
+    #[test]
+    fn outbound_http_refuses_when_no_vetted_address() {
+        let url = Url::parse("https://attacker.example/").expect("url");
+        let error = issue_outbound_http_request(&url, &options(), &empty_headers(), &[])
+            .expect_err("empty pinned set must be refused");
+        let message = error.to_string();
+        assert!(
+            message.contains("EACCES") || message.contains("ERR_HTTP_REQUEST_FAILED"),
+            "expected an egress refusal, got: {message}"
+        );
     }
 }

--- a/packages/core/tests/framing.test.ts
+++ b/packages/core/tests/framing.test.ts
@@ -31,4 +31,36 @@ describe("length-prefixed framing", () => {
 		expect([...(decoded?.payload ?? [])]).toEqual([7, 8]);
 		expect(Buffer.from(decoded?.remaining ?? []).equals(second)).toBe(true);
 	});
+
+	// Adversarial coverage (VECTORS.md E2 / browser TS frame-length cap): a
+	// hostile peer declares an enormous frame length. The decoder must NOT
+	// allocate or slice based on the *declared* length; it only ever yields a
+	// payload once that many real bytes have actually arrived. An oversized
+	// declared length therefore returns null (keep waiting) and never produces
+	// an out-of-bounds read or an unbounded allocation from the length field.
+	test("an oversized declared length never over-reads or over-allocates", () => {
+		// declaredLength = 0xFFFFFFFF (~4 GiB) but only a handful of real bytes.
+		const hostile = Buffer.alloc(LENGTH_PREFIX_BYTES + 8);
+		hostile.writeUInt32BE(0xffffffff, 0);
+		hostile.fill(0x41, LENGTH_PREFIX_BYTES);
+
+		// No 4 GiB allocation, no throw: the decoder simply waits for bytes that
+		// will never come and reports "incomplete".
+		expect(tryDecodeLengthPrefixedPayload(hostile)).toBeNull();
+
+		// A frame is only ever emitted when the buffer truly holds frameEnd
+		// bytes, and the emitted payload length equals the declared length and
+		// is bounded by the bytes actually supplied.
+		const honest = encodeLengthPrefixedPayload(Uint8Array.from([1, 2, 3, 4]));
+		const decoded = tryDecodeLengthPrefixedPayload(honest);
+		expect(decoded?.payload.length).toBe(4);
+		expect(decoded?.payload.length).toBeLessThanOrEqual(honest.length);
+	});
+
+	test("a declared length larger than the buffer is treated as incomplete", () => {
+		// Claim 1 KiB but provide only 10 payload bytes.
+		const buf = Buffer.alloc(LENGTH_PREFIX_BYTES + 10);
+		buf.writeUInt32BE(1024, 0);
+		expect(tryDecodeLengthPrefixedPayload(buf)).toBeNull();
+	});
 });


### PR DESCRIPTION
Closes the four security-review coverage gaps from VECTORS.md. Each gap got an adversarial test that plays an untrusted guest; one was a real, guest-reachable break and is fixed. Based on `main` (#79 merge).

## Gap 1 — DNS rebinding (D.3): REAL FINDING, FIXED (F-011, High)

The Python/Pyodide `httpRequestSync` outbound HTTP path (`crates/sidecar/src/execution.rs::handle_python_http_rpc_request` → `issue_outbound_http_request`) resolved the request hostname once and ran the resolved IPs through the egress range guard (`filter_dns_safe_ip_addrs`). For `http` it rewrote the URL host to the vetted IP, but for **`https` it handed the original hostname URL to `ureq`**, which performs its **own** second DNS resolution for the TCP/TLS connect. A guest-controlled rebinding DNS server returns a public IP for the host's check and a private/link-local/metadata IP (e.g. `169.254.169.254`) for `ureq`'s connect — reaching cloud metadata / internal services. Literal-IP requests (`https://169.254.169.254/`) also skipped `filter_dns_safe_ip_addrs` entirely. Reachable from any Pyodide guest via `fetch`/`micropip` (the policy-vetted bridge whose transport this is).

**Fix:** pin `ureq`'s resolver to the egress-vetted address set (refusing any other host or an empty/fully-rejected set), route literal IPs through the same range guard, and keep the URL hostname so TLS SNI / Host stays correct. Tests: `dns_rebinding_pin_tests` (`split_netloc_*`, `outbound_http_connect_is_pinned_to_vetted_ip`, `outbound_http_refuses_when_no_vetted_address`).

Note: the direct `net.connect` TCP, UDP, and HTTP/2 paths were checked and are already correctly pinned — they resolve once, filter, pick one `SocketAddr`, and connect to that exact address (no re-resolution).

## Gap 2 — Supply chain (I.1/I.3): DEFENDS-CORRECTLY

Module materialization (`node_import_cache.rs`) writes bundled files only — no install/lifecycle/postinstall script execution, no host process spawn. The Pyodide package base URL / `micropip` fetch is guest-configurable but is forced through the policy-obeying `bridge.httpRequestSync` → `require_network_access` egress gate (no direct host fetch / SSRF). The shared transport is the same one hardened in Gap 1, so the egress IP is now pinned there too.

## Gap 3 — Builtin allow/deny desync (A.2): DEFENDS-CORRECTLY

Added an adversarial test that, with an allow-list excluding `dns`, requires every guest resolution path on the **live shared V8 runtime** (`require` / `createRequire` / `process.getBuiltinModule` / dynamic `import`) to reject both `dns` and the sub-path specifier `dns/promises`. The V8 path funnels through a single `loadBuiltinModule` that gates by root name (`split('/')[0]`), so it denies consistently. Test: `javascript_execution_denies_dns_and_subpaths_on_every_resolution_path`.

Note: the host-Node `NODE_EXECUTION_RUNNER_SOURCE` in `node_import_cache.rs` carries a stale `DENIED_BUILTINS` set missing `dns/promises`, but that runner is **dead for guest JS** (only the python/wasm runner paths are read), so it is not guest-reachable — no fix forced into the dead copy.

## Gap 4 — Browser isolation (E2): DEFENDS-CORRECTLY

Prior E2 findings were false positives; re-examined the secure-exec-side parts.
- **TS frame-length cap:** `tryDecodeLengthPrefixedPayload` never allocates/slices on the *declared* length — it only emits a payload once that many real bytes have arrived, so an oversized declared length (`0xFFFFFFFF`) just reports "incomplete". The browser sync-bridge read (`worker.ts` `readBytes` → `data.slice(0,len)`) is clamped by the SharedArrayBuffer view and the write side rejects oversized payloads. Added adversarial unit tests in `packages/core/tests/framing.test.ts`.
- **OPFS per-tenant namespacing:** the browser runtime is single-tenant-per-origin; OPFS is origin-scoped by the browser itself and there is no multi-tenant-per-origin multiplexing in this code, so the "tenant A reads tenant B same-origin" scenario is not reachable (browser-enforced origin isolation). No fix.

## Verdicts
- D.3 DNS rebinding: **REAL FINDING → FIXED** (F-011, High)
- I.1/I.3 supply chain: **DEFENDS-CORRECTLY**
- A.2 builtin desync: **DEFENDS-CORRECTLY**
- E2 browser isolation: **DEFENDS-CORRECTLY**