### PR TITLE
feat: opt-in wall-clock execution backstop (complements CPU-time budget)

### DIFF
--- a/crates/execution/src/javascript.rs
+++ b/crates/execution/src/javascript.rs
@@ -71,6 +71,13 @@ const V8_HEAP_LIMIT_MB_ENV: &str = "AGENT_OS_V8_HEAP_LIMIT_MB";
 /// platform/operator MUST set it to cap a guest. A wall-clock backstop is
 /// intentionally NOT part of this knob (deferred to a follow-up).
 const V8_CPU_TIME_LIMIT_MS_ENV: &str = "AGENT_OS_V8_CPU_TIME_LIMIT_MS";
+/// Opt-in WALL-CLOCK execution backstop (ms). INDEPENDENT of the CPU-time budget:
+/// this counts elapsed real time INCLUDING idle/await, so it can cap a guest that
+/// blocks or awaits indefinitely. There is NO default — with this unset the guest
+/// has no wall-clock limit (long-lived ACP adapters must run indefinitely). When
+/// both this and `AGENT_OS_V8_CPU_TIME_LIMIT_MS` are set, both guards are armed and
+/// whichever fires first terminates execution.
+const V8_WALL_CLOCK_LIMIT_MS_ENV: &str = "AGENT_OS_V8_WALL_CLOCK_LIMIT_MS";
 const NODE_SYNC_RPC_DEFAULT_DATA_BYTES: usize = 4 * 1024 * 1024;
 const NODE_SYNC_RPC_DEFAULT_WAIT_TIMEOUT_MS: u64 = 30_000;
 const NODE_SYNC_RPC_RESPONSE_QUEUE_CAPACITY: usize = 1;
@@ -1536,6 +1543,7 @@ fn register_v8_session<F>(
     session_id: String,
     heap_limit_mb: u32,
     cpu_time_limit_ms: u32,
+    wall_clock_limit_ms: u32,
     send_frame: F,
 ) -> Result<PendingV8SessionRegistration<'_>, JavascriptExecutionError>
 where
@@ -1550,6 +1558,7 @@ where
         session_id,
         heap_limit_mb,
         cpu_time_limit_ms,
+        wall_clock_limit_ms,
     })
     .map_err(JavascriptExecutionError::Spawn)?;
 
@@ -1674,6 +1683,7 @@ impl JavascriptExecutionEngine {
             session_id.clone(),
             javascript_heap_limit_mb(&request),
             javascript_cpu_time_limit_ms(&request),
+            javascript_wall_clock_limit_ms(&request),
             |frame| v8_host.send_frame(frame),
         )?;
 
@@ -1886,6 +1896,21 @@ fn javascript_cpu_time_limit_ms(request: &StartJavascriptExecutionRequest) -> u3
     request
         .env
         .get(V8_CPU_TIME_LIMIT_MS_ENV)
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or(0)
+}
+
+/// Resolve the opt-in WALL-CLOCK backstop (ms) for a JavaScript execution.
+///
+/// Opt-in with NO default: read from `AGENT_OS_V8_WALL_CLOCK_LIMIT_MS`, falling
+/// back to `0` (no limit) when unset/unparsable. `0` is normalized to `None` by
+/// the V8 session, so the wall-clock `TimeoutGuard` is NOT armed and the guest
+/// runs without a wall-clock limit. This is INDEPENDENT of the CPU-time budget:
+/// setting only one arms only that guard.
+fn javascript_wall_clock_limit_ms(request: &StartJavascriptExecutionRequest) -> u32 {
+    request
+        .env
+        .get(V8_WALL_CLOCK_LIMIT_MS_ENV)
         .and_then(|value| value.parse::<u32>().ok())
         .unwrap_or(0)
 }
@@ -6577,7 +6602,7 @@ mod tests {
                 .as_nanos()
         );
 
-        let error = match register_v8_session(&host, session_id.clone(), 0, 0, |_frame| {
+        let error = match register_v8_session(&host, session_id.clone(), 0, 0, 0, |_frame| {
             Err(std::io::Error::new(
                 std::io::ErrorKind::BrokenPipe,
                 "simulated CreateSession send failure",

--- a/crates/execution/src/v8_host.rs
+++ b/crates/execution/src/v8_host.rs
@@ -250,6 +250,7 @@ mod tests {
             session_id: session_id.clone(),
             heap_limit_mb: 0,
             cpu_time_limit_ms: 0,
+            wall_clock_limit_ms: 0,
         })
         .expect("create embedded runtime session");
 
@@ -258,6 +259,7 @@ mod tests {
                 session_id: session_id.clone(),
                 heap_limit_mb: 0,
                 cpu_time_limit_ms: 0,
+                wall_clock_limit_ms: 0,
             })
             .expect_err("duplicate session ids should be rejected");
         assert_eq!(duplicate_error.kind(), io::ErrorKind::Other);
@@ -273,6 +275,7 @@ mod tests {
             session_id: session_id.clone(),
             heap_limit_mb: 0,
             cpu_time_limit_ms: 0,
+            wall_clock_limit_ms: 0,
         })
         .expect("recreate embedded runtime session");
 

--- a/crates/execution/src/v8_ipc.rs
+++ b/crates/execution/src/v8_ipc.rs
@@ -44,6 +44,7 @@ pub enum BinaryFrame {
         session_id: String,
         heap_limit_mb: u32,
         cpu_time_limit_ms: u32,
+        wall_clock_limit_ms: u32,
     },
     DestroySession {
         session_id: String,
@@ -153,10 +154,12 @@ pub fn decode_frame(buf: &[u8]) -> io::Result<BinaryFrame> {
         MSG_CREATE_SESSION => {
             let heap_limit_mb = read_u32(buf, &mut pos)?;
             let cpu_time_limit_ms = read_u32(buf, &mut pos)?;
+            let wall_clock_limit_ms = read_u32(buf, &mut pos)?;
             Ok(BinaryFrame::CreateSession {
                 session_id,
                 heap_limit_mb,
                 cpu_time_limit_ms,
+                wall_clock_limit_ms,
             })
         }
         MSG_DESTROY_SESSION => Ok(BinaryFrame::DestroySession { session_id }),
@@ -291,11 +294,13 @@ fn encode_body(buf: &mut Vec<u8>, frame: &BinaryFrame) -> io::Result<()> {
             session_id,
             heap_limit_mb,
             cpu_time_limit_ms,
+            wall_clock_limit_ms,
         } => {
             buf.push(MSG_CREATE_SESSION);
             write_session_id(buf, session_id)?;
             buf.extend_from_slice(&heap_limit_mb.to_be_bytes());
             buf.extend_from_slice(&cpu_time_limit_ms.to_be_bytes());
+            buf.extend_from_slice(&wall_clock_limit_ms.to_be_bytes());
         }
         BinaryFrame::DestroySession { session_id } => {
             buf.push(MSG_DESTROY_SESSION);
@@ -542,6 +547,7 @@ mod tests {
             session_id: "sess-1".into(),
             heap_limit_mb: 256,
             cpu_time_limit_ms: 30000,
+            wall_clock_limit_ms: 45000,
         };
         let bytes = encode_frame(&frame).unwrap();
         let decoded = decode_frame(&bytes[4..]).unwrap();

--- a/crates/execution/src/v8_runtime.rs
+++ b/crates/execution/src/v8_runtime.rs
@@ -34,11 +34,13 @@ impl V8Runtime {
         session_id: &str,
         heap_limit_mb: u32,
         cpu_time_limit_ms: u32,
+        wall_clock_limit_ms: u32,
     ) -> io::Result<()> {
         self.send_frame(&BinaryFrame::CreateSession {
             session_id: session_id.to_owned(),
             heap_limit_mb,
             cpu_time_limit_ms,
+            wall_clock_limit_ms,
         })
     }
 

--- a/crates/execution/tests/javascript_v8.rs
+++ b/crates/execution/tests/javascript_v8.rs
@@ -4578,6 +4578,276 @@ fn javascript_no_cpu_budget_when_env_unset() {
     }
 }
 
+// WALL-CLOCK BACKSTOP (opt-in, complements the CPU-time budget): with
+// `AGENT_OS_V8_WALL_CLOCK_LIMIT_MS` set, a guest that exceeds the wall-clock limit
+// must be terminated and the result attributed to the WALL-CLOCK reason. Crucially,
+// the wall-clock limit counts elapsed REAL time INCLUDING idle/await, so a guest
+// that merely AWAITS past the limit (burning almost no CPU) is still killed — this
+// is exactly what the CPU-time budget does NOT do. The guest awaits ~1.5s while the
+// wall-clock limit is only 300ms, and NO CPU budget is set, so only the wall-clock
+// guard can fire.
+//
+// BOUNDED variant: small explicit wall-clock limit so the backstop fires fast; the
+// run is fenced behind a worker thread + recv timeout so a regression surfaces as a
+// clear failure instead of a CI hang.
+fn javascript_awaiting_guest_is_terminated_by_wall_clock_backstop() {
+    let (tx, rx) = mpsc::channel::<(i32, String, String)>();
+    thread::spawn(move || {
+        let temp = match tempdir() {
+            Ok(temp) => temp,
+            Err(error) => {
+                let _ = tx.send((-1, String::new(), format!("tempdir failed: {error}")));
+                return;
+            }
+        };
+        let mut engine = JavascriptExecutionEngine::default();
+        let context = engine.create_context(CreateJavascriptContextRequest {
+            vm_id: String::from("vm-js-wallclock"),
+            bootstrap_module: None,
+            compile_cache_root: None,
+        });
+
+        let execution = engine.start_execution(StartJavascriptExecutionRequest {
+            vm_id: String::from("vm-js-wallclock"),
+            context_id: context.context_id,
+            argv: vec![String::from("./entry.mjs")],
+            // Wall-clock limit (300ms) much SMALLER than the wall time the guest
+            // spends awaiting (~1.5s). The wall-clock backstop counts idle/await, so
+            // it must terminate the guest even though it burns almost no CPU. No CPU
+            // budget is set, proving the two knobs are independent.
+            env: BTreeMap::from([(
+                String::from("AGENT_OS_V8_WALL_CLOCK_LIMIT_MS"),
+                String::from("300"),
+            )]),
+            cwd: temp.path().to_path_buf(),
+            inline_code: Some(String::from(
+                "await new Promise((resolve) => setTimeout(resolve, 1500));\n\
+                 console.log('awaited-ok');\n",
+            )),
+        });
+
+        match execution {
+            Ok(execution) => match execution.wait() {
+                Ok(result) => {
+                    let stdout = String::from_utf8_lossy(&result.stdout).into_owned();
+                    let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
+                    let _ = tx.send((result.exit_code, stdout, stderr));
+                }
+                Err(error) => {
+                    let _ = tx.send((-1, String::new(), format!("wait failed: {error}")));
+                }
+            },
+            Err(error) => {
+                let _ = tx.send((-1, String::new(), format!("start failed: {error}")));
+            }
+        }
+    });
+
+    match rx.recv_timeout(Duration::from_secs(20)) {
+        Ok((exit_code, stdout, stderr)) => {
+            assert_ne!(
+                exit_code, 0,
+                "awaiting guest returned a clean exit instead of being terminated by the \
+                 wall-clock backstop: stdout={stdout} stderr={stderr}"
+            );
+            // Must be attributed to the WALL-CLOCK reason specifically (not CPU budget).
+            assert!(
+                stderr.contains("ERR_SCRIPT_WALL_CLOCK_EXCEEDED")
+                    || stderr.contains("wall-clock limit"),
+                "termination was not attributed to the wall-clock backstop: \
+                 stdout={stdout} stderr={stderr}"
+            );
+            assert!(
+                !stderr.contains("ERR_SCRIPT_CPU_BUDGET_EXCEEDED")
+                    && !stderr.contains("CPU-time budget"),
+                "wall-clock termination was wrongly attributed to the CPU budget: \
+                 stdout={stdout} stderr={stderr}"
+            );
+            assert!(
+                !stdout.contains("awaited-ok"),
+                "guest ran to completion despite exceeding the wall-clock limit: \
+                 stdout={stdout} stderr={stderr}"
+            );
+        }
+        Err(_) => {
+            panic!(
+                "awaiting guest was NOT terminated by the wall-clock backstop \
+                 (wait() never returned within the bounded test window => backstop never fired)"
+            );
+        }
+    }
+}
+
+// WALL-CLOCK / CPU-BUDGET INDEPENDENCE: setting ONLY the CPU budget must NOT impose
+// any wall-clock limit. A guest that awaits past a window which the wall-clock limit
+// (if it were armed) would have killed, but burns almost no CPU, must run to
+// completion when only `AGENT_OS_V8_CPU_TIME_LIMIT_MS` is set. This confirms the CPU
+// budget does not secretly behave like a wall-clock timer and that the knobs are
+// independent.
+fn javascript_cpu_budget_only_does_not_impose_wall_clock_limit() {
+    let (tx, rx) = mpsc::channel::<(i32, String, String)>();
+    thread::spawn(move || {
+        let temp = match tempdir() {
+            Ok(temp) => temp,
+            Err(error) => {
+                let _ = tx.send((-1, String::new(), format!("tempdir failed: {error}")));
+                return;
+            }
+        };
+        let mut engine = JavascriptExecutionEngine::default();
+        let context = engine.create_context(CreateJavascriptContextRequest {
+            vm_id: String::from("vm-js-cpu-only"),
+            bootstrap_module: None,
+            compile_cache_root: None,
+        });
+
+        let execution = engine.start_execution(StartJavascriptExecutionRequest {
+            vm_id: String::from("vm-js-cpu-only"),
+            context_id: context.context_id,
+            argv: vec![String::from("./entry.mjs")],
+            // Only the CPU budget is set (300ms). The guest awaits ~1.2s of wall
+            // time but burns no CPU, so neither guard should fire — proving the CPU
+            // budget alone does NOT arm a wall-clock limit.
+            env: BTreeMap::from([(
+                String::from("AGENT_OS_V8_CPU_TIME_LIMIT_MS"),
+                String::from("300"),
+            )]),
+            cwd: temp.path().to_path_buf(),
+            inline_code: Some(String::from(
+                "await new Promise((resolve) => setTimeout(resolve, 1200));\n\
+                 console.log('cpu-only-ok');\n",
+            )),
+        });
+
+        match execution {
+            Ok(execution) => match execution.wait() {
+                Ok(result) => {
+                    let stdout = String::from_utf8_lossy(&result.stdout).into_owned();
+                    let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
+                    let _ = tx.send((result.exit_code, stdout, stderr));
+                }
+                Err(error) => {
+                    let _ = tx.send((-1, String::new(), format!("wait failed: {error}")));
+                }
+            },
+            Err(error) => {
+                let _ = tx.send((-1, String::new(), format!("start failed: {error}")));
+            }
+        }
+    });
+
+    match rx.recv_timeout(Duration::from_secs(20)) {
+        Ok((exit_code, stdout, stderr)) => {
+            assert!(
+                !stderr.contains("ERR_SCRIPT_WALL_CLOCK_EXCEEDED")
+                    && !stderr.contains("wall-clock limit"),
+                "a wall-clock limit fired despite only the CPU budget being set; the knobs \
+                 must be independent: exit_code={exit_code} stdout={stdout} stderr={stderr}"
+            );
+            assert_eq!(
+                exit_code, 0,
+                "awaiting guest should complete cleanly with only a CPU budget set \
+                 (idle excluded, no wall-clock limit): stdout={stdout} stderr={stderr}"
+            );
+            assert!(
+                stdout.contains("cpu-only-ok"),
+                "guest did not run to completion with only a CPU budget set: \
+                 stdout={stdout} stderr={stderr}"
+            );
+        }
+        Err(_) => {
+            panic!(
+                "cpu-budget-only guest never produced a result within the bounded test window \
+                 (unexpected hang)"
+            );
+        }
+    }
+}
+
+// WALL-CLOCK OPT-IN: with NEITHER `AGENT_OS_V8_WALL_CLOCK_LIMIT_MS` nor
+// `AGENT_OS_V8_CPU_TIME_LIMIT_MS` set, there is NO time limit of any kind. A guest
+// that awaits well past any default a former wall-clock timer might have imposed
+// must run to completion. This guards the requirement that long-lived ACP adapters
+// (which run indefinitely on wall-clock) are never killed by a default.
+fn javascript_no_time_limit_when_neither_env_set() {
+    let (tx, rx) = mpsc::channel::<(i32, String, String)>();
+    thread::spawn(move || {
+        let temp = match tempdir() {
+            Ok(temp) => temp,
+            Err(error) => {
+                let _ = tx.send((-1, String::new(), format!("tempdir failed: {error}")));
+                return;
+            }
+        };
+        let mut engine = JavascriptExecutionEngine::default();
+        let context = engine.create_context(CreateJavascriptContextRequest {
+            vm_id: String::from("vm-js-notimelimit"),
+            bootstrap_module: None,
+            compile_cache_root: None,
+        });
+
+        let execution = engine.start_execution(StartJavascriptExecutionRequest {
+            vm_id: String::from("vm-js-notimelimit"),
+            context_id: context.context_id,
+            argv: vec![String::from("./entry.mjs")],
+            // No time-limit env of any kind: no wall-clock and no CPU guard armed.
+            env: BTreeMap::new(),
+            cwd: temp.path().to_path_buf(),
+            // Awaits ~1.2s, then exits cleanly. Self-terminating so the test cannot
+            // hang even if (incorrectly) no limit were enforced.
+            inline_code: Some(String::from(
+                "await new Promise((resolve) => setTimeout(resolve, 1200));\n\
+                 console.log('no-limit-ok');\n",
+            )),
+        });
+
+        match execution {
+            Ok(execution) => match execution.wait() {
+                Ok(result) => {
+                    let stdout = String::from_utf8_lossy(&result.stdout).into_owned();
+                    let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
+                    let _ = tx.send((result.exit_code, stdout, stderr));
+                }
+                Err(error) => {
+                    let _ = tx.send((-1, String::new(), format!("wait failed: {error}")));
+                }
+            },
+            Err(error) => {
+                let _ = tx.send((-1, String::new(), format!("start failed: {error}")));
+            }
+        }
+    });
+
+    match rx.recv_timeout(Duration::from_secs(20)) {
+        Ok((exit_code, stdout, stderr)) => {
+            assert!(
+                !stderr.contains("ERR_SCRIPT_WALL_CLOCK_EXCEEDED")
+                    && !stderr.contains("wall-clock limit")
+                    && !stderr.contains("ERR_SCRIPT_CPU_BUDGET_EXCEEDED")
+                    && !stderr.contains("CPU-time budget"),
+                "a time limit fired despite no limit env being set (must be strictly opt-in): \
+                 exit_code={exit_code} stdout={stdout} stderr={stderr}"
+            );
+            assert_eq!(
+                exit_code, 0,
+                "awaiting guest should complete cleanly when no time limit is set: \
+                 stdout={stdout} stderr={stderr}"
+            );
+            assert!(
+                stdout.contains("no-limit-ok"),
+                "guest did not run to completion with no time limit set: \
+                 stdout={stdout} stderr={stderr}"
+            );
+        }
+        Err(_) => {
+            panic!(
+                "no-limit guest never produced a result within the bounded test window \
+                 (unexpected hang)"
+            );
+        }
+    }
+}
+
 // SE-EXEC-06 (M.1 / F-003): a heap-allocation bomb must be capped by terminating
 // the offending isolate, NOT by letting V8 fatal-abort (SIGTRAP) the process-global
 // runtime and take down every concurrent tenant. Before the fix, no
@@ -4811,4 +5081,12 @@ fn javascript_v8_suite() {
     javascript_infinite_loop_is_terminated_by_cpu_watchdog();
     javascript_awaiting_guest_is_not_killed_by_cpu_budget();
     javascript_no_cpu_budget_when_env_unset();
+
+    // WALL-CLOCK BACKSTOP (opt-in, complements the CPU-time budget):
+    //   1. wall-clock SET  => awaiting guest terminated (wall-clock reason; idle counted)
+    //   2. CPU budget only => no wall-clock limit imposed (knobs independent)
+    //   3. neither SET     => no time limit at all (strictly opt-in)
+    javascript_awaiting_guest_is_terminated_by_wall_clock_backstop();
+    javascript_cpu_budget_only_does_not_impose_wall_clock_limit();
+    javascript_no_time_limit_when_neither_env_set();
 }

--- a/crates/v8-runtime/src/embedded_runtime.rs
+++ b/crates/v8-runtime/src/embedded_runtime.rs
@@ -200,6 +200,7 @@ impl EmbeddedV8Runtime {
                 session_id,
                 heap_limit_mb,
                 cpu_time_limit_ms,
+                wall_clock_limit_ms,
             } => {
                 let output_generation = self
                     .session_outputs
@@ -215,6 +216,7 @@ impl EmbeddedV8Runtime {
                     session_id,
                     heap_limit_mb,
                     cpu_time_limit_ms,
+                    wall_clock_limit_ms,
                     output_generation,
                 )
                 .map_err(other_io_error)
@@ -526,10 +528,16 @@ fn dispatch_runtime_command(
             session_id,
             heap_limit_mb,
             cpu_time_limit_ms,
+            wall_clock_limit_ms,
         } => {
             let mut mgr = session_mgr.lock().expect("session manager lock poisoned");
-            mgr.create_session(session_id, heap_limit_mb, cpu_time_limit_ms)
-                .map_err(other_io_error)
+            mgr.create_session(
+                session_id,
+                heap_limit_mb,
+                cpu_time_limit_ms,
+                wall_clock_limit_ms,
+            )
+            .map_err(other_io_error)
         }
         RuntimeCommand::DestroySession { session_id } => {
             let shutdown = {
@@ -697,6 +705,7 @@ mod tests {
                     session_id: "drop-lifecycle".into(),
                     heap_limit_mb: None,
                     cpu_time_limit_ms: None,
+                    wall_clock_limit_ms: None,
                 })
                 .expect("create session");
             assert_eq!(
@@ -732,7 +741,7 @@ mod tests {
 
         {
             let mut mgr = session_mgr.lock().expect("session manager");
-            mgr.create_session("stream-target".into(), None, None)
+            mgr.create_session("stream-target".into(), None, None, None)
                 .expect("create target session");
         }
         call_id_router
@@ -1047,6 +1056,7 @@ mod tests {
                 session_id: session_id.into(),
                 heap_limit_mb: None,
                 cpu_time_limit_ms: None,
+                wall_clock_limit_ms: None,
             })
             .expect("create first session");
         runtime
@@ -1062,6 +1072,7 @@ mod tests {
                 session_id: session_id.into(),
                 heap_limit_mb: None,
                 cpu_time_limit_ms: None,
+                wall_clock_limit_ms: None,
             })
             .expect("create reused session");
 
@@ -1088,11 +1099,11 @@ mod tests {
         let session_mgr = test_session_manager();
         {
             let mut mgr = session_mgr.lock().expect("session manager");
-            mgr.create_session_with_output_generation("reused".into(), None, None, Some(1))
+            mgr.create_session_with_output_generation("reused".into(), None, None, None, Some(1))
                 .expect("create first session");
             mgr.destroy_session("reused")
                 .expect("destroy first session");
-            mgr.create_session_with_output_generation("reused".into(), None, None, Some(2))
+            mgr.create_session_with_output_generation("reused".into(), None, None, None, Some(2))
                 .expect("create reused session");
 
             assert!(
@@ -1141,6 +1152,7 @@ mod tests {
             .expect("session manager")
             .create_session_with_output_generation(
                 session_id.into(),
+                None,
                 None,
                 None,
                 Some(output_generation),

--- a/crates/v8-runtime/src/ipc_binary.rs
+++ b/crates/v8-runtime/src/ipc_binary.rs
@@ -47,6 +47,7 @@ pub enum BinaryFrame {
         session_id: String,
         heap_limit_mb: u32,
         cpu_time_limit_ms: u32,
+        wall_clock_limit_ms: u32,
     },
     DestroySession {
         session_id: String,
@@ -209,11 +210,13 @@ fn encode_body(buf: &mut Vec<u8>, frame: &BinaryFrame) -> io::Result<()> {
             session_id,
             heap_limit_mb,
             cpu_time_limit_ms,
+            wall_clock_limit_ms,
         } => {
             buf.push(MSG_CREATE_SESSION);
             write_session_id(buf, session_id)?;
             buf.extend_from_slice(&heap_limit_mb.to_be_bytes());
             buf.extend_from_slice(&cpu_time_limit_ms.to_be_bytes());
+            buf.extend_from_slice(&wall_clock_limit_ms.to_be_bytes());
         }
         BinaryFrame::DestroySession { session_id } => {
             buf.push(MSG_DESTROY_SESSION);
@@ -372,11 +375,13 @@ fn decode_body(buf: &[u8]) -> io::Result<BinaryFrame> {
         MSG_CREATE_SESSION => {
             let heap_limit_mb = read_u32(buf, &mut pos)?;
             let cpu_time_limit_ms = read_u32(buf, &mut pos)?;
+            let wall_clock_limit_ms = read_u32(buf, &mut pos)?;
             ensure_frame_consumed(buf, pos)?;
             Ok(BinaryFrame::CreateSession {
                 session_id,
                 heap_limit_mb,
                 cpu_time_limit_ms,
+                wall_clock_limit_ms,
             })
         }
         MSG_DESTROY_SESSION => {
@@ -691,6 +696,7 @@ mod tests {
             session_id: "sess-abc-123".into(),
             heap_limit_mb: 128,
             cpu_time_limit_ms: 5000,
+            wall_clock_limit_ms: 9000,
         });
     }
 
@@ -700,6 +706,7 @@ mod tests {
             session_id: "sess-1".into(),
             heap_limit_mb: 0,
             cpu_time_limit_ms: 0,
+            wall_clock_limit_ms: 0,
         });
     }
 
@@ -982,6 +989,7 @@ mod tests {
                 session_id: "a".into(),
                 heap_limit_mb: 64,
                 cpu_time_limit_ms: 1000,
+                wall_clock_limit_ms: 0,
             },
             BinaryFrame::Execute {
                 session_id: "a".into(),
@@ -1054,6 +1062,7 @@ mod tests {
         let mut create_session = vec![MSG_CREATE_SESSION, 1, b's'];
         create_session.extend_from_slice(&0u32.to_be_bytes());
         create_session.extend_from_slice(&0u32.to_be_bytes());
+        create_session.extend_from_slice(&0u32.to_be_bytes());
         create_session.push(0xAA);
 
         let destroy_session = vec![MSG_DESTROY_SESSION, 1, b's', 0xAA];
@@ -1124,6 +1133,7 @@ mod tests {
                 session_id: "sess-create".into(),
                 heap_limit_mb: 0,
                 cpu_time_limit_ms: 0,
+                wall_clock_limit_ms: 0,
             },
             BinaryFrame::DestroySession {
                 session_id: "sess-destroy".into(),
@@ -1205,6 +1215,7 @@ mod tests {
                     session_id: "s".into(),
                     heap_limit_mb: 0,
                     cpu_time_limit_ms: 0,
+                    wall_clock_limit_ms: 0,
                 },
                 0x02,
             ),

--- a/crates/v8-runtime/src/runtime_protocol.rs
+++ b/crates/v8-runtime/src/runtime_protocol.rs
@@ -7,6 +7,7 @@ pub enum RuntimeCommand {
         session_id: String,
         heap_limit_mb: Option<u32>,
         cpu_time_limit_ms: Option<u32>,
+        wall_clock_limit_ms: Option<u32>,
     },
     DestroySession {
         session_id: String,
@@ -96,10 +97,12 @@ impl TryFrom<BinaryFrame> for RuntimeCommand {
                 session_id,
                 heap_limit_mb,
                 cpu_time_limit_ms,
+                wall_clock_limit_ms,
             } => Ok(RuntimeCommand::CreateSession {
                 session_id,
                 heap_limit_mb: non_zero_option(heap_limit_mb),
                 cpu_time_limit_ms: non_zero_option(cpu_time_limit_ms),
+                wall_clock_limit_ms: non_zero_option(wall_clock_limit_ms),
             }),
             BinaryFrame::DestroySession { session_id } => {
                 Ok(RuntimeCommand::DestroySession { session_id })

--- a/crates/v8-runtime/src/session.rs
+++ b/crates/v8-runtime/src/session.rs
@@ -56,6 +56,15 @@ fn normalize_cpu_time_limit_ms(cpu_time_limit_ms: Option<u32>) -> Option<u32> {
     cpu_time_limit_ms.filter(|budget_ms| *budget_ms > 0)
 }
 
+/// Normalize an opt-in WALL-CLOCK backstop: `Some(0)` means "disabled" and folds
+/// to `None` so the wall-clock `TimeoutGuard` is NOT armed. There is no default —
+/// when the caller passes `None`/`0`, the guest runs with no wall-clock limit
+/// (opt-in by design, so long-lived ACP adapters are never killed by a default).
+/// This is INDEPENDENT of the CPU-time budget: setting one does not arm the other.
+fn normalize_wall_clock_limit_ms(wall_clock_limit_ms: Option<u32>) -> Option<u32> {
+    wall_clock_limit_ms.filter(|limit_ms| *limit_ms > 0)
+}
+
 /// Internal entry for a running session
 struct SessionEntry {
     /// Output receiver generation current when this session was created.
@@ -106,9 +115,11 @@ pub(crate) type DeferredQueue = Arc<Mutex<VecDeque<SessionMessage>>>;
 pub(crate) enum ExecutionAbortReason {
     /// Caller explicitly terminated the execution (e.g. session destroy).
     Terminated,
-    /// The WALL-CLOCK backstop (`TimeoutGuard`) elapsed. DORMANT in this PR: not
-    /// armed by F-001. Retained for the deferred wall-clock follow-up PR.
-    #[allow(dead_code)]
+    /// The opt-in WALL-CLOCK backstop (`TimeoutGuard`) elapsed. Counts elapsed
+    /// real time INCLUDING idle/await, so it can cap a guest that blocks/awaits
+    /// indefinitely. Armed only when `AGENT_OS_V8_WALL_CLOCK_LIMIT_MS` is set;
+    /// independent of the CPU-time budget.
+    #[cfg_attr(test, allow(dead_code))]
     WallClockTimedOut,
     /// The TRUE CPU-TIME budget (`CpuBudgetGuard`) was exhausted by active JS CPU.
     #[cfg_attr(test, allow(dead_code))]
@@ -230,11 +241,13 @@ impl SessionManager {
         session_id: String,
         heap_limit_mb: Option<u32>,
         cpu_time_limit_ms: Option<u32>,
+        wall_clock_limit_ms: Option<u32>,
     ) -> Result<(), String> {
         self.create_session_with_output_generation(
             session_id,
             heap_limit_mb,
             cpu_time_limit_ms,
+            wall_clock_limit_ms,
             None,
         )
     }
@@ -244,6 +257,7 @@ impl SessionManager {
         session_id: String,
         heap_limit_mb: Option<u32>,
         cpu_time_limit_ms: Option<u32>,
+        wall_clock_limit_ms: Option<u32>,
         output_generation: Option<u64>,
     ) -> Result<(), String> {
         if self.sessions.contains_key(&session_id) {
@@ -251,6 +265,7 @@ impl SessionManager {
         }
 
         let cpu_time_limit_ms = normalize_cpu_time_limit_ms(cpu_time_limit_ms);
+        let wall_clock_limit_ms = normalize_wall_clock_limit_ms(wall_clock_limit_ms);
         let (tx, rx) = crossbeam_channel::bounded(SESSION_COMMAND_CHANNEL_CAPACITY);
         let slot_control = Arc::clone(&self.slot_control);
         let max = self.max_concurrency;
@@ -275,6 +290,7 @@ impl SessionManager {
                 session_thread(
                     heap_limit_mb,
                     cpu_time_limit_ms,
+                    wall_clock_limit_ms,
                     rx,
                     slot_control,
                     max,
@@ -667,6 +683,7 @@ fn defer_session_command_before_slot(
 fn session_thread(
     #[cfg_attr(test, allow(unused_variables))] heap_limit_mb: Option<u32>,
     #[cfg_attr(test, allow(unused_variables))] cpu_time_limit_ms: Option<u32>,
+    #[cfg_attr(test, allow(unused_variables))] wall_clock_limit_ms: Option<u32>,
     rx: Receiver<SessionCommand>,
     slot_control: SlotControl,
     max_concurrency: usize,
@@ -1001,17 +1018,15 @@ fn session_thread(
                         }
 
                         // Arm the TRUE CPU-TIME budget watchdog before running
-                        // guest code. This is the ONLY execution budget F-001 arms
-                        // in this PR, and only when the operator opts in via
+                        // guest code, only when the operator opts in via
                         // `AGENT_OS_V8_CPU_TIME_LIMIT_MS` (normalized: `0`/unset =>
-                        // `None` => not armed => NO CPU limit). The wall-clock
-                        // `TimeoutGuard` is intentionally left DORMANT here; a
-                        // follow-up PR re-introduces a wall-clock backstop as its
-                        // own opt-in knob.
+                        // `None` => not armed => NO CPU limit).
                         //
                         // The watchdog counts ACTIVE JS CPU only (idle/await
                         // excluded) by polling the execution thread's CPU clock, so
-                        // a guest that mostly awaits is NOT killed by it.
+                        // a guest that mostly awaits is NOT killed by it. The
+                        // INDEPENDENT wall-clock backstop (armed just below) covers
+                        // the idle/await case when the operator opts into it.
                         let mut cpu_budget_guard = match cpu_time_limit_ms {
                             Some(budget_ms) => {
                                 // Enforcing a CPU budget requires the execution
@@ -1064,6 +1079,50 @@ fn session_thread(
                                                 stack: String::new(),
                                                 code:
                                                     crate::timeout::CPU_BUDGET_GUARD_START_ERROR_CODE
+                                                        .into(),
+                                            }),
+                                        };
+                                        send_event_with_generation(
+                                            &event_tx,
+                                            output_generation,
+                                            result_frame,
+                                        );
+                                        continue;
+                                    }
+                                }
+                            }
+                            _ => None,
+                        };
+
+                        // Arm the INDEPENDENT, opt-in WALL-CLOCK backstop alongside
+                        // the CPU budget. Unlike the CPU budget, this counts elapsed
+                        // real time INCLUDING idle/await, so it can cap a guest that
+                        // blocks or awaits indefinitely. Armed only when the operator
+                        // opts in via `AGENT_OS_V8_WALL_CLOCK_LIMIT_MS` (normalized:
+                        // `0`/unset => `None` => not armed => NO wall-clock limit, so
+                        // long-lived ACP adapters are never killed by a default).
+                        // Whichever guard fires first calls `terminate_execution` and
+                        // records its abort reason; the result frame reports which.
+                        let mut wall_clock_guard = match wall_clock_limit_ms {
+                            Some(limit_ms) => {
+                                let handle = iso.thread_safe_handle();
+                                match crate::timeout::TimeoutGuard::with_execution_abort(
+                                    limit_ms,
+                                    handle,
+                                    execution_abort.clone(),
+                                ) {
+                                    Ok(guard) => Some(guard),
+                                    Err(message) => {
+                                        let result_frame = RuntimeEvent::ExecutionResult {
+                                            session_id,
+                                            exit_code: 1,
+                                            exports: None,
+                                            error: Some(ExecutionErrorBin {
+                                                error_type: "Error".into(),
+                                                message,
+                                                stack: String::new(),
+                                                code:
+                                                    crate::timeout::TIMEOUT_GUARD_START_ERROR_CODE
                                                         .into(),
                                             }),
                                         };
@@ -1255,20 +1314,43 @@ fn session_thread(
                             }
                         }
 
-                        // Check whether the CPU-time budget watchdog fired.
+                        // Determine which execution budget (if any) fired. Both the
+                        // CPU-time budget and the wall-clock backstop can be armed;
+                        // whichever fired first recorded its abort reason. Prefer the
+                        // recorded abort reason (first-writer-wins) so the result
+                        // attributes termination to the guard that actually fired.
                         let abort_reason = execution_abort_reason(&execution_abort);
+                        let wall_clock_timed_out =
+                            wall_clock_guard.as_ref().is_some_and(|g| g.timed_out())
+                                || matches!(
+                                    abort_reason,
+                                    Some(ExecutionAbortReason::WallClockTimedOut)
+                                );
                         let cpu_budget_exceeded =
                             cpu_budget_guard.as_ref().is_some_and(|g| g.exceeded())
                                 || matches!(
                                     abort_reason,
                                     Some(ExecutionAbortReason::CpuBudgetExceeded)
                                 );
+                        // If both happened to fire, the recorded abort reason is the
+                        // authoritative first-fired guard; fall back to wall-clock
+                        // only when no CPU-budget reason was recorded.
+                        let cpu_budget_exceeded = cpu_budget_exceeded
+                            && !matches!(
+                                abort_reason,
+                                Some(ExecutionAbortReason::WallClockTimedOut)
+                            );
+                        let wall_clock_timed_out = wall_clock_timed_out && !cpu_budget_exceeded;
 
-                        // Cancel the CPU-budget watchdog (joins its thread).
+                        // Cancel both watchdogs (joins their threads).
                         if let Some(ref mut guard) = cpu_budget_guard {
                             guard.cancel();
                         }
                         drop(cpu_budget_guard);
+                        if let Some(ref mut guard) = wall_clock_guard {
+                            guard.cancel();
+                        }
+                        drop(wall_clock_guard);
 
                         if matches!(abort_reason, Some(ExecutionAbortReason::Terminated)) {
                             terminated = true;
@@ -1290,6 +1372,20 @@ fn session_thread(
                                         .into(),
                                     stack: String::new(),
                                     code: "ERR_SCRIPT_CPU_BUDGET_EXCEEDED".into(),
+                                }),
+                            }
+                        } else if wall_clock_timed_out {
+                            RuntimeEvent::ExecutionResult {
+                                session_id,
+                                exit_code: 1,
+                                exports: None,
+                                error: Some(ExecutionErrorBin {
+                                    error_type: "Error".into(),
+                                    message: "Script execution exceeded the wall-clock limit \
+                                         (AGENT_OS_V8_WALL_CLOCK_LIMIT_MS)"
+                                        .into(),
+                                    stack: String::new(),
+                                    code: "ERR_SCRIPT_WALL_CLOCK_EXCEEDED".into(),
                                 }),
                             }
                         } else if terminated {
@@ -1975,7 +2071,7 @@ mod tests {
         {
             let mut mgr = test_manager(4);
 
-            mgr.create_session("session-aaa".into(), None, None)
+            mgr.create_session("session-aaa".into(), None, None, None)
                 .expect("create session A");
             assert_eq!(mgr.session_count(), 1);
 
@@ -1992,16 +2088,16 @@ mod tests {
         {
             let mut mgr = test_manager(4);
 
-            mgr.create_session("session-bbb".into(), None, None)
+            mgr.create_session("session-bbb".into(), None, None, None)
                 .expect("create session B");
-            mgr.create_session("session-ccc".into(), Some(16), None)
+            mgr.create_session("session-ccc".into(), Some(16), None, None)
                 .expect("create session C");
             assert_eq!(mgr.session_count(), 2);
 
             std::thread::sleep(std::time::Duration::from_millis(200));
 
             // Duplicate session ID is rejected
-            let err = mgr.create_session("session-bbb".into(), None, None);
+            let err = mgr.create_session("session-bbb".into(), None, None, None);
             assert!(err.is_err());
             assert!(err.unwrap_err().contains("already exists"));
 
@@ -2023,11 +2119,11 @@ mod tests {
         {
             let mut mgr = test_manager(2);
 
-            mgr.create_session("s1".into(), None, None)
+            mgr.create_session("s1".into(), None, None, None)
                 .expect("create s1");
-            mgr.create_session("s2".into(), None, None)
+            mgr.create_session("s2".into(), None, None, None)
                 .expect("create s2");
-            mgr.create_session("s3".into(), None, None)
+            mgr.create_session("s3".into(), None, None, None)
                 .expect("create s3");
 
             // Allow threads to acquire slots
@@ -2054,8 +2150,14 @@ mod tests {
     #[test]
     fn detach_session_clears_call_id_routes_for_session() {
         let mut mgr = test_manager(1);
-        mgr.create_session_with_output_generation("session-route".into(), None, None, Some(7))
-            .expect("create session");
+        mgr.create_session_with_output_generation(
+            "session-route".into(),
+            None,
+            None,
+            None,
+            Some(7),
+        )
+        .expect("create session");
         mgr.call_id_router()
             .lock()
             .expect("call_id router")
@@ -2079,7 +2181,7 @@ mod tests {
     #[test]
     fn begin_destroy_session_removes_entry_before_finish() {
         let mut mgr = test_manager(1);
-        mgr.create_session("two-phase".into(), None, None)
+        mgr.create_session("two-phase".into(), None, None, None)
             .expect("create session");
 
         let first_shutdown = mgr
@@ -2093,7 +2195,7 @@ mod tests {
 
         // A same-id create during the unfinished shutdown window must succeed
         // because the entry was removed up front.
-        mgr.create_session("two-phase".into(), None, None)
+        mgr.create_session("two-phase".into(), None, None, None)
             .expect("re-create session while first shutdown is unfinished");
 
         let second_shutdown = mgr
@@ -2107,7 +2209,7 @@ mod tests {
     #[test]
     fn session_shutdown_finish_clears_late_call_routes() {
         let mut mgr = test_manager(1);
-        mgr.create_session("late-route".into(), None, None)
+        mgr.create_session("late-route".into(), None, None, None)
             .expect("create session");
 
         let shutdown = mgr
@@ -2248,7 +2350,7 @@ mod tests {
     #[test]
     fn late_terminate_execution_is_logged_instead_of_silently_dropped() {
         let (mut mgr, rx) = test_manager_with_events(1);
-        mgr.create_session("late-terminate".into(), None, None)
+        mgr.create_session("late-terminate".into(), None, None, None)
             .expect("create session");
 
         mgr.send_to_session("late-terminate", SessionMessage::TerminateExecution)
@@ -2299,7 +2401,7 @@ mod tests {
     #[test]
     fn late_bridge_response_is_logged_instead_of_silently_dropped() {
         let (mut mgr, rx) = test_manager_with_events(1);
-        mgr.create_session("late-bridge".into(), None, None)
+        mgr.create_session("late-bridge".into(), None, None, None)
             .expect("create session");
 
         mgr.send_to_session(

--- a/crates/v8-runtime/src/timeout.rs
+++ b/crates/v8-runtime/src/timeout.rs
@@ -2,19 +2,22 @@
 //
 // Two INDEPENDENT mechanisms live here:
 //
-//   * `TimeoutGuard` — a WALL-CLOCK timer. It is intentionally left DORMANT in
-//     this PR (not armed by F-001). A follow-up PR will re-introduce a
-//     wall-clock backstop as its own opt-in knob; the code is retained so that
-//     re-arming it is a small, reviewed change rather than a rewrite.
+//   * `TimeoutGuard` — a WALL-CLOCK timer. It counts elapsed real time
+//     INCLUDING idle/await, so it can cap a guest that blocks or awaits
+//     indefinitely. It is an INDEPENDENT, opt-in backstop armed only when the
+//     operator sets `AGENT_OS_V8_WALL_CLOCK_LIMIT_MS` (off by default so
+//     long-lived ACP adapters are never killed by a default).
 //
 //   * `CpuBudgetGuard` — a TRUE CPU-TIME budget. It samples the EXECUTION
 //     thread's per-thread CPU clock (`pthread_getcpuclockid` +
 //     `clock_gettime`). Because a thread's CPU clock does not advance while the
 //     thread is parked/awaiting I/O, this counts ONLY active JS CPU time and
 //     EXCLUDES idle/await. V8 has no native budget primitive, so this poll +
-//     `terminate_execution()` approach is the standard embedder pattern. This
-//     is the only guard F-001 arms in this PR, and only when the operator opts
-//     in via `AGENT_OS_V8_CPU_TIME_LIMIT_MS`.
+//     `terminate_execution()` approach is the standard embedder pattern. Armed
+//     only when the operator opts in via `AGENT_OS_V8_CPU_TIME_LIMIT_MS`.
+//
+// The two guards are independent: setting one env knob arms only that guard,
+// and when both are set whichever fires first terminates execution.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -244,9 +247,12 @@ impl TimeoutGuard {
         })
     }
 
-    // DORMANT in this PR: the wall-clock session backstop is not armed by F-001.
-    // Retained for the deferred wall-clock follow-up PR.
-    #[allow(dead_code)]
+    /// Spawn a wall-clock backstop that signals the execution abort with
+    /// [`crate::session::ExecutionAbortReason::WallClockTimedOut`] when the limit
+    /// elapses. Unlike the CPU budget, this counts elapsed real time INCLUDING
+    /// idle/await. Armed only when the operator opts in via
+    /// `AGENT_OS_V8_WALL_CLOCK_LIMIT_MS`.
+    #[cfg_attr(test, allow(dead_code))]
     pub(crate) fn with_execution_abort(
         timeout_ms: u32,
         isolate_handle: v8::IsolateHandle,

--- a/crates/v8-runtime/tests/embedded_runtime_session.rs
+++ b/crates/v8-runtime/tests/embedded_runtime_session.rs
@@ -25,6 +25,7 @@ fn register_and_create_session(
         session_id: session_id.to_owned(),
         heap_limit_mb: None,
         cpu_time_limit_ms: None,
+        wall_clock_limit_ms: None,
     })?;
     Ok(receiver)
 }
@@ -39,6 +40,7 @@ fn register_and_create_session_with_cpu_time_limit(
         session_id: session_id.to_owned(),
         heap_limit_mb: None,
         cpu_time_limit_ms,
+        wall_clock_limit_ms: None,
     })?;
     Ok(receiver)
 }
@@ -153,6 +155,7 @@ fn assert_create_destroy_reuses_session_ids() -> io::Result<()> {
             session_id: session_id.clone(),
             heap_limit_mb: None,
             cpu_time_limit_ms: None,
+            wall_clock_limit_ms: None,
         })
         .expect_err("duplicate sessions should be rejected");
     assert_eq!(duplicate_error.kind(), io::ErrorKind::Other);


### PR DESCRIPTION
Deferred follow-up to #79, which made F-001 a **CPU-time budget only** and left the wall-clock `TimeoutGuard` dormant. This re-wires the wall-clock guard as an **independent, opt-in** limit that complements the CPU budget.

## What changed

- **New env knob `AGENT_OS_V8_WALL_CLOCK_LIMIT_MS`.** When set (`>0`) it arms the wall-clock `TimeoutGuard` in the session execution path, alongside the `CpuBudgetGuard`. Threaded through the `CreateSession`/Start frame next to the existing CPU-budget knob (`AGENT_OS_V8_CPU_TIME_LIMIT_MS`).
- **Off by default.** Unset / `0` normalizes to `None`, so the guard is not armed and there is no wall-clock limit. Long-lived ACP adapters run indefinitely on wall-clock and are **not** killed by a default. The CPU budget remains the primary guard.
- **Coexists with the CPU budget.** Both guards can be armed at once; whichever fires first calls `terminate_execution`. The recorded `ExecutionAbortReason` is authoritative (first-writer-wins), and the result frame attributes termination to the correct guard:
  - wall-clock: `ERR_SCRIPT_WALL_CLOCK_EXCEEDED`
  - CPU budget: `ERR_SCRIPT_CPU_BUDGET_EXCEEDED`
- **Independent semantics.** Unlike the CPU budget (which counts active JS CPU only, excluding idle/await), the wall-clock backstop counts elapsed real time **including** idle/await — so it can cap a guest that blocks or awaits indefinitely.

## Tests (bounded; fenced behind worker-thread + recv-timeout)

Added to the V8 integration suite:
1. Wall-clock SET small -> an **awaiting** guest (~1.5s await, 300ms limit, no CPU budget) is terminated with the **wall-clock** reason — proving idle/await is counted.
2. CPU budget only -> no wall-clock limit imposed; an awaiting guest completes cleanly (knobs independent).
3. Neither set -> no time limit of any kind (strictly opt-in).

## Verification

- `cargo fmt --all --check` clean
- `cargo build --workspace` green
- New + existing V8 integration suite and v8-runtime tests pass