### PR TITLE
ci: pin rust toolchain (1.96.0) + fix clippy lints

### DIFF
--- a/crates/execution/src/wasm.rs
+++ b/crates/execution/src/wasm.rs
@@ -4730,7 +4730,7 @@ fn wasm_guest_path_mappings(request: &StartWasmExecutionRequest) -> Vec<WasmGues
         String::from("/workspace"),
         request.cwd.clone(),
     );
-    mappings.sort_by(|left, right| right.guest_path.len().cmp(&left.guest_path.len()));
+    mappings.sort_by_key(|mapping| std::cmp::Reverse(mapping.guest_path.len()));
     mappings
 }
 

--- a/crates/kernel/src/mount_table.rs
+++ b/crates/kernel/src/mount_table.rs
@@ -714,7 +714,7 @@ impl MountTable {
             filesystem,
         });
         self.mounts
-            .sort_by(|left, right| right.path.len().cmp(&left.path.len()));
+            .sort_by_key(|mount| std::cmp::Reverse(mount.path.len()));
         Ok(())
     }
 

--- a/crates/sidecar/src/execution.rs
+++ b/crates/sidecar/src/execution.rs
@@ -3705,10 +3705,7 @@ where
 
         let vm_ids = self.vm_ids_for_scope(ownership)?;
         for vm_id in vm_ids {
-            loop {
-                let Some(vm) = self.vms.get(&vm_id) else {
-                    break;
-                };
+            while let Some(vm) = self.vms.get(&vm_id) {
                 let connection_id = vm.connection_id.clone();
                 let session_id = vm.session_id.clone();
                 let process_ids = self
@@ -8906,7 +8903,7 @@ fn runtime_guest_path_mappings(vm: &VmState) -> Vec<RuntimeGuestPathMapping> {
         host_path: vm.cwd.to_string_lossy().into_owned(),
         read_only: false,
     });
-    mappings.sort_by(|left, right| right.guest_path.len().cmp(&left.guest_path.len()));
+    mappings.sort_by_key(|mapping| std::cmp::Reverse(mapping.guest_path.len()));
     mappings.dedup_by(|left, right| {
         left.guest_path == right.guest_path && left.host_path == right.host_path
     });
@@ -10882,7 +10879,7 @@ fn host_mount_path_for_guest_path(vm: &VmState, guest_path: &str) -> Option<Path
                 .flatten()
         })
         .collect::<Vec<_>>();
-    mounts.sort_by(|left, right| right.0.len().cmp(&left.0.len()));
+    mounts.sort_by_key(|mount| std::cmp::Reverse(mount.0.len()));
 
     for (guest_root, host_root) in mounts {
         if normalized != guest_root && !normalized.starts_with(&format!("{guest_root}/")) {
@@ -10967,7 +10964,7 @@ pub(crate) fn host_path_from_runtime_guest_mappings(
             ))
         })
         .collect::<Vec<_>>();
-    sorted_mappings.sort_by(|left, right| right.0.len().cmp(&left.0.len()));
+    sorted_mappings.sort_by_key(|mapping| std::cmp::Reverse(mapping.0.len()));
 
     for (guest_root, mut host_root) in sorted_mappings {
         if guest_root != "/"
@@ -11069,7 +11066,7 @@ fn guest_path_from_runtime_host_mappings(
             ))
         })
         .collect::<Vec<_>>();
-    sorted_mappings.sort_by(|left, right| right.1.as_os_str().len().cmp(&left.1.as_os_str().len()));
+    sorted_mappings.sort_by_key(|mapping| std::cmp::Reverse(mapping.1.as_os_str().len()));
 
     for (guest_root, host_root) in sorted_mappings {
         if !path_is_within_root(&normalized, &host_root) {
@@ -11112,7 +11109,7 @@ fn host_mount_path_for_guest_path_from_mounts(
                 .flatten()
         })
         .collect::<Vec<_>>();
-    host_mounts.sort_by(|left, right| right.0.len().cmp(&left.0.len()));
+    host_mounts.sort_by_key(|mount| std::cmp::Reverse(mount.0.len()));
 
     for (guest_root, host_root) in host_mounts {
         if normalized != guest_root && !normalized.starts_with(&format!("{guest_root}/")) {
@@ -16052,7 +16049,7 @@ fn parse_http_header_collection(
         normalized
             .entry(normalized_name)
             .or_default()
-            .extend(values.into_iter());
+            .extend(values);
     }
 
     Ok(HttpHeaderCollection {

--- a/crates/sidecar/src/filesystem.rs
+++ b/crates/sidecar/src/filesystem.rs
@@ -1831,7 +1831,7 @@ fn mapped_runtime_host_path(
             ))
         })
         .collect::<Vec<_>>();
-    sorted_mappings.sort_by(|left, right| right.0.len().cmp(&left.0.len()));
+    sorted_mappings.sort_by_key(|mapping| std::cmp::Reverse(mapping.0.len()));
     let readable_roots = runtime_host_access_roots(process, "AGENT_OS_EXTRA_FS_READ_PATHS")?;
     let writable_roots = writable
         .then(|| runtime_host_access_roots(process, "AGENT_OS_EXTRA_FS_WRITE_PATHS"))

--- a/crates/sidecar/src/plugins/host_dir.rs
+++ b/crates/sidecar/src/plugins/host_dir.rs
@@ -986,7 +986,7 @@ impl HostDirModuleReader {
         if entries.is_empty() {
             return None;
         }
-        entries.sort_by(|left, right| right.guest_prefix.len().cmp(&left.guest_prefix.len()));
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.guest_prefix.len()));
         entries.dedup_by(|left, right| left.guest_prefix == right.guest_prefix);
         Some(Self { mounts: entries })
     }

--- a/crates/sidecar/src/service.rs
+++ b/crates/sidecar/src/service.rs
@@ -61,7 +61,7 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll, Wake, Waker};
+use std::task::{Context, Poll, Waker};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::time;
@@ -766,22 +766,11 @@ where
 }
 
 fn poll_future_once<F: std::future::Future>(future: std::pin::Pin<&mut F>) -> Option<F::Output> {
-    let waker = noop_waker();
-    let mut context = Context::from_waker(&waker);
+    let mut context = Context::from_waker(Waker::noop());
     match future.poll(&mut context) {
         Poll::Ready(output) => Some(output),
         Poll::Pending => None,
     }
-}
-
-fn noop_waker() -> Waker {
-    Waker::from(Arc::new(NoopWake))
-}
-
-struct NoopWake;
-
-impl Wake for NoopWake {
-    fn wake(self: Arc<Self>) {}
 }
 
 // ConnectionState, SessionState, VmConfiguration, VmState moved to crate::state

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.96.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Problem

CI uses `dtolnay/rust-toolchain@stable`, which currently resolves to **rust 1.96.0**, while the repo had no toolchain pin. Local development was on 1.94.0, so `cargo clippy --workspace --all-targets -- -D warnings` passed locally but failed in CI — 1.96.0 flags lints (including pre-existing code like `crates/kernel/src/mount_table.rs:716`) that 1.94.0 did not. This drift makes CI unpredictable.

## Fix

- Add `rust-toolchain.toml` at the repo root pinning `channel = "1.96.0"` with `clippy` + `rustfmt` components, so local and CI use the same toolchain and this can't silently drift again.
- Fix every clippy 1.96.0 lint surfaced under `-D warnings`:
  - `unnecessary_sort_by` → `sort_by_key` with `std::cmp::Reverse`: `crates/kernel/src/mount_table.rs`, `crates/execution/src/wasm.rs`, `crates/sidecar/src/execution.rs` (5 sites), `crates/sidecar/src/filesystem.rs`, `crates/sidecar/src/plugins/host_dir.rs`.
  - `while_let_loop` → `while let` loop in `crates/sidecar/src/execution.rs`.
  - `useless_conversion` (explicit `.into_iter()` in `extend`) in `crates/sidecar/src/execution.rs`.
  - `manual_noop_waker` → use `std::task::Waker::noop()`, removing the hand-rolled `NoopWake` impl in `crates/sidecar/src/service.rs`.

## Verification (with 1.96.0)

- `cargo clippy --workspace --all-targets -- -D warnings` exits 0
- `cargo fmt --all --check` clean
- `cargo build --workspace` green