### PR TITLE
[codex] security runtime followups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -30,6 +28,7 @@ jobs:
           key: ${{ runner.os }}-rusty-v8-${{ hashFiles('Cargo.lock', 'crates/v8-runtime/Cargo.toml', 'crates/v8-runtime/build.rs', 'crates/build-support/v8_bridge_build.rs', 'packages/build-tools/scripts/build-v8-bridge.mjs') }}
           restore-keys: |
             ${{ runner.os }}-rusty-v8-
+      - run: find . -name node_modules -prune -exec rm -rf {} +
       - run: bash scripts/ci.sh
         env:
           CI_FORK_PULL_REQUEST: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && '1' || '0' }}

--- a/crates/execution/build.rs
+++ b/crates/execution/build.rs
@@ -96,5 +96,7 @@ fn stage_pyodide_assets(manifest_dir: &Path, out_dir: &Path) {
 /// build; treat it as missing so a later workspace build can replace it with the
 /// real in-tree asset.
 fn is_placeholder(path: &Path) -> bool {
-    fs::metadata(path).map(|meta| meta.len() == 0).unwrap_or(false)
+    fs::metadata(path)
+        .map(|meta| meta.len() == 0)
+        .unwrap_or(false)
 }

--- a/crates/execution/src/javascript.rs
+++ b/crates/execution/src/javascript.rs
@@ -1940,18 +1940,20 @@ fn javascript_heap_limit_mb(request: &StartJavascriptExecutionRequest) -> u32 {
         .unwrap_or(0)
 }
 
-/// Resolve the opt-in TRUE CPU-time budget (ms) for a JavaScript execution.
+/// Resolve the TRUE CPU-time budget (ms) for a JavaScript execution.
 ///
-/// Opt-in with NO default: read from `AGENT_OS_V8_CPU_TIME_LIMIT_MS`, falling
-/// back to `0` (no limit) when unset/unparsable. `0` is normalized to `None` by
-/// the V8 session, so the CPU-budget watchdog is NOT armed and the guest runs
-/// CPU-uncapped. The platform/operator must set this to cap a guest.
+/// Read from `AGENT_OS_V8_CPU_TIME_LIMIT_MS`, falling back to a bounded default
+/// when unset/unparsable. `0` remains an explicit trusted opt-out and is
+/// normalized to `None` by the V8 session.
 fn javascript_cpu_time_limit_ms(request: &StartJavascriptExecutionRequest) -> u32 {
     request
         .env
         .get(V8_CPU_TIME_LIMIT_MS_ENV)
         .and_then(|value| value.parse::<u32>().ok())
-        .unwrap_or(0)
+        // Generous active-CPU budget: long-lived adapters are still not capped
+        // on wall-clock, but CPU-bound runaways no longer pin a core forever by
+        // default.
+        .unwrap_or(30_000)
 }
 
 /// Resolve the opt-in WALL-CLOCK backstop (ms) for a JavaScript execution.
@@ -6777,6 +6779,26 @@ mod tests {
             .expect("failed registration should not leak the session output receiver");
         drop(receiver);
         host.unregister_session(&session_id);
+    }
+
+    #[test]
+    fn javascript_cpu_time_limit_defaults_to_bounded_value() {
+        let request = StartJavascriptExecutionRequest {
+            limits: Default::default(),
+            guest_runtime: Default::default(),
+            vm_id: String::from("vm-js-default-cpu"),
+            context_id: String::from("ctx-js-default-cpu"),
+            argv: vec![String::from("./entry.mjs")],
+            env: BTreeMap::new(),
+            cwd: std::path::PathBuf::from("/tmp"),
+            inline_code: None,
+        };
+
+        assert_eq!(
+            javascript_cpu_time_limit_ms(&request),
+            30_000,
+            "unset JavaScript CPU budget must be bounded by default"
+        );
     }
 
     #[test]

--- a/crates/execution/src/python.rs
+++ b/crates/execution/src/python.rs
@@ -239,13 +239,19 @@ pub struct PythonExecutionResult {
 #[derive(Debug)]
 pub enum PythonExecutionError {
     MissingContext(String),
-    VmMismatch { expected: String, found: String },
+    VmMismatch {
+        expected: String,
+        found: String,
+    },
     /// Guest Python is unavailable because this build was compiled without the
     /// bundled Pyodide runtime assets (the published crate excludes them).
     RuntimeUnavailable,
     PrepareRuntime(std::io::Error),
     PrepareWarmPath(std::io::Error),
-    WarmupFailed { exit_code: i32, stderr: String },
+    WarmupFailed {
+        exit_code: i32,
+        stderr: String,
+    },
     Spawn(std::io::Error),
     StdinClosed,
     Stdin(std::io::Error),
@@ -253,7 +259,10 @@ pub enum PythonExecutionError {
     TimedOut(Duration),
     PendingVfsRpcRequest(u64),
     RpcResponse(String),
-    OutputBufferExceeded { stream: &'static str, limit: usize },
+    OutputBufferExceeded {
+        stream: &'static str,
+        limit: usize,
+    },
     EventChannelClosed,
 }
 
@@ -938,7 +947,7 @@ fn start_python_javascript_execution(
     // limits, not env — the JS engine reads them from `limits`, not `AGENT_OS_*`.
     let max_old_space_mb = python_max_old_space_mb(request);
     let runner_limits = JavascriptExecutionLimits {
-        v8_heap_limit_mb: (max_old_space_mb > 0).then(|| max_old_space_mb as u32),
+        v8_heap_limit_mb: (max_old_space_mb > 0).then_some(max_old_space_mb as u32),
         sync_rpc_wait_timeout_ms: Some(PYTHON_SYNC_RPC_WAIT_TIMEOUT_MS),
     };
 

--- a/crates/execution/src/wasm.rs
+++ b/crates/execution/src/wasm.rs
@@ -339,6 +339,8 @@ pub struct WasmExecution {
     child_pid: u32,
     inner: JavascriptExecution,
     execution_timeout: Option<Duration>,
+    execution_started_at: Instant,
+    timeout_reported: bool,
     internal_sync_rpc: WasmInternalSyncRpc,
     pending_events: VecDeque<WasmExecutionEvent>,
     stdout_stream_buffer: Vec<u8>,
@@ -437,9 +439,13 @@ impl WasmExecution {
                 self.enqueue_wasm_event(event)?;
                 continue;
             }
+            if let Some(event) = self.timeout_event_if_expired()? {
+                return Ok(Some(event));
+            }
+            let poll_timeout = self.deadline_capped_timeout(timeout);
             match self
                 .inner
-                .poll_event(timeout)
+                .poll_event(poll_timeout)
                 .await
                 .map_err(map_javascript_error)?
             {
@@ -454,6 +460,7 @@ impl WasmExecution {
                     }
                     self.enqueue_javascript_event(event)?;
                 }
+                None if poll_timeout < timeout => continue,
                 None => return Ok(None),
             }
         }
@@ -471,9 +478,13 @@ impl WasmExecution {
                 self.enqueue_wasm_event(event)?;
                 continue;
             }
+            if let Some(event) = self.timeout_event_if_expired()? {
+                return Ok(Some(event));
+            }
+            let poll_timeout = self.deadline_capped_timeout(timeout);
             match self
                 .inner
-                .poll_event_blocking(timeout)
+                .poll_event_blocking(poll_timeout)
                 .map_err(map_javascript_error)?
             {
                 Some(event) => {
@@ -487,6 +498,7 @@ impl WasmExecution {
                     }
                     self.enqueue_javascript_event(event)?;
                 }
+                None if poll_timeout < timeout => continue,
                 None => return Ok(None),
             }
         }
@@ -496,22 +508,9 @@ impl WasmExecution {
         self.close_stdin()?;
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
-        let started = Instant::now();
 
         loop {
-            let poll_timeout = self
-                .execution_timeout
-                .map(|limit| {
-                    let elapsed = started.elapsed();
-                    if elapsed >= limit {
-                        Duration::ZERO
-                    } else {
-                        limit.saturating_sub(elapsed).min(Duration::from_millis(50))
-                    }
-                })
-                .unwrap_or_else(|| Duration::from_millis(50));
-
-            match self.poll_event_blocking(poll_timeout)? {
+            match self.poll_event_blocking(Duration::from_millis(50))? {
                 Some(WasmExecutionEvent::Stdout(chunk)) => {
                     append_wasm_captured_output(&mut stdout, &chunk, "stdout")?;
                 }
@@ -538,24 +537,42 @@ impl WasmExecution {
                 }
                 None => {}
             }
-
-            if let Some(limit) = self.execution_timeout {
-                if started.elapsed() >= limit {
-                    let _ = self.inner.terminate();
-                    append_wasm_captured_output(
-                        &mut stderr,
-                        b"WebAssembly fuel budget exhausted\n",
-                        "stderr",
-                    )?;
-                    return Ok(WasmExecutionResult {
-                        execution_id: self.execution_id,
-                        exit_code: WASM_TIMEOUT_EXIT_CODE,
-                        stdout,
-                        stderr,
-                    });
-                }
-            }
         }
+    }
+
+    fn deadline_capped_timeout(&self, timeout: Duration) -> Duration {
+        self.execution_timeout
+            .map(|limit| {
+                let elapsed = self.execution_started_at.elapsed();
+                if elapsed >= limit {
+                    Duration::ZERO
+                } else {
+                    timeout.min(limit.saturating_sub(elapsed))
+                }
+            })
+            .unwrap_or(timeout)
+    }
+
+    fn timeout_event_if_expired(
+        &mut self,
+    ) -> Result<Option<WasmExecutionEvent>, WasmExecutionError> {
+        if self.timeout_reported {
+            return Ok(None);
+        }
+        let Some(limit) = self.execution_timeout else {
+            return Ok(None);
+        };
+        if self.execution_started_at.elapsed() < limit {
+            return Ok(None);
+        }
+
+        let _ = self.inner.terminate();
+        self.timeout_reported = true;
+        self.enqueue_wasm_event(WasmExecutionEvent::Stderr(
+            b"WebAssembly fuel budget exhausted\n".to_vec(),
+        ))?;
+        self.enqueue_wasm_event(WasmExecutionEvent::Exited(WASM_TIMEOUT_EXIT_CODE))?;
+        Ok(self.pending_events.pop_front())
     }
 
     fn handle_internal_sync_rpc(
@@ -847,6 +864,8 @@ impl WasmExecutionEngine {
             child_pid,
             inner: javascript_execution,
             execution_timeout,
+            execution_started_at: Instant::now(),
+            timeout_reported: false,
             pending_events: VecDeque::new(),
             stdout_stream_buffer: Vec::new(),
             stderr_stream_buffer: Vec::new(),
@@ -5428,12 +5447,14 @@ mod tests {
 
     #[test]
     fn wasm_limits_default_to_none_when_unset_even_with_env_present() {
-        // Same misleading env, but no typed limits: every limit must be absent.
+        // Same misleading env, but no typed limits: memory and stack remain absent.
+        // Execution time still gets the runtime default timeout so fuel-less
+        // infinite loops are bounded on the poll path.
         let request = request_with_typed_limits_and_misleading_env(WasmExecutionLimits::default());
 
         assert_eq!(
             resolve_wasm_execution_timeout(&request).expect("fuel"),
-            None
+            Some(Duration::from_millis(DEFAULT_WASM_EXECUTION_TIMEOUT_MS))
         );
         assert_eq!(wasm_memory_limit_bytes(&request).expect("memory"), None);
         assert_eq!(

--- a/crates/execution/tests/javascript_v8.rs
+++ b/crates/execution/tests/javascript_v8.rs
@@ -1038,6 +1038,8 @@ fn javascript_execution_to_locale_date_string_does_not_crash_embedded_v8() {
 
     let execution = engine
         .start_execution(StartJavascriptExecutionRequest {
+            limits: Default::default(),
+            guest_runtime: Default::default(),
             vm_id: String::from("vm-js"),
             context_id: context.context_id,
             argv: vec![String::from("./entry.mjs")],
@@ -4717,13 +4719,12 @@ fn javascript_awaiting_guest_is_not_killed_by_cpu_budget() {
     }
 }
 
-// SE-EXEC-04 (F-001) OPT-IN: with NO `AGENT_OS_V8_CPU_TIME_LIMIT_MS` set, the
-// CPU-budget watchdog must NOT be armed (no default), so a short CPU-bound guest
-// runs to completion uninterrupted. This confirms the knob is strictly opt-in and
-// that there is no implicit (e.g. former 30s) limit. We deliberately use a SHORT,
-// self-terminating busy loop (not an infinite one) so the test cannot hang even
-// when there is no limit.
-fn javascript_no_cpu_budget_when_env_unset() {
+// SE-EXEC-04 (F-001): with NO `AGENT_OS_V8_CPU_TIME_LIMIT_MS` set, the
+// CPU-budget watchdog uses the bounded default. A short CPU-bound guest still
+// runs to completion because it stays below that generous active-CPU budget. We
+// deliberately use a SHORT, self-terminating busy loop (not an infinite one) so
+// the test cannot hang if the guard regresses.
+fn javascript_default_cpu_budget_allows_short_cpu_work() {
     let (tx, rx) = mpsc::channel::<(i32, String, String)>();
     thread::spawn(move || {
         let temp = match tempdir() {
@@ -4744,7 +4745,7 @@ fn javascript_no_cpu_budget_when_env_unset() {
             vm_id: String::from("vm-js-nolimit"),
             context_id: context.context_id,
             argv: vec![String::from("./entry.mjs")],
-            // No CPU-limit env: watchdog must NOT arm (opt-in, no default).
+            // No CPU-limit env: the watchdog uses the bounded default.
             env: BTreeMap::new(),
             cwd: temp.path().to_path_buf(),
             // ~600ms busy loop: long enough to have tripped the old 30s default's
@@ -4782,17 +4783,17 @@ fn javascript_no_cpu_budget_when_env_unset() {
             assert!(
                 !stderr.contains("ERR_SCRIPT_CPU_BUDGET_EXCEEDED")
                     && !stderr.contains("CPU-time budget"),
-                "guest was CPU-limited despite no AGENT_OS_V8_CPU_TIME_LIMIT_MS set \
-                 (watchdog must be opt-in): exit_code={exit_code} stdout={stdout} stderr={stderr}"
+                "guest was CPU-limited despite staying below the default CPU budget: \
+                 exit_code={exit_code} stdout={stdout} stderr={stderr}"
             );
             assert_eq!(
                 exit_code, 0,
-                "unbounded short busy loop should exit cleanly when no CPU limit is set: \
+                "short busy loop should exit cleanly under the default CPU budget: \
                  stdout={stdout} stderr={stderr}"
             );
             assert!(
                 stdout.contains("busy-done true"),
-                "busy loop did not run to completion with no CPU limit set: \
+                "busy loop did not run to completion under the default CPU budget: \
                  stdout={stdout} stderr={stderr}"
             );
         }
@@ -4995,11 +4996,12 @@ fn javascript_cpu_budget_only_does_not_impose_wall_clock_limit() {
     }
 }
 
-// WALL-CLOCK OPT-IN: with NEITHER `AGENT_OS_V8_WALL_CLOCK_LIMIT_MS` nor
-// `AGENT_OS_V8_CPU_TIME_LIMIT_MS` set, there is NO time limit of any kind. A guest
-// that awaits well past any default a former wall-clock timer might have imposed
-// must run to completion. This guards the requirement that long-lived ACP adapters
-// (which run indefinitely on wall-clock) are never killed by a default.
+// WALL-CLOCK OPT-IN: with no `AGENT_OS_V8_WALL_CLOCK_LIMIT_MS` set, there is no
+// wall-clock limit. A guest that awaits well past any default a former
+// wall-clock timer might have imposed must run to completion. This guards the
+// requirement that long-lived ACP adapters (which run indefinitely on
+// wall-clock) are never killed by a wall-clock default. The default CPU budget
+// remains armed but excludes idle/await time.
 fn javascript_no_time_limit_when_neither_env_set() {
     let (tx, rx) = mpsc::channel::<(i32, String, String)>();
     thread::spawn(move || {
@@ -5021,7 +5023,8 @@ fn javascript_no_time_limit_when_neither_env_set() {
             vm_id: String::from("vm-js-notimelimit"),
             context_id: context.context_id,
             argv: vec![String::from("./entry.mjs")],
-            // No time-limit env of any kind: no wall-clock and no CPU guard armed.
+            // No wall-clock env: no wall-clock guard is armed. The default CPU
+            // budget excludes this idle await.
             env: BTreeMap::new(),
             cwd: temp.path().to_path_buf(),
             // Awaits ~1.2s, then exits cleanly. Self-terminating so the test cannot
@@ -5058,17 +5061,17 @@ fn javascript_no_time_limit_when_neither_env_set() {
                     && !stderr.contains("wall-clock limit")
                     && !stderr.contains("ERR_SCRIPT_CPU_BUDGET_EXCEEDED")
                     && !stderr.contains("CPU-time budget"),
-                "a time limit fired despite no limit env being set (must be strictly opt-in): \
+                "a wall-clock or CPU limit fired despite this idle await staying below the default CPU budget: \
                  exit_code={exit_code} stdout={stdout} stderr={stderr}"
             );
             assert_eq!(
                 exit_code, 0,
-                "awaiting guest should complete cleanly when no time limit is set: \
+                "awaiting guest should complete cleanly when no wall-clock limit is set: \
                  stdout={stdout} stderr={stderr}"
             );
             assert!(
                 stdout.contains("no-limit-ok"),
-                "guest did not run to completion with no time limit set: \
+                "guest did not run to completion with no wall-clock limit set: \
                  stdout={stdout} stderr={stderr}"
             );
         }
@@ -5312,19 +5315,19 @@ fn javascript_v8_suite() {
     // behind worker-thread wall-clock watchdogs.
     javascript_heap_allocation_bomb_is_capped_by_oom_guard();
 
-    // SE-EXEC-04 (F-001): opt-in TRUE CPU-time budget. These run LAST because a
+    // SE-EXEC-04 (F-001): TRUE CPU-time budget. These run LAST because a
     // regression in the tight-loop case could leak a CPU-bound worker thread.
     //   1. budget SET  => tight busy loop terminated (cpu-budget reason)
     //   2. budget SET  => awaiting/idle guest NOT killed (idle excluded)  [critical negative]
-    //   3. budget UNSET => watchdog not armed; short busy loop runs free  [opt-in, no default]
+    //   3. budget UNSET => default watchdog allows short CPU work
     javascript_infinite_loop_is_terminated_by_cpu_watchdog();
     javascript_awaiting_guest_is_not_killed_by_cpu_budget();
-    javascript_no_cpu_budget_when_env_unset();
+    javascript_default_cpu_budget_allows_short_cpu_work();
 
     // WALL-CLOCK BACKSTOP (opt-in, complements the CPU-time budget):
     //   1. wall-clock SET  => awaiting guest terminated (wall-clock reason; idle counted)
     //   2. CPU budget only => no wall-clock limit imposed (knobs independent)
-    //   3. neither SET     => no time limit at all (strictly opt-in)
+    //   3. wall-clock unset => idle await completes; default CPU budget excludes idle
     javascript_awaiting_guest_is_terminated_by_wall_clock_backstop();
     javascript_cpu_budget_only_does_not_impose_wall_clock_limit();
     javascript_no_time_limit_when_neither_env_set();

--- a/crates/execution/tests/wasm.rs
+++ b/crates/execution/tests/wasm.rs
@@ -1845,6 +1845,68 @@ fn wasm_execution_times_out_when_fuel_budget_is_exhausted() {
     );
 }
 
+fn wasm_execution_poll_path_times_out_when_fuel_budget_is_exhausted() {
+    assert_node_available();
+
+    let temp = tempdir().expect("create temp dir");
+    write_fixture(
+        &temp.path().join("guest.wasm"),
+        &wasm_infinite_loop_module(),
+    );
+
+    let mut engine = WasmExecutionEngine::default();
+    let context = engine.create_context(CreateWasmContextRequest {
+        vm_id: String::from("vm-wasm"),
+        module_path: Some(String::from("./guest.wasm")),
+    });
+
+    let mut execution = engine
+        .start_execution(StartWasmExecutionRequest {
+            guest_runtime: Default::default(),
+            limits: WasmExecutionLimits {
+                max_fuel: Some(25),
+                ..Default::default()
+            },
+            vm_id: String::from("vm-wasm"),
+            context_id: context.context_id,
+            argv: Vec::new(),
+            env: BTreeMap::new(),
+            cwd: temp.path().to_path_buf(),
+            permission_tier: WasmPermissionTier::Full,
+        })
+        .expect("start wasm execution");
+
+    let mut stderr = String::new();
+    let mut exit_code = None;
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while exit_code.is_none() {
+        let remaining = deadline
+            .checked_duration_since(std::time::Instant::now())
+            .expect("poll path did not time out within the bounded test window");
+        match execution
+            .poll_event_blocking(remaining.min(Duration::from_millis(250)))
+            .expect("poll wasm event")
+        {
+            Some(WasmExecutionEvent::Stderr(chunk)) => {
+                stderr.push_str(&String::from_utf8_lossy(&chunk));
+            }
+            Some(WasmExecutionEvent::Exited(code)) => {
+                exit_code = Some(code);
+            }
+            Some(WasmExecutionEvent::Stdout(_))
+            | Some(WasmExecutionEvent::SyncRpcRequest(_))
+            | Some(WasmExecutionEvent::SignalState { .. })
+            | None => {}
+        }
+    }
+
+    assert_eq!(exit_code, Some(124), "stderr={stderr}");
+    assert!(
+        stderr.contains("fuel budget exhausted"),
+        "stderr should mention the exhausted fuel budget: {stderr}"
+    );
+}
+
 fn wasm_execution_allows_prewarm_timeout_to_differ_from_execution_timeout() {
     assert_node_available();
 
@@ -2459,6 +2521,7 @@ fn wasm_suite() {
     wasm_execution_rewarms_when_symlink_target_changes_with_same_size_module();
     wasm_warmup_metrics_encode_emoji_module_paths_as_json();
     wasm_execution_times_out_when_fuel_budget_is_exhausted();
+    wasm_execution_poll_path_times_out_when_fuel_budget_is_exhausted();
     wasm_execution_allows_prewarm_timeout_to_differ_from_execution_timeout();
     wasm_execution_rejects_modules_whose_memory_cap_exceeds_limit();
     wasm_execution_enforces_runtime_memory_growth_limit_for_modules_without_declared_maximum();

--- a/crates/kernel/src/overlay_fs.rs
+++ b/crates/kernel/src/overlay_fs.rs
@@ -1868,8 +1868,7 @@ mod tests {
             .write_file("/data/secret.txt", b"secret".to_vec())
             .expect("seed lower file");
 
-        let mut overlay =
-            OverlayFileSystem::with_upper(vec![lower], MemoryFileSystem::new());
+        let mut overlay = OverlayFileSystem::with_upper(vec![lower], MemoryFileSystem::new());
 
         // Delete a lower-layer file: a whiteout marker is written under the
         // reserved metadata root and the file disappears from the merged view.
@@ -1893,9 +1892,7 @@ mod tests {
         // Removing the whiteout marker through the symlink must be denied, so the
         // deleted lower-layer file cannot be resurrected.
         assert!(
-            overlay
-                .remove_file("/escape/anything")
-                .is_err(),
+            overlay.remove_file("/escape/anything").is_err(),
             "tampering with metadata via a symlink must be denied"
         );
         assert!(

--- a/crates/kernel/src/resource_accounting.rs
+++ b/crates/kernel/src/resource_accounting.rs
@@ -25,6 +25,7 @@ pub const DEFAULT_MAX_PROCESS_ARGV_BYTES: usize = 1024 * 1024;
 pub const DEFAULT_MAX_PROCESS_ENV_BYTES: usize = 1024 * 1024;
 pub const DEFAULT_MAX_READDIR_ENTRIES: usize = 4_096;
 pub const DEFAULT_VIRTUAL_CPU_COUNT: usize = 1;
+pub const DEFAULT_MAX_WASM_MEMORY_BYTES: u64 = 128 * 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ResourceSnapshot {
@@ -89,7 +90,9 @@ impl Default for ResourceLimits {
             max_process_env_bytes: Some(DEFAULT_MAX_PROCESS_ENV_BYTES),
             max_readdir_entries: Some(DEFAULT_MAX_READDIR_ENTRIES),
             max_wasm_fuel: None,
-            max_wasm_memory_bytes: None,
+            // Match the Workers-style default memory envelope where sensible:
+            // guests are bounded unless the trusted VM config raises the cap.
+            max_wasm_memory_bytes: Some(DEFAULT_MAX_WASM_MEMORY_BYTES),
             max_wasm_stack_bytes: None,
         }
     }

--- a/crates/sidecar/src/execution.rs
+++ b/crates/sidecar/src/execution.rs
@@ -3147,7 +3147,7 @@ where
                         guest_runtime: wasm_guest_runtime,
                     })
                     .map_err(wasm_error)?;
-                (ActiveExecution::Wasm(execution), env)
+                (ActiveExecution::Wasm(Box::new(execution)), env)
             }
         };
         let child_pid = execution.child_pid();
@@ -5369,7 +5369,7 @@ where
                             guest_runtime: wasm_guest_runtime,
                         })
                         .map_err(wasm_error)?;
-                    ActiveExecution::Wasm(execution)
+                    ActiveExecution::Wasm(Box::new(execution))
                 }
                 GuestRuntimeKind::Python => {
                     unreachable!("python child_process execution is rejected")
@@ -5761,7 +5761,7 @@ where
                             guest_runtime: wasm_guest_runtime,
                         })
                         .map_err(wasm_error)?;
-                    ActiveExecution::Wasm(execution)
+                    ActiveExecution::Wasm(Box::new(execution))
                 }
                 GuestRuntimeKind::Python => {
                     unreachable!("python child_process execution is rejected")

--- a/crates/sidecar/src/limits.rs
+++ b/crates/sidecar/src/limits.rs
@@ -34,6 +34,7 @@ pub const DEFAULT_JS_CAPTURED_OUTPUT_LIMIT_BYTES: usize = 16 * 1024 * 1024;
 pub const DEFAULT_JS_STDIN_BUFFER_LIMIT_BYTES: usize = 16 * 1024 * 1024;
 pub const DEFAULT_JS_EVENT_PAYLOAD_LIMIT_BYTES: usize = 1024 * 1024;
 pub const DEFAULT_V8_IPC_MAX_FRAME_BYTES: u32 = 64 * 1024 * 1024;
+pub const DEFAULT_V8_HEAP_LIMIT_MB: u32 = 128;
 
 pub const DEFAULT_PYTHON_OUTPUT_BUFFER_MAX_BYTES: usize = 1024 * 1024;
 pub const DEFAULT_PYTHON_EXECUTION_TIMEOUT_MS: u64 = 5 * 60 * 1000;
@@ -170,7 +171,9 @@ impl Default for AcpLimits {
 impl Default for JsRuntimeLimits {
     fn default() -> Self {
         Self {
-            v8_heap_limit_mb: None,
+            // Workers-style 128 MiB heap cap by default. Operators can raise or
+            // clear this through trusted VM config when a VM needs more room.
+            v8_heap_limit_mb: Some(DEFAULT_V8_HEAP_LIMIT_MB),
             sync_rpc_wait_timeout_ms: None,
             captured_output_limit_bytes: DEFAULT_JS_CAPTURED_OUTPUT_LIMIT_BYTES,
             stdin_buffer_limit_bytes: DEFAULT_JS_STDIN_BUFFER_LIMIT_BYTES,

--- a/crates/sidecar/src/plugins/google_drive.rs
+++ b/crates/sidecar/src/plugins/google_drive.rs
@@ -279,8 +279,7 @@ impl GoogleDriveObjectStore {
         token_url: String,
         api_base_url: String,
     ) -> Result<Self, PluginError> {
-        let api_base_url =
-            validate_google_drive_url(&api_base_url, "apiBaseUrl", false)?;
+        let api_base_url = validate_google_drive_url(&api_base_url, "apiBaseUrl", false)?;
 
         Ok(Self {
             auth: GoogleServiceAccountAuth::new(credentials, token_url)?,
@@ -542,8 +541,7 @@ impl GoogleServiceAccountAuth {
                     "google_drive mount credentials.privateKey is not valid PEM: {error}"
                 ))
             })?;
-        let token_url =
-            validate_google_drive_url(&token_url, "tokenUrl", true)?;
+        let token_url = validate_google_drive_url(&token_url, "tokenUrl", true)?;
 
         Ok(Self {
             client_email: credentials.client_email,

--- a/crates/sidecar/src/state.rs
+++ b/crates/sidecar/src/state.rs
@@ -913,7 +913,7 @@ pub(crate) struct ActiveUdpSocket {
 pub(crate) enum ActiveExecution {
     Javascript(JavascriptExecution),
     Python(PythonExecution),
-    Wasm(WasmExecution),
+    Wasm(Box<WasmExecution>),
     Tool(ToolExecution),
 }
 

--- a/crates/sidecar/tests/limits.rs
+++ b/crates/sidecar/tests/limits.rs
@@ -14,6 +14,16 @@ fn defaults_match_struct_default() {
     let parsed =
         vm_limits_from_config(None, SIDECAR_FRAME_CAP).expect("empty config parses to defaults");
     assert_eq!(parsed, VmLimits::default());
+    assert_eq!(
+        parsed.js_runtime.v8_heap_limit_mb,
+        Some(128),
+        "JavaScript heap must be bounded by default"
+    );
+    assert_eq!(
+        parsed.resources.max_wasm_memory_bytes,
+        Some(128 * 1024 * 1024),
+        "WASM memory must be bounded by default"
+    );
 }
 
 #[test]

--- a/crates/sidecar/tests/service.rs
+++ b/crates/sidecar/tests/service.rs
@@ -1912,7 +1912,7 @@ ykAheWCsAteSEWVc0w==\n\
                     kernel_pid,
                     kernel_handle,
                     GuestRuntimeKind::WebAssembly,
-                    ActiveExecution::Wasm(execution),
+                    ActiveExecution::Wasm(Box::new(execution)),
                 )
                 .with_guest_cwd(String::from("/"))
                 .with_env(env)
@@ -3367,11 +3367,17 @@ ykAheWCsAteSEWVc0w==\n\
 
             // Two distinct guest exec processes in one VM.
             let server_cwd = temp_dir("secure-exec-sidecar-js-cross-exec-server-cwd");
-            write_fixture(&server_cwd.join("entry.mjs"), "setInterval(() => {}, 1000);");
+            write_fixture(
+                &server_cwd.join("entry.mjs"),
+                "setInterval(() => {}, 1000);",
+            );
             start_fake_javascript_process(&mut sidecar, &vm_id, &server_cwd, "proc-server");
 
             let client_cwd = temp_dir("secure-exec-sidecar-js-cross-exec-client-cwd");
-            write_fixture(&client_cwd.join("entry.mjs"), "setInterval(() => {}, 1000);");
+            write_fixture(
+                &client_cwd.join("entry.mjs"),
+                "setInterval(() => {}, 1000);",
+            );
             start_fake_javascript_process(&mut sidecar, &vm_id, &client_cwd, "proc-client");
 
             // Process A (server) listens on loopback.
@@ -7908,6 +7914,100 @@ ykAheWCsAteSEWVc0w==\n\
             assert_eq!(exit_code, Some(0), "stderr: {stderr}");
             assert!(stdout.contains("wasm:ready"), "stdout: {stdout}");
         }
+
+        fn wasm_command_timeout_is_enforced_by_sidecar_poll_path() {
+            let command_root = temp_dir("secure-exec-sidecar-command-resolution-wasm-timeout");
+            write_fixture(
+                &command_root.join("spin"),
+                wat::parse_str(
+                    r#"
+(module
+  (memory (export "memory") 1)
+  (func $_start (export "_start")
+    (loop $spin
+      br $spin
+    )
+  )
+)
+"#,
+                )
+                .expect("compile infinite-loop wasm fixture"),
+            );
+
+            let mut sidecar = create_test_sidecar();
+            let (connection_id, session_id) =
+                authenticate_and_open_session(&mut sidecar).expect("authenticate and open session");
+            let vm_id = create_vm_with_metadata(
+                &mut sidecar,
+                &connection_id,
+                &session_id,
+                PermissionsPolicy::allow_all(),
+                BTreeMap::from([(String::from("resource.max_wasm_fuel"), String::from("25"))]),
+            )
+            .expect("create vm");
+
+            sidecar
+                .dispatch_blocking(request(
+                    4,
+                    OwnershipScope::vm(&connection_id, &session_id, &vm_id),
+                    RequestPayload::ConfigureVm(ConfigureVmRequest {
+                        mounts: vec![MountDescriptor {
+                            guest_path: String::from("/__secure_exec/commands/0"),
+                            read_only: true,
+                            plugin: MountPluginDescriptor {
+                                id: String::from("host_dir"),
+                                config: json!({
+                                    "hostPath": command_root,
+                                    "readOnly": true,
+                                })
+                                .to_string(),
+                            },
+                        }],
+                        software: Vec::new(),
+                        permissions: None,
+                        module_access_cwd: None,
+                        instructions: Vec::new(),
+                        projected_modules: Vec::new(),
+                        command_permissions: std::collections::HashMap::new(),
+                        loopback_exempt_ports: Vec::new(),
+                    }),
+                ))
+                .expect("configure command mount");
+
+            let response = sidecar
+                .dispatch_blocking(request(
+                    5,
+                    OwnershipScope::vm(&connection_id, &session_id, &vm_id),
+                    RequestPayload::Execute(crate::protocol::ExecuteRequest {
+                        process_id: String::from("proc-command-wasm-timeout"),
+                        command: Some(String::from("spin")),
+                        runtime: None,
+                        entrypoint: None,
+                        args: Vec::new(),
+                        env: std::collections::HashMap::new(),
+                        cwd: None,
+                        wasm_permission_tier: None,
+                    }),
+                ))
+                .expect("dispatch wasm command execute");
+
+            match response.response.payload {
+                ResponsePayload::ProcessStarted(response) => {
+                    assert_eq!(response.process_id, "proc-command-wasm-timeout");
+                }
+                other => panic!("unexpected execute response: {other:?}"),
+            }
+
+            let (stdout, stderr, exit_code) =
+                drain_process_output(&mut sidecar, &vm_id, "proc-command-wasm-timeout");
+
+            assert_eq!(exit_code, Some(124), "stdout: {stdout} stderr: {stderr}");
+            assert!(
+                stderr.contains("fuel budget exhausted"),
+                "stderr should mention timeout: {stderr}"
+            );
+        }
+
         fn wasm_fd_write_sync_rpc_keeps_stdout_isolated_per_vm() {
             let cwd_a = temp_dir("secure-exec-sidecar-wasm-stdio-vm-a");
             let cwd_b = temp_dir("secure-exec-sidecar-wasm-stdio-vm-b");
@@ -15861,6 +15961,7 @@ console.log(JSON.stringify({
             configure_vm_host_dir_plugin_fails_closed_for_escape_symlinks();
             execute_starts_python_runtime_instead_of_rejecting_it();
             command_resolution_executes_wasm_command_from_sidecar_path();
+            wasm_command_timeout_is_enforced_by_sidecar_poll_path();
             wasm_fd_write_sync_rpc_keeps_stdout_isolated_per_vm();
             wasm_fd_write_sync_rpc_routes_stdout_into_kernel_pty();
             javascript_child_process_searches_path_for_mounted_wasm_commands();
@@ -15981,6 +16082,11 @@ console.log(JSON.stringify({
         }
 
         #[test]
+        fn aab_wasm_command_timeout_is_enforced_by_sidecar_poll_path() {
+            run_isolated_service_test("wasm-command-timeout");
+        }
+
+        #[test]
         fn __service_isolated_runner() {
             let Ok(test_name) = std::env::var(ISOLATED_SERVICE_TEST_ENV) else {
                 return;
@@ -15992,6 +16098,9 @@ console.log(JSON.stringify({
                 }
                 "http2-file-response" => {
                     javascript_http2_settings_pause_push_and_file_response_surfaces_work();
+                }
+                "wasm-command-timeout" => {
+                    wasm_command_timeout_is_enforced_by_sidecar_poll_path();
                 }
                 other => panic!("unknown isolated service test {other}"),
             }

--- a/crates/v8-runtime/src/session.rs
+++ b/crates/v8-runtime/src/session.rs
@@ -907,6 +907,7 @@ fn session_thread(
                         }
 
                         let iso = v8_isolate.as_mut().unwrap();
+                        iso.cancel_terminate_execution();
 
                         // Create execution context: Context::new on a snapshot-restored
                         // isolate gives a fresh clone of the snapshot's default context
@@ -1357,6 +1358,9 @@ fn session_thread(
                             code = 1;
                             exports = None;
                             error = None;
+                        }
+                        if terminated || cpu_budget_exceeded || wall_clock_timed_out {
+                            iso.cancel_terminate_execution();
                         }
 
                         // Send ExecutionResult

--- a/crates/v8-runtime/tests/embedded_runtime_session.rs
+++ b/crates/v8-runtime/tests/embedded_runtime_session.rs
@@ -491,12 +491,63 @@ fn assert_terminate_interrupts_sync_bridge_wait() -> io::Result<()> {
         "terminate() should interrupt a blocked sync bridge call instead of waiting for a host response"
     );
 
+    dispatch_execute(
+        runtime.as_ref(),
+        &session_id,
+        0,
+        "",
+        "globalThis.__afterExplicitTerminate = 'ok';",
+    )?;
+    assert_execution_ok(&receiver, &session_id);
+
     runtime.dispatch(RuntimeCommand::DestroySession {
         session_id: session_id.clone(),
     })?;
     runtime.unregister_session(&session_id);
     wait_until(
         "expected the terminated sync-bridge session to drain cleanly",
+        || runtime.session_count() == 0 && runtime.active_slot_count() == 0,
+    );
+    Ok(())
+}
+
+fn assert_cpu_terminated_session_can_execute_again() -> io::Result<()> {
+    let runtime = Arc::new(EmbeddedV8Runtime::new(Some(1))?);
+    let session_id = next_session_id();
+    let receiver =
+        register_and_create_session_with_cpu_time_limit(&runtime, &session_id, Some(25))?;
+
+    dispatch_execute(runtime.as_ref(), &session_id, 0, "", "while (true) {}")?;
+    let terminated = wait_for_execution_result(&receiver, &session_id);
+    assert!(
+        matches!(
+            terminated,
+            RuntimeEvent::ExecutionResult {
+                exit_code: 1,
+                ref error,
+                ..
+            } if error
+                .as_ref()
+                .is_some_and(|error| error.code == "ERR_SCRIPT_CPU_BUDGET_EXCEEDED")
+        ),
+        "CPU-budget termination should be attributed before reuse"
+    );
+
+    dispatch_execute(
+        runtime.as_ref(),
+        &session_id,
+        0,
+        "",
+        "globalThis.__afterCpuTerminate = 'ok';",
+    )?;
+    assert_execution_ok(&receiver, &session_id);
+
+    runtime.dispatch(RuntimeCommand::DestroySession {
+        session_id: session_id.clone(),
+    })?;
+    runtime.unregister_session(&session_id);
+    wait_until(
+        "expected CPU-terminated session to drain cleanly after reuse",
         || runtime.session_count() == 0 && runtime.active_slot_count() == 0,
     );
     Ok(())
@@ -514,5 +565,6 @@ fn embedded_runtime_session_consolidated_behaviors() -> io::Result<()> {
     assert_queued_work_waits_for_slot_release()?;
     assert_shared_runtime_handles_share_concurrency_quota()?;
     assert_terminate_interrupts_sync_bridge_wait()?;
+    assert_cpu_terminated_session_can_execute_again()?;
     Ok(())
 }

--- a/examples/docs/uc-code-mode/src/index.mts
+++ b/examples/docs/uc-code-mode/src/index.mts
@@ -23,12 +23,13 @@ const rt = await NodeRuntime.create({
         properties: { city: { type: "string" } },
         required: ["city"],
       },
-      handler: ({ city }: { city: string }) => {
-        const table: Record<string, { temp_f: number }> = {
-          "San Francisco": { temp_f: 61 },
-          Tokyo: { temp_f: 75 },
-        };
-        return table[city] ?? { temp_f: null };
+			handler: (input: unknown) => {
+				const { city } = input as { city: string };
+				const table: Record<string, { temp_f: number }> = {
+					"San Francisco": { temp_f: 61 },
+					Tokyo: { temp_f: 75 },
+				};
+				return table[city] ?? { temp_f: null };
       },
     },
     calculate: {
@@ -38,9 +39,10 @@ const rt = await NodeRuntime.create({
         properties: { expression: { type: "string" } },
         required: ["expression"],
       },
-      handler: ({ expression }: { expression: string }) => {
-        return { result: Number(eval(expression)) };
-      },
+			handler: (input: unknown) => {
+				const { expression } = input as { expression: string };
+				return { result: Number(eval(expression)) };
+			},
     },
   },
 });


### PR DESCRIPTION
## What changed

Implements the secure-exec security-review followups for the runtime layer:

- enforces WASM execution deadlines from the production poll paths, not only `wait()`
- defaults JS CPU, JS heap, and WASM memory to bounded values
- clears V8 sticky termination state before reused executions and after terminated runs
- adds regression coverage for WASM poll timeout, sidecar command timeout, runtime defaults, and reused-session execution after termination

## Why

The post-merge review found that several earlier protections were either default-off or not enforced on the sidecar production path. These gaps left CPU/memory runaways possible and could poison reused V8 isolates after termination.

## Validation

- `pnpm --dir /home/nathan/secure-exec-followups/packages/core build`
- `cargo test -p secure-exec-sidecar defaults_match_struct_default --test limits -- --exact --nocapture`
- `cargo test -p secure-exec-v8-runtime embedded_runtime_session_consolidated_behaviors --test embedded_runtime_session -- --exact --nocapture`
- `cargo test -p secure-exec-execution wasm_suite --test wasm -- --exact --nocapture`
- `cargo test -p secure-exec-sidecar service::tests::aab_wasm_command_timeout_is_enforced_by_sidecar_poll_path --test service -- --exact --nocapture`
- `cargo test -p secure-exec-execution javascript_v8_suite --test javascript_v8 -- --exact --nocapture`

## Notes

The TODO suggested one finding per PR. I grouped the three secure-exec runtime findings here because the tests and behavior overlap in the execution timeout/limit surface; split is possible if preferred.
