### PR TITLE
test: stabilize crash-isolation timeout (pre-existing flake)

### DIFF
--- a/crates/sidecar/src/execution.rs
+++ b/crates/sidecar/src/execution.rs
@@ -9216,6 +9216,17 @@ fn prepare_javascript_shadow(
         .env
         .get("AGENT_OS_GUEST_ENTRYPOINT")
         .cloned()
+        // An absolute `entrypoint` may be a host path that lives inside the VM's
+        // host cwd (callers can pass a fully-qualified host path). The guest sees
+        // it at its translated guest path (host_cwd -> guest_cwd), so the shadow
+        // must be keyed by that guest path rather than the raw host path. Falling
+        // back to the host path here would materialize the file at the wrong guest
+        // location and the runtime's `require()` would fail with "Cannot find
+        // module".
+        .or_else(|| {
+            resolve_host_entrypoint_within_vm_host_cwd(vm, &resolved.entrypoint)
+                .map(|(guest_entrypoint, _)| guest_entrypoint)
+        })
         .or_else(|| {
             resolved
                 .entrypoint
@@ -9238,10 +9249,58 @@ fn prepare_javascript_shadow(
             }
         };
         if host_entrypoint.exists() {
-            return materialize_host_path_to_shadow(vm, &guest_entrypoint, &host_entrypoint);
+            materialize_host_path_to_shadow(vm, &guest_entrypoint, &host_entrypoint)?;
+            // The shadow write only stages the file on the host side; the runtime
+            // resolves modules against the kernel VFS, so the staged entrypoint
+            // must be synced into the kernel before execution starts (otherwise
+            // `require()` reports "Cannot find module").
+            return sync_shadow_entrypoint_into_kernel(vm, &guest_entrypoint);
         }
     }
     materialize_guest_path_to_shadow(vm, &guest_entrypoint)
+}
+
+/// Sync a freshly-staged shadow entrypoint into the kernel VFS so the runtime's
+/// kernel-backed module resolver can read it. Mirrors the host->kernel file sync
+/// used by the broader shadow reconciliation, but scoped to the single
+/// entrypoint we just materialized.
+fn sync_shadow_entrypoint_into_kernel(
+    vm: &mut VmState,
+    guest_entrypoint: &str,
+) -> Result<(), SidecarError> {
+    if vm.kernel.exists(guest_entrypoint).unwrap_or(false) {
+        return Ok(());
+    }
+    let shadow_path = shadow_path_for_guest(vm, guest_entrypoint);
+    let bytes = match fs::read(&shadow_path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(SidecarError::Io(format!(
+                "failed to read staged shadow entrypoint {}: {error}",
+                shadow_path.display()
+            )));
+        }
+    };
+    if let Some(parent) = guest_parent_path(guest_entrypoint) {
+        if !vm.kernel.exists(&parent).unwrap_or(false) {
+            vm.kernel.mkdir(&parent, true).map_err(kernel_error)?;
+        }
+    }
+    vm.kernel
+        .write_file(guest_entrypoint, bytes)
+        .map_err(kernel_error)?;
+    Ok(())
+}
+
+fn guest_parent_path(guest_path: &str) -> Option<String> {
+    let parent = Path::new(guest_path).parent()?;
+    let parent = parent.to_string_lossy();
+    if parent.is_empty() || parent == "/" {
+        None
+    } else {
+        Some(parent.into_owned())
+    }
 }
 
 fn materialize_host_path_to_shadow(


### PR DESCRIPTION
## Summary

The `crash_isolation::guest_failure_in_one_vm_does_not_break_peer_vm_execution` test (and the sibling `process_isolation` test) timed out after 10s waiting for events. This reproduces deterministically on `main` and is unrelated to any security review.

## Root cause

It is **not** a crash-isolation defect — VM isolation works correctly. Both guest VMs ran fully independently and each emitted its own VM-scoped output/exit events. The test timed out because **both** VMs failed identically with `Error: Cannot find module '/<entry>.cjs'`, so the "healthy" VM exited 1 instead of 0 and the loop's completion condition (`healthy.exit_code == Some(0)`) was never met.

The defect is in entrypoint materialization. When an `Execute` request supplies an absolute **host** path as the entrypoint (one that lives inside the VM's host cwd), `prepare_javascript_shadow()`:

1. treated that absolute host path as if it were the guest path, materializing the file at the wrong guest location in the shadow, and
2. never synced the staged file into the kernel VFS.

The JavaScript runtime resolves modules against the **kernel VFS** (`KernelModuleFsReader`), so `require("/<entry>.cjs")` could not find the module and every such process exited 1.

## Fix

In `prepare_javascript_shadow()`:

- Translate the absolute host entrypoint to its guest path (`host_cwd` → `guest_cwd`) via `resolve_host_entrypoint_within_vm_host_cwd` before keying the shadow, so the file is staged at the path the runtime actually requires.
- After staging, sync the entrypoint into the kernel VFS (`sync_shadow_entrypoint_into_kernel`) so the kernel-backed module resolver can read it.

The tests are unchanged — they verify the same behavior and now pass deterministically and fast (~1.1s instead of timing out at 10s). Confirmed green over repeated runs; `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` are clean; related sidecar suites (crash_isolation, process_isolation, vm_lifecycle, kill_cleanup, session_isolation, stdio_binary, fs_watch_and_streams, lib) pass.