### PR TITLE
test: regression coverage for V8 Intl crash (#70), cross-exec loopback (#88), and JSON-over-VFS result decode (#11/#59)

### DIFF
--- a/crates/execution/tests/javascript_v8.rs
+++ b/crates/execution/tests/javascript_v8.rs
@@ -953,6 +953,61 @@ console.log(formatter.format(1234.5));
     assert_eq!(stdout, "1,234.50\n");
 }
 
+// Regression for #70: `Date#toLocaleDateString` with a non-default locale,
+// formatting options, and an explicit IANA time zone used to crash the embedded
+// V8 isolate with SIGTRAP. ICU's `DateTimePatternGeneratorCache::CreateGenerator`
+// hit a fatal abort under the near-heap-limit path; the OOM guard in
+// `crates/v8-runtime/src/isolate.rs` now converts that fatal abort into clean
+// termination, and ICU is bundled, so the exact repro runs and returns a string.
+fn javascript_execution_to_locale_date_string_does_not_crash_embedded_v8() {
+    let temp = tempdir().expect("create temp dir");
+    let mut engine = JavascriptExecutionEngine::default();
+    let context = engine.create_context(CreateJavascriptContextRequest {
+        vm_id: String::from("vm-js"),
+        bootstrap_module: None,
+        compile_cache_root: None,
+    });
+
+    let execution = engine
+        .start_execution(StartJavascriptExecutionRequest {
+            vm_id: String::from("vm-js"),
+            context_id: context.context_id,
+            argv: vec![String::from("./entry.mjs")],
+            env: BTreeMap::new(),
+            cwd: temp.path().to_path_buf(),
+            inline_code: Some(String::from(
+                r#"
+const formatted = new Date(Date.UTC(2020, 0, 15)).toLocaleDateString("en-GB", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+  timeZone: "Europe/Warsaw",
+});
+console.log(JSON.stringify({ formatted }));
+"#,
+            )),
+        })
+        .expect("start JavaScript execution");
+
+    let result = execution.wait().expect("wait for JavaScript execution");
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert_eq!(
+        result.exit_code, 0,
+        "guest process must not crash (e.g. SIGTRAP); stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let output: Value = serde_json::from_slice(&result.stdout).expect("parse guest stdout as JSON");
+    let formatted = output
+        .get("formatted")
+        .and_then(Value::as_str)
+        .expect("formatted date string present");
+    assert!(
+        !formatted.is_empty(),
+        "toLocaleDateString returned an empty string: {output}"
+    );
+}
+
 fn javascript_execution_stream_consumers_text_reads_live_stdin() {
     let temp = tempdir().expect("create temp dir");
     let mut engine = JavascriptExecutionEngine::default();
@@ -5010,6 +5065,7 @@ fn javascript_v8_suite() {
     javascript_execution_process_kill_rejects_invalid_pid_in_guest_js();
     javascript_execution_preserves_binary_process_stdio_writes();
     javascript_execution_intl_number_format_does_not_require_host_icu();
+    javascript_execution_to_locale_date_string_does_not_crash_embedded_v8();
     javascript_execution_stream_consumers_text_reads_live_stdin();
     javascript_execution_process_stdin_async_iterator_finishes_with_live_stdin();
     javascript_execution_process_exit_from_live_stdin_listener_exits_without_waiting_for_eof();

--- a/crates/sidecar/tests/service.rs
+++ b/crates/sidecar/tests/service.rs
@@ -3337,6 +3337,216 @@ ykAheWCsAteSEWVc0w==\n\
             )
             .expect("close listener");
         }
+        // Regression for #88: a server in one guest exec process and a client in a
+        // *different* guest exec process inside the SAME VM must talk over loopback.
+        // The fix builds the per-VM socket-path context from every concurrent exec's
+        // listeners (`build_javascript_socket_path_context` iterates all
+        // `active_processes`), so the client's `net.connect` resolves the server
+        // process's listener and routes through the shared kernel socket table.
+        fn javascript_net_cross_exec_loopback_routes_through_kernel_socket_table() {
+            assert_node_available();
+
+            let mut sidecar = create_test_sidecar();
+            let (connection_id, session_id) =
+                authenticate_and_open_session(&mut sidecar).expect("authenticate and open session");
+            let vm_id = create_vm(
+                &mut sidecar,
+                &connection_id,
+                &session_id,
+                PermissionsPolicy::allow_all(),
+            )
+            .expect("create vm");
+
+            // Two distinct guest exec processes in one VM.
+            let server_cwd = temp_dir("secure-exec-sidecar-js-cross-exec-server-cwd");
+            write_fixture(&server_cwd.join("entry.mjs"), "setInterval(() => {}, 1000);");
+            start_fake_javascript_process(&mut sidecar, &vm_id, &server_cwd, "proc-server");
+
+            let client_cwd = temp_dir("secure-exec-sidecar-js-cross-exec-client-cwd");
+            write_fixture(&client_cwd.join("entry.mjs"), "setInterval(() => {}, 1000);");
+            start_fake_javascript_process(&mut sidecar, &vm_id, &client_cwd, "proc-client");
+
+            // Process A (server) listens on loopback.
+            let listen = call_javascript_sync_rpc(
+                &mut sidecar,
+                &vm_id,
+                "proc-server",
+                JavascriptSyncRpcRequest {
+                    id: 1,
+                    method: String::from("net.listen"),
+                    args: vec![json!({
+                        "host": "127.0.0.1",
+                        "port": 0,
+                        "backlog": 1,
+                    })],
+                },
+            )
+            .expect("server listen through sidecar net RPC");
+            let server_id = listen["serverId"].as_str().expect("server id").to_string();
+            let guest_port = listen["localPort"]
+                .as_u64()
+                .and_then(|value| u16::try_from(value).ok())
+                .expect("server listener guest port");
+
+            // Process B (client, a SEPARATE exec) connects to A's listener.
+            let connect = call_javascript_sync_rpc(
+                &mut sidecar,
+                &vm_id,
+                "proc-client",
+                JavascriptSyncRpcRequest {
+                    id: 2,
+                    method: String::from("net.connect"),
+                    args: vec![json!({
+                        "host": "127.0.0.1",
+                        "port": guest_port,
+                    })],
+                },
+            )
+            .expect("client connect to the other exec's listener");
+            let client_socket_id = connect["socketId"]
+                .as_str()
+                .expect("client socket id")
+                .to_string();
+
+            // The client socket must be routed through the shared kernel socket
+            // table, not a host-only loopback shortcut.
+            {
+                let vm = sidecar.vms.get(&vm_id).expect("javascript vm");
+                let client = vm
+                    .active_processes
+                    .get("proc-client")
+                    .expect("client process");
+                let socket = client
+                    .tcp_sockets
+                    .get(&client_socket_id)
+                    .expect("client tcp socket");
+                assert!(
+                    socket.kernel_socket_id.is_some(),
+                    "cross-exec net.connect must route through the kernel socket table"
+                );
+            }
+
+            // Process A accepts the connection from the other exec.
+            let mut accepted = None;
+            for attempt in 0..40 {
+                let value = call_javascript_sync_rpc(
+                    &mut sidecar,
+                    &vm_id,
+                    "proc-server",
+                    JavascriptSyncRpcRequest {
+                        id: 10 + attempt,
+                        method: String::from("net.server_accept"),
+                        args: vec![json!(server_id.clone())],
+                    },
+                )
+                .expect("server accept client from other exec");
+                if value != "__secure_exec_net_timeout__" {
+                    accepted = Some(value);
+                    break;
+                }
+                thread::sleep(std::time::Duration::from_millis(10));
+            }
+            let accepted = accepted.expect("eventually accept the cross-exec connection");
+            let accepted: Value =
+                serde_json::from_str(accepted.as_str().expect("accepted payload string"))
+                    .expect("parse accepted payload");
+            let server_socket_id = accepted["socketId"]
+                .as_str()
+                .expect("accepted socket id")
+                .to_string();
+
+            // Client (exec B) writes a byte; it must cross the exec boundary and be
+            // read by the server (exec A).
+            call_javascript_sync_rpc(
+                &mut sidecar,
+                &vm_id,
+                "proc-client",
+                JavascriptSyncRpcRequest {
+                    id: 100,
+                    method: String::from("net.write"),
+                    args: vec![
+                        json!(client_socket_id.clone()),
+                        json!({
+                            "__agentOsType": "bytes",
+                            "base64": base64::engine::general_purpose::STANDARD.encode("ping"),
+                        }),
+                    ],
+                },
+            )
+            .expect("client write payload across exec boundary");
+            call_javascript_sync_rpc(
+                &mut sidecar,
+                &vm_id,
+                "proc-client",
+                JavascriptSyncRpcRequest {
+                    id: 101,
+                    method: String::from("net.shutdown"),
+                    args: vec![json!(client_socket_id.clone())],
+                },
+            )
+            .expect("client shutdown write half");
+
+            let mut payload = None;
+            for attempt in 0..40 {
+                let value = call_javascript_sync_rpc(
+                    &mut sidecar,
+                    &vm_id,
+                    "proc-server",
+                    JavascriptSyncRpcRequest {
+                        id: 200 + attempt,
+                        method: String::from("net.socket_read"),
+                        args: vec![json!(server_socket_id.clone())],
+                    },
+                )
+                .expect("server read bridged chunk from the other exec");
+                if value != "__secure_exec_net_timeout__" {
+                    payload = Some(value);
+                    break;
+                }
+                thread::sleep(std::time::Duration::from_millis(10));
+            }
+            let payload = payload.expect("eventually receive the cross-exec payload");
+            assert_eq!(
+                payload,
+                Value::from("cGluZw=="),
+                "server (exec A) must read the byte sent by client (exec B)"
+            );
+
+            // Tear everything down.
+            call_javascript_sync_rpc(
+                &mut sidecar,
+                &vm_id,
+                "proc-client",
+                JavascriptSyncRpcRequest {
+                    id: 300,
+                    method: String::from("net.destroy"),
+                    args: vec![json!(client_socket_id)],
+                },
+            )
+            .expect("destroy client socket");
+            call_javascript_sync_rpc(
+                &mut sidecar,
+                &vm_id,
+                "proc-server",
+                JavascriptSyncRpcRequest {
+                    id: 301,
+                    method: String::from("net.destroy"),
+                    args: vec![json!(server_socket_id)],
+                },
+            )
+            .expect("destroy server-accepted socket");
+            call_javascript_sync_rpc(
+                &mut sidecar,
+                &vm_id,
+                "proc-server",
+                JavascriptSyncRpcRequest {
+                    id: 302,
+                    method: String::from("net.server_close"),
+                    args: vec![json!(server_id)],
+                },
+            )
+            .expect("close listener");
+        }
         fn javascript_net_upgrade_socket_aliases_use_tcp_socket_state() {
             assert_node_available();
 
@@ -15569,6 +15779,7 @@ console.log(JSON.stringify({
             loopback_tls_endpoint_read_survives_competing_drain_and_peer_drop();
             javascript_net_socket_wait_connect_reports_tcp_socket_info();
             javascript_net_socket_read_and_socket_options_work_for_tcp_sockets();
+            javascript_net_cross_exec_loopback_routes_through_kernel_socket_table();
             javascript_net_upgrade_socket_aliases_use_tcp_socket_state();
             javascript_dgram_address_and_buffer_size_sync_rpcs_work();
             javascript_tls_client_upgrade_query_and_cipher_list_work();

--- a/packages/core/tests/node-runtime-decode.test.ts
+++ b/packages/core/tests/node-runtime-decode.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+// Regression guard for #11 and #59.
+//
+// Both issues were caused by the removed `@secure-exec/v8` runtime.js
+// (a stdout/socket-path handshake plus a TDZ bug) together with a host-side
+// `node:v8.deserialize()` decode of `run()` results. That host-side V8
+// serialization made result decoding sensitive to the host Node version /
+// V8 engine build (#11) and crashed on constrained hosts such as Lambda
+// cold-starts (#59).
+//
+// The current architecture runs guest code in a process-isolated sidecar
+// binary and decodes `run()` results as plain JSON read back over the VFS
+// (`packages/core/src/node-runtime.ts`), with NO host-side `node:v8`. These
+// tests lock in that root-cause fix at the source level (so they run in a
+// plain Node-host CI without booting a sidecar) and verify the structured
+// JSON-over-VFS decode behaves correctly for nested values.
+
+const nodeRuntimeSource = readFileSync(
+	fileURLToPath(new URL("../src/node-runtime.ts", import.meta.url)),
+	"utf8",
+);
+
+describe("node-runtime run() result transport (#11, #59)", () => {
+	test("the host transport never uses node:v8 deserialize", () => {
+		// The whole point of the fix: no host-side V8 serialization in the
+		// run()/decode path, which is what made #11 host-engine-sensitive and
+		// crashed Lambda cold-starts in #59.
+		expect(nodeRuntimeSource).not.toContain("node:v8");
+		expect(nodeRuntimeSource).not.toContain("v8.deserialize");
+		expect(nodeRuntimeSource).not.toContain("deserialize(");
+	});
+
+	test("run() decodes structured results as JSON read back over the VFS", () => {
+		// The decode must go through a VFS result file plus JSON.parse over a
+		// TextDecoder, not a host-engine-specific binary deserializer.
+		expect(nodeRuntimeSource).toContain("this.kernel.readFile(resultPath)");
+		expect(nodeRuntimeSource).toMatch(
+			/JSON\.parse\(\s*new TextDecoder\(\)\.decode\(bytes\)/,
+		);
+		// And the guest writes its return value as JSON to that same VFS file.
+		expect(nodeRuntimeSource).toContain(
+			"JSON.stringify(value === undefined ? null : value)",
+		);
+	});
+
+	test("structured nested values round-trip through the JSON-over-VFS path", () => {
+		// Model the exact host/guest decode used by run(): the guest writes
+		// JSON.stringify(value) into a VFS file; the host reads the bytes back
+		// and decodes them with JSON.parse(new TextDecoder().decode(bytes)).
+		// A nested object with numbers must survive intact, with no dependency
+		// on host V8 structured-clone serialization.
+		const value = {
+			ok: true,
+			count: 3,
+			ratio: 1.5,
+			nested: { items: [1, 2, 3], label: "x", deep: { n: 42 } },
+		};
+
+		// Guest side: __return() writes JSON.stringify(value) to the result file.
+		const guestBytes = new TextEncoder().encode(JSON.stringify(value));
+
+		// Host side: node-runtime reads the file bytes and JSON.parses them.
+		const decoded = JSON.parse(new TextDecoder().decode(guestBytes));
+
+		expect(decoded).toEqual(value);
+		expect(decoded.nested.items).toEqual([1, 2, 3]);
+		expect(decoded.nested.deep.n).toBe(42);
+	});
+});


### PR DESCRIPTION
Adds permanent regression tests for four issues already fixed on `main` but lacking dedicated coverage.

- **`Closes #70`** — `javascript_execution_to_locale_date_string_does_not_crash_embedded_v8` runs the exact `toLocaleDateString` repro (`en-GB`, day/month/year, `Europe/Warsaw`) and asserts clean termination with a non-empty string, guarding the near-heap-limit OOM guard in `crates/v8-runtime/src/isolate.rs`.
- **`Closes #88`** — `javascript_net_cross_exec_loopback_routes_through_kernel_socket_table` proves a listener in one exec and a connector in a *different* exec inside the same VM communicate over loopback, with the client routed through the shared kernel socket table and bytes crossing the exec boundary.
- **`Refs #11`** / **`Refs #59`** — `packages/core/tests/node-runtime-decode.test.ts` locks in the architectural fix: no host-side `node:v8` deserialize, structured results decoded as JSON over the VFS. These issues are largely environmental (host Node/V8 version sensitivity, Lambda cold-start); this is the testable root-cause guard in a plain Node-host CI, alongside the existing binary-resolution suite (`packages/sidecar/tests/index.test.cjs`). Not marked `Closes` because full behavioral coverage would need a live sidecar binary.

### Verification
- `cargo test -p secure-exec-execution --test javascript_v8 javascript_v8_suite` → passed (includes the #70 test).
- #88 test passed in isolation (`cargo test -p secure-exec-sidecar --test service`). Note: the `secure-exec-sidecar` service suite carries a pre-existing environmental flake in `javascript_tls_client_upgrade_query_and_cipher_list_work` (host TLS-server port-ownership EACCES), reproducible on clean `main` and unrelated to this change.
- `pnpm --filter @secure-exec/core exec vitest run tests/node-runtime-decode.test.ts` → 3 passed.