### PR TITLE
style: rustfmt security-review additions (unblock cargo fmt --check)

### DIFF
--- a/crates/execution/src/javascript.rs
+++ b/crates/execution/src/javascript.rs
@@ -395,10 +395,7 @@ enum GuestModuleResolution {
 
 impl GuestModuleResolution {
     fn from_env(env: &BTreeMap<String, String>) -> Self {
-        match env
-            .get("AGENT_OS_JS_MODULE_RESOLUTION")
-            .map(String::as_str)
-        {
+        match env.get("AGENT_OS_JS_MODULE_RESOLUTION").map(String::as_str) {
             Some("relative") => Self::Relative,
             Some("none") => Self::None,
             _ => Self::Node,

--- a/crates/execution/tests/javascript_v8.rs
+++ b/crates/execution/tests/javascript_v8.rs
@@ -4026,7 +4026,10 @@ fn js_runtime_env(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
         .collect()
 }
 
-fn run_js_runtime_guest(env: BTreeMap<String, String>, inline_code: &str) -> JavascriptExecutionResult {
+fn run_js_runtime_guest(
+    env: BTreeMap<String, String>,
+    inline_code: &str,
+) -> JavascriptExecutionResult {
     let temp = tempdir().expect("create temp dir");
     let mut engine = JavascriptExecutionEngine::default();
     let context = engine.create_context(CreateJavascriptContextRequest {
@@ -4225,7 +4228,10 @@ fn js_runtime_module_resolution_relative_allows_local_denies_bare() {
         .expect("start JavaScript execution");
     let result = execution.wait().expect("wait for JavaScript execution");
     let stderr = String::from_utf8_lossy(&result.stderr);
-    assert_eq!(result.exit_code, 0, "relative-resolution test failed\nstderr:\n{stderr}");
+    assert_eq!(
+        result.exit_code, 0,
+        "relative-resolution test failed\nstderr:\n{stderr}"
+    );
 }
 
 fn js_runtime_node_platform_allow_list_restricts_builtins() {
@@ -4256,8 +4262,11 @@ fn js_runtime_browser_loads_cjs_npm_package() {
         r#"{"name":"demo-pkg","version":"1.0.0","main":"index.js"}"#,
     )
     .expect("write package.json");
-    std::fs::write(pkg_dir.join("index.js"), "module.exports = { answer: 42 };\n")
-        .expect("write index.js");
+    std::fs::write(
+        pkg_dir.join("index.js"),
+        "module.exports = { answer: 42 };\n",
+    )
+    .expect("write index.js");
     let mut engine = JavascriptExecutionEngine::default();
     let context = engine.create_context(CreateJavascriptContextRequest {
         vm_id: String::from("vm-js"),

--- a/crates/execution/tests/wasm.rs
+++ b/crates/execution/tests/wasm.rs
@@ -2346,7 +2346,10 @@ fn run_wasm_execution_with_watchdog(
 fn wasm_deep_recursion_respects_configured_stack_byte_limit() {
     assert_node_available();
 
-    let env = BTreeMap::from([(String::from(WASM_MAX_STACK_BYTES_ENV), String::from("65536"))]);
+    let env = BTreeMap::from([(
+        String::from(WASM_MAX_STACK_BYTES_ENV),
+        String::from("65536"),
+    )]);
     let outcome = run_wasm_execution_with_watchdog(
         wasm_unbounded_recursion_module(),
         env,

--- a/crates/kernel/tests/default_deny_guards.rs
+++ b/crates/kernel/tests/default_deny_guards.rs
@@ -22,9 +22,9 @@
 //!      here.
 
 use secure_exec_kernel::permissions::{
-    check_command_execution, check_network_access, filter_env, EnvAccessRequest, EnvironmentOperation,
-    FsAccessRequest, FsOperation, NetworkAccessRequest, NetworkOperation, PermissionedFileSystem,
-    Permissions,
+    check_command_execution, check_network_access, filter_env, EnvAccessRequest,
+    EnvironmentOperation, FsAccessRequest, FsOperation, NetworkAccessRequest, NetworkOperation,
+    PermissionedFileSystem, Permissions,
 };
 use secure_exec_kernel::resource_accounting::ResourceLimits;
 use secure_exec_kernel::vfs::{MemoryFileSystem, VfsResult, VirtualFileSystem};
@@ -48,8 +48,23 @@ fn all_fs_operations() -> Vec<FsOperation> {
         | ReadLink | Link | Chmod | Chown | Utimes | Truncate | MountSensitive => (),
     };
     let all = vec![
-        Read, Write, Mkdir, CreateDir, ReadDir, Stat, Remove, Rename, Exists, Symlink, ReadLink,
-        Link, Chmod, Chown, Utimes, Truncate, MountSensitive,
+        Read,
+        Write,
+        Mkdir,
+        CreateDir,
+        ReadDir,
+        Stat,
+        Remove,
+        Rename,
+        Exists,
+        Symlink,
+        ReadLink,
+        Link,
+        Chmod,
+        Chown,
+        Utimes,
+        Truncate,
+        MountSensitive,
     ];
     for op in &all {
         exhaustiveness_witness(*op);

--- a/crates/sidecar/src/execution.rs
+++ b/crates/sidecar/src/execution.rs
@@ -16199,7 +16199,9 @@ fn issue_outbound_http_request(
         if expected_host != Some(host) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
-                format!("EACCES: outbound HTTP resolver pinned to {expected_host:?}, refusing {host}"),
+                format!(
+                    "EACCES: outbound HTTP resolver pinned to {expected_host:?}, refusing {host}"
+                ),
             ));
         }
         if pinned.is_empty() {
@@ -20362,7 +20364,10 @@ mod ssrf_egress_classifier_tests {
         assert_restricted(IpAddr::V6(Ipv6Addr::UNSPECIFIED), "unspecified");
 
         // CGNAT 100.64.0.0/10 spans 100.64.x.x .. 100.127.x.x.
-        assert_restricted(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1)), "carrier-grade-nat");
+        assert_restricted(
+            IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1)),
+            "carrier-grade-nat",
+        );
         assert_restricted(
             IpAddr::V4(Ipv4Addr::new(100, 127, 255, 254)),
             "carrier-grade-nat",
@@ -20382,7 +20387,10 @@ mod ssrf_egress_classifier_tests {
         // The DNS egress filter must also deny these via EACCES.
         assert_dns_denied(IpAddr::V4(Ipv4Addr::UNSPECIFIED), "0.0.0.0 (unspecified)");
         assert_dns_denied(IpAddr::V6(Ipv6Addr::UNSPECIFIED), ":: (unspecified)");
-        assert_dns_denied(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1)), "100.64.0.1 (CGNAT)");
+        assert_dns_denied(
+            IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1)),
+            "100.64.0.1 (CGNAT)",
+        );
     }
 
     // F-006 (sec-sidecar T7).
@@ -20462,8 +20470,14 @@ mod ssrf_egress_classifier_tests {
         );
 
         // The DNS egress filter must also deny these via EACCES.
-        assert_dns_denied(IpAddr::V4(Ipv4Addr::new(240, 0, 0, 1)), "240.0.0.1 (reserved)");
-        assert_dns_denied(IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1)), "224.0.0.1 (multicast)");
+        assert_dns_denied(
+            IpAddr::V4(Ipv4Addr::new(240, 0, 0, 1)),
+            "240.0.0.1 (reserved)",
+        );
+        assert_dns_denied(
+            IpAddr::V4(Ipv4Addr::new(224, 0, 0, 1)),
+            "224.0.0.1 (multicast)",
+        );
     }
 }
 
@@ -20500,7 +20514,10 @@ mod dns_rebinding_pin_tests {
 
     #[test]
     fn split_netloc_handles_hostnames_and_bracketed_ipv6() {
-        assert_eq!(split_netloc("attacker.example:80"), Some(("attacker.example", 80)));
+        assert_eq!(
+            split_netloc("attacker.example:80"),
+            Some(("attacker.example", 80))
+        );
         assert_eq!(split_netloc("[::1]:443"), Some(("::1", 443)));
         assert_eq!(split_netloc("10.0.0.1:8080"), Some(("10.0.0.1", 8080)));
         assert_eq!(split_netloc("no-port"), None);

--- a/crates/sidecar/tests/architecture_guards.rs
+++ b/crates/sidecar/tests/architecture_guards.rs
@@ -163,7 +163,8 @@ impl CfgTestTracker {
             // on a `use` / `fn` / `const` is a single item and gets matched
             // line-by-line, so we still skip just that line below.
             self.pending_cfg_test = false;
-            if trimmed.starts_with("mod ") || trimmed.starts_with("pub mod ")
+            if trimmed.starts_with("mod ")
+                || trimmed.starts_with("pub mod ")
                 || trimmed.starts_with("pub(crate) mod ")
                 || trimmed.starts_with("pub(super) mod ")
             {
@@ -215,8 +216,8 @@ fn scan_class(root: &Path, files: &[PathBuf], class: &BannedClass) -> Vec<String
         let rel_str = rel.to_string_lossy().replace('\\', "/");
         let allowed = allow.contains(rel_str.as_str());
         let abs = root.join(rel);
-        let content = std::fs::read_to_string(&abs)
-            .unwrap_or_else(|err| panic!("read {abs:?}: {err}"));
+        let content =
+            std::fs::read_to_string(&abs).unwrap_or_else(|err| panic!("read {abs:?}: {err}"));
         let mut tracker = CfgTestTracker::new();
         for (idx, raw) in content.lines().enumerate() {
             let in_test = tracker.in_test(raw);
@@ -228,12 +229,7 @@ fn scan_class(root: &Path, files: &[PathBuf], class: &BannedClass) -> Vec<String
             }
             let code = strip_line_comment(raw);
             if line_matches(code, class.needles) {
-                violations.push(format!(
-                    "{}:{}: {}",
-                    rel_str,
-                    idx + 1,
-                    raw.trim()
-                ));
+                violations.push(format!("{}:{}: {}", rel_str, idx + 1, raw.trim()));
             }
         }
     }

--- a/crates/v8-runtime/src/session.rs
+++ b/crates/v8-runtime/src/session.rs
@@ -1257,10 +1257,12 @@ fn session_thread(
 
                         // Check whether the CPU-time budget watchdog fired.
                         let abort_reason = execution_abort_reason(&execution_abort);
-                        let cpu_budget_exceeded = cpu_budget_guard
-                            .as_ref()
-                            .is_some_and(|g| g.exceeded())
-                            || matches!(abort_reason, Some(ExecutionAbortReason::CpuBudgetExceeded));
+                        let cpu_budget_exceeded =
+                            cpu_budget_guard.as_ref().is_some_and(|g| g.exceeded())
+                                || matches!(
+                                    abort_reason,
+                                    Some(ExecutionAbortReason::CpuBudgetExceeded)
+                                );
 
                         // Cancel the CPU-budget watchdog (joins its thread).
                         if let Some(ref mut guard) = cpu_budget_guard {
@@ -1283,10 +1285,9 @@ fn session_thread(
                                 exports: None,
                                 error: Some(ExecutionErrorBin {
                                     error_type: "Error".into(),
-                                    message:
-                                        "Script execution exceeded the CPU-time budget \
+                                    message: "Script execution exceeded the CPU-time budget \
                                          (AGENT_OS_V8_CPU_TIME_LIMIT_MS)"
-                                            .into(),
+                                        .into(),
                                     stack: String::new(),
                                     code: "ERR_SCRIPT_CPU_BUDGET_EXCEEDED".into(),
                                 }),

--- a/crates/vm-config/src/lib.rs
+++ b/crates/vm-config/src/lib.rs
@@ -788,10 +788,9 @@ mod tests {
 
     #[test]
     fn unknown_fields_are_rejected() {
-        let error = serde_json::from_str::<CreateVmConfig>(
-            r#"{"rootFilesystem":{},"surprise":true}"#,
-        )
-        .expect_err("unknown fields should fail");
+        let error =
+            serde_json::from_str::<CreateVmConfig>(r#"{"rootFilesystem":{},"surprise":true}"#)
+                .expect_err("unknown fields should fail");
         assert!(error.to_string().contains("unknown field"));
     }
 
@@ -846,16 +845,11 @@ mod tests {
         let none = js_runtime_config(serde_json::json!({ "platform": "node" })).unwrap();
         assert!(none.js_runtime.unwrap().allowed_builtins.is_none());
         // Some([]) => deny all (representable, distinct from None).
-        let empty =
-            js_runtime_config(serde_json::json!({ "allowedBuiltins": [] })).unwrap();
-        assert_eq!(
-            empty.js_runtime.unwrap().allowed_builtins,
-            Some(Vec::new())
-        );
+        let empty = js_runtime_config(serde_json::json!({ "allowedBuiltins": [] })).unwrap();
+        assert_eq!(empty.js_runtime.unwrap().allowed_builtins, Some(Vec::new()));
         // Some([..]) => explicit.
-        let some =
-            js_runtime_config(serde_json::json!({ "allowedBuiltins": ["path", "node:fs"] }))
-                .unwrap();
+        let some = js_runtime_config(serde_json::json!({ "allowedBuiltins": ["path", "node:fs"] }))
+            .unwrap();
         assert_eq!(
             some.js_runtime.unwrap().allowed_builtins,
             Some(vec!["path".to_owned(), "node:fs".to_owned()])


### PR DESCRIPTION
CI runs `cargo fmt --check`; the merged security-review code (F-001 CPU budget, SSRF/DNS classifier, guards + tests) was not rustfmt-clean. This runs `cargo fmt --all`. Format-only; no logic changes.