### PR TITLE
security: fix guest-reachable sandbox issues + remove over-defense against trusted config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,25 @@
 
 secure-exec is the fully virtualized runtime extracted from Agent OS. The kernel provides a POSIX-like VM with a virtual filesystem, process table, socket table, pipes, PTYs, permission policy, and managed language runtimes.
 
+## Trust Model
+
+secure-exec is a sandbox: it runs untrusted code safely for a trusted caller. Decide which side of this boundary something is on before judging whether it is a security bug. Three components:
+
+- **Client** (trusted, *except for anything it submits for execution*). The party that speaks the sidecar wire protocol. The client process and every value it sends are trusted: `CreateVmConfig`, mount descriptors and their plugin configs (host_dir paths, S3 endpoints/credentials, Google Drive, sandbox-agent), the permission policy, network allowlist, resource limits, env, and DNS overrides. Configuration is **not** an attack surface. The one thing from the client that is *not* trusted is the code/payload it asks to run, because that runs in the executor.
+- **Sidecar** (trusted; the TCB and the enforcement point). Brokers client requests and owns the kernel, VFS, mount/plugin registry, socket table, and permission policy. It is responsible for enforcing the boundary against the executor.
+- **Executor** — V8 isolates or WASM (untrusted; the adversary). Runs guest JS/Python/WASM plus any third-party/npm/agent-generated code. Assume everything here is actively hostile. How code reached the executor never makes it trusted.
+
+**The security boundary is sidecar ↔ executor.** The runtime must stop guest code in the executor from: escaping the kernel boundary (real host fs/network/process/memory), bypassing the *applied* permission policy/allowlist/limits, exhausting host resources beyond configured bounds, or reading another VM's state.
+
+**A defect that requires the client to supply a malicious config/endpoint/credential/policy is NOT a sandbox vulnerability** — the client is configuring its own VM and already controls the host. Treat such hardening as defense-in-depth, not as an escape, and do not add validation that only guards trusted client-provided configuration.
+
+Two corollaries that are easy to get wrong:
+
+- *Trusted policy, untrusted subject.* The permission policy and limits are trusted input, but the guest executor is the subject they bind. "Guest bypasses an applied permission / egress rule / resource cap" is in-scope and serious. Trusted = who sets the rule; untrusted = who is bound by it.
+- *Trusted mount, untrusted traffic.* A host-backed mount (host_dir, s3, …) comes from trusted config, so its existence/target/credentials are not attack surface, but the guest drives I/O through it, so confining those guest operations to the mount root (symlink / `..` / TOCTOU / path-aliasing escapes) is in-scope.
+
+**Transport scope.** The wire protocol is same-version lockstep and single-client over stdio (one trusted client per sidecar process). There is no second, mutually-distrusting client, so wire-level authn/authz-between-clients and VM-to-VM access via forged connection ids are out of scope until a multi-client transport exists.
+
 ## Runtime Invariants
 
 - All guest code must execute inside the kernel isolation boundary with zero host escapes.

--- a/crates/kernel/src/mount_table.rs
+++ b/crates/kernel/src/mount_table.rs
@@ -820,10 +820,12 @@ impl MountTable {
             if normalized == mount.path {
                 return Ok((index, String::from("/")));
             }
-            if normalized.starts_with(&format!("{}/", mount.path)) {
-                let suffix = normalized
-                    .trim_start_matches(&mount.path)
-                    .trim_start_matches('/');
+            let mount_prefix = format!("{}/", mount.path);
+            if let Some(suffix) = normalized.strip_prefix(&mount_prefix) {
+                // Strip exactly the mount prefix once. `trim_start_matches` would
+                // strip every leading repetition of `mount.path`, so a path like
+                // `/data/data/file` under mount `/data` would alias to `/file`
+                // instead of `/data/file`, routing reads/writes to the wrong file.
                 return Ok((index, format!("/{suffix}")));
             }
         }

--- a/crates/kernel/src/overlay_fs.rs
+++ b/crates/kernel/src/overlay_fs.rs
@@ -164,7 +164,7 @@ impl OverlayFileSystem {
             if should_follow {
                 if let Ok(stat) = self.merged_lstat(&candidate) {
                     if stat.is_symbolic_link {
-                        let target = self.read_link(&candidate)?;
+                        let target = self.read_link_inner(&candidate)?;
                         let target_path = if target.starts_with('/') {
                             Self::normalized(&target)
                         } else {
@@ -243,7 +243,7 @@ impl OverlayFileSystem {
                     paths.push(current.clone());
                 }
 
-                let target = self.read_link(&current)?;
+                let target = self.read_link_inner(&current)?;
                 let target_path = if target.starts_with('/') {
                     Self::normalized(&target)
                 } else {
@@ -297,6 +297,33 @@ impl OverlayFileSystem {
         let normalized = Self::normalized(path);
         normalized == OVERLAY_METADATA_ROOT
             || normalized.starts_with(&(String::from(OVERLAY_METADATA_ROOT) + "/"))
+    }
+
+    /// Returns true if `path`, or the location it resolves to through symlinks,
+    /// lands in the reserved overlay metadata namespace.
+    ///
+    /// The lexical [`is_internal_metadata_path`] check alone is bypassable: the
+    /// underlying `MemoryFileSystem` follows symlinks, so a guest-created symlink
+    /// whose resolved target enters `/.secure-exec-overlay` (directly, or via a
+    /// symlink to an ancestor such as `/`) would slip past a purely lexical guard
+    /// and let the guest read or tamper with whiteout/opaque markers (e.g.
+    /// resurrecting a deleted lower-layer file). Resolving before the check
+    /// closes that hole while leaving ordinary symlinks unaffected.
+    fn touches_internal_metadata(&self, path: &str) -> bool {
+        if Self::is_internal_metadata_path(path) {
+            return true;
+        }
+        if let Ok(resolved) = self.resolve_merged_path(path, true, 0) {
+            if Self::is_internal_metadata_path(&resolved) {
+                return true;
+            }
+        }
+        if let Ok(resolved) = self.resolved_destination_path(path) {
+            if Self::is_internal_metadata_path(&resolved) {
+                return true;
+            }
+        }
+        false
     }
 
     fn hidden_root_entry_name() -> &'static str {
@@ -521,7 +548,7 @@ impl OverlayFileSystem {
             let stat = self.lstat(&current_path)?;
             if !self.has_entry_in_upper(&current_path) {
                 let bytes = if stat.is_symbolic_link {
-                    self.read_link(&current_path)?.len() as u64
+                    self.read_link_inner(&current_path)?.len() as u64
                 } else if stat.is_directory {
                     0
                 } else {
@@ -554,7 +581,7 @@ impl OverlayFileSystem {
 
         let stat = self.merged_lstat(path)?;
         let bytes = if stat.is_symbolic_link {
-            self.read_link(path)?.len() as u64
+            self.read_link_inner(path)?.len() as u64
         } else if stat.is_directory {
             0
         } else {
@@ -801,6 +828,31 @@ impl OverlayFileSystem {
             .ok_or_else(|| Self::entry_not_found(path))
     }
 
+    /// `read_link` body without the resolving metadata guard, for use by the
+    /// internal symlink-resolution helpers (`resolve_merged_path` and friends).
+    /// The public `read_link` wraps this with `touches_internal_metadata`;
+    /// resolution must not call back into that wrapper or it would recurse on a
+    /// symlink that points at itself's resolution path.
+    fn read_link_inner(&self, path: &str) -> VfsResult<String> {
+        if Self::is_internal_metadata_path(path) {
+            return Err(Self::entry_not_found(path));
+        }
+        if self.is_whited_out(path) {
+            return Err(Self::entry_not_found(path));
+        }
+        if self.has_entry_in_upper(path) {
+            return self
+                .upper
+                .as_ref()
+                .expect("upper must exist when path exists")
+                .read_link(path);
+        }
+        let Some((index, _)) = self.find_lower_by_entry(path) else {
+            return Err(Self::entry_not_found(path));
+        };
+        self.lowers[index].read_link(path)
+    }
+
     fn ensure_ancestor_directories_in_upper(&mut self, path: &str) -> VfsResult<()> {
         if Self::is_internal_metadata_path(path) {
             return Err(VfsError::permission_denied("mkdir", path));
@@ -934,7 +986,7 @@ impl OverlayFileSystem {
                 entries.push(OverlaySnapshotEntry {
                     path: current_path.clone(),
                     stat,
-                    kind: OverlaySnapshotKind::Symlink(self.read_link(&current_path)?),
+                    kind: OverlaySnapshotKind::Symlink(self.read_link_inner(&current_path)?),
                 });
                 continue;
             }
@@ -1148,7 +1200,7 @@ fn sync_upper_root_metadata(upper: &mut MemoryFileSystem, lowers: &[MemoryFileSy
 
 impl VirtualFileSystem for OverlayFileSystem {
     fn read_file(&mut self, path: &str) -> VfsResult<Vec<u8>> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(Self::entry_not_found(path));
         }
         if self.is_whited_out(path) {
@@ -1168,7 +1220,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn read_dir(&mut self, path: &str) -> VfsResult<Vec<String>> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(Self::directory_not_found(path));
         }
         if self.is_whited_out(path) {
@@ -1232,7 +1284,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn read_dir_limited(&mut self, path: &str, max_entries: usize) -> VfsResult<Vec<String>> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(Self::directory_not_found(path));
         }
         if self.is_whited_out(path) {
@@ -1331,7 +1383,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn read_dir_with_types(&mut self, path: &str) -> VfsResult<Vec<VirtualDirEntry>> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(Self::directory_not_found(path));
         }
         if self.is_whited_out(path) {
@@ -1407,7 +1459,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn write_file(&mut self, path: &str, content: impl Into<Vec<u8>>) -> VfsResult<()> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(VfsError::permission_denied("open", path));
         }
         self.clear_path_metadata(path)?;
@@ -1420,7 +1472,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn create_file_exclusive(&mut self, path: &str, content: impl Into<Vec<u8>>) -> VfsResult<()> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(VfsError::permission_denied("open", path));
         }
         self.clear_path_metadata(path)?;
@@ -1433,7 +1485,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn append_file(&mut self, path: &str, content: impl Into<Vec<u8>>) -> VfsResult<u64> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(VfsError::permission_denied("open", path));
         }
         self.clear_path_metadata(path)?;
@@ -1446,7 +1498,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn create_dir(&mut self, path: &str) -> VfsResult<()> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(VfsError::permission_denied("mkdir", path));
         }
         self.clear_path_metadata(path)?;
@@ -1458,7 +1510,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn mkdir(&mut self, path: &str, recursive: bool) -> VfsResult<()> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(VfsError::permission_denied("mkdir", path));
         }
         self.clear_path_metadata(path)?;
@@ -1474,14 +1526,14 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn exists(&self, path: &str) -> bool {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return false;
         }
         self.path_exists_in_merged_view(path)
     }
 
     fn stat(&mut self, path: &str) -> VfsResult<VirtualStat> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(Self::entry_not_found(path));
         }
         if self.is_whited_out(path) {
@@ -1501,7 +1553,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn remove_file(&mut self, path: &str) -> VfsResult<()> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(VfsError::permission_denied("unlink", path));
         }
         if self.is_whited_out(path) {
@@ -1524,7 +1576,7 @@ impl VirtualFileSystem for OverlayFileSystem {
 
     fn remove_dir(&mut self, path: &str) -> VfsResult<()> {
         let normalized = Self::normalized(path);
-        if Self::is_internal_metadata_path(&normalized) {
+        if self.touches_internal_metadata(&normalized) {
             return Err(VfsError::permission_denied("rmdir", path));
         }
         if normalized == "/" {
@@ -1564,8 +1616,8 @@ impl VirtualFileSystem for OverlayFileSystem {
     fn rename(&mut self, old_path: &str, new_path: &str) -> VfsResult<()> {
         let old_normalized = Self::normalized(old_path);
         let new_normalized = Self::normalized(new_path);
-        if Self::is_internal_metadata_path(&old_normalized)
-            || Self::is_internal_metadata_path(&new_normalized)
+        if self.touches_internal_metadata(&old_normalized)
+            || self.touches_internal_metadata(&new_normalized)
         {
             return Err(VfsError::permission_denied("rename", old_path));
         }
@@ -1633,7 +1685,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn realpath(&self, path: &str) -> VfsResult<String> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(Self::entry_not_found(path));
         }
         if self.is_whited_out(path) {
@@ -1653,7 +1705,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn symlink(&mut self, target: &str, link_path: &str) -> VfsResult<()> {
-        if Self::is_internal_metadata_path(link_path) {
+        if self.touches_internal_metadata(link_path) {
             return Err(VfsError::permission_denied("symlink", link_path));
         }
         self.clear_path_metadata(link_path)?;
@@ -1662,7 +1714,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn read_link(&self, path: &str) -> VfsResult<String> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(Self::entry_not_found(path));
         }
         if self.is_whited_out(path) {
@@ -1682,7 +1734,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn lstat(&self, path: &str) -> VfsResult<VirtualStat> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(Self::entry_not_found(path));
         }
         if self.is_whited_out(path) {
@@ -1701,7 +1753,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn link(&mut self, old_path: &str, new_path: &str) -> VfsResult<()> {
-        if Self::is_internal_metadata_path(old_path) || Self::is_internal_metadata_path(new_path) {
+        if self.touches_internal_metadata(old_path) || self.touches_internal_metadata(new_path) {
             return Err(VfsError::permission_denied("link", new_path));
         }
         self.clear_path_metadata(new_path)?;
@@ -1711,7 +1763,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn chmod(&mut self, path: &str, mode: u32) -> VfsResult<()> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(VfsError::permission_denied("chmod", path));
         }
         if self.is_whited_out(path) {
@@ -1724,7 +1776,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn chown(&mut self, path: &str, uid: u32, gid: u32) -> VfsResult<()> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(VfsError::permission_denied("chown", path));
         }
         if self.is_whited_out(path) {
@@ -1737,7 +1789,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn utimes(&mut self, path: &str, atime_ms: u64, mtime_ms: u64) -> VfsResult<()> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(VfsError::permission_denied("utime", path));
         }
         if self.is_whited_out(path) {
@@ -1756,7 +1808,7 @@ impl VirtualFileSystem for OverlayFileSystem {
         mtime: VirtualUtimeSpec,
         follow_symlinks: bool,
     ) -> VfsResult<()> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(VfsError::permission_denied("utime", path));
         }
         if self.is_whited_out(path) {
@@ -1770,7 +1822,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn truncate(&mut self, path: &str, length: u64) -> VfsResult<()> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(VfsError::permission_denied("truncate", path));
         }
         if self.is_whited_out(path) {
@@ -1783,7 +1835,7 @@ impl VirtualFileSystem for OverlayFileSystem {
     }
 
     fn pread(&mut self, path: &str, offset: u64, length: usize) -> VfsResult<Vec<u8>> {
-        if Self::is_internal_metadata_path(path) {
+        if self.touches_internal_metadata(path) {
             return Err(Self::entry_not_found(path));
         }
         if self.is_whited_out(path) {
@@ -1807,6 +1859,61 @@ impl VirtualFileSystem for OverlayFileSystem {
 mod tests {
     use super::{OverlayFileSystem, OverlayMode};
     use crate::vfs::{MemoryFileSystem, VfsResult, VirtualFileSystem};
+
+    #[test]
+    fn symlink_into_metadata_namespace_cannot_read_or_resurrect_whiteouts() {
+        let mut lower = MemoryFileSystem::new();
+        lower.mkdir("/data", true).expect("create lower directory");
+        lower
+            .write_file("/data/secret.txt", b"secret".to_vec())
+            .expect("seed lower file");
+
+        let mut overlay =
+            OverlayFileSystem::with_upper(vec![lower], MemoryFileSystem::new());
+
+        // Delete a lower-layer file: a whiteout marker is written under the
+        // reserved metadata root and the file disappears from the merged view.
+        overlay
+            .remove_file("/data/secret.txt")
+            .expect("whiteout lower file");
+        assert!(!overlay.exists("/data/secret.txt"));
+
+        // A guest symlink whose target is the metadata root must not become a
+        // window into the reserved namespace.
+        overlay
+            .symlink("/.secure-exec-overlay/whiteouts", "/escape")
+            .expect("creating the symlink itself is allowed");
+
+        // Listing through the symlink must be denied, not disclose markers.
+        assert!(
+            overlay.read_dir("/escape").is_err(),
+            "listing the metadata namespace via a symlink must be denied"
+        );
+
+        // Removing the whiteout marker through the symlink must be denied, so the
+        // deleted lower-layer file cannot be resurrected.
+        assert!(
+            overlay
+                .remove_file("/escape/anything")
+                .is_err(),
+            "tampering with metadata via a symlink must be denied"
+        );
+        assert!(
+            !overlay.exists("/data/secret.txt"),
+            "deleted lower-layer file must stay deleted"
+        );
+
+        // The same bypass via a symlink to an ancestor (e.g. `/`) is also closed.
+        overlay
+            .symlink("/", "/rootlink")
+            .expect("symlink to root is allowed");
+        assert!(
+            overlay
+                .read_dir("/rootlink/.secure-exec-overlay/whiteouts")
+                .is_err(),
+            "metadata must be unreachable via an ancestor symlink too"
+        );
+    }
 
     #[test]
     fn whiteouts_persist_when_overlay_reopens_with_same_upper() {

--- a/crates/kernel/src/permissions.rs
+++ b/crates/kernel/src/permissions.rs
@@ -586,12 +586,23 @@ impl<F: VirtualFileSystem> VirtualFileSystem for PermissionedFileSystem<F> {
     }
 
     fn read_link(&self, path: &str) -> VfsResult<String> {
-        self.check(FsOperation::ReadLink, &crate::vfs::normalize_path(path))?;
+        // Authorize the parent-symlink-resolved path (without following the
+        // final component, matching `lstat`/`readlink` semantics). A lexical
+        // check would let a symlink whose parent resolves into a denied prefix
+        // disclose link targets of permission-denied paths.
+        validate_path(path)?;
+        let subject = self.resolved_destination_path(path)?;
+        self.check(FsOperation::ReadLink, &subject)?;
         self.inner.read_link(path)
     }
 
     fn lstat(&self, path: &str) -> VfsResult<VirtualStat> {
-        self.check(FsOperation::Stat, &crate::vfs::normalize_path(path))?;
+        // Authorize the parent-symlink-resolved path (see `read_link`); a
+        // lexical check would leak metadata (size/mode/mtime/inode) of files
+        // under a permission-denied prefix reached via a symlinked parent.
+        validate_path(path)?;
+        let subject = self.resolved_destination_path(path)?;
+        self.check(FsOperation::Stat, &subject)?;
         self.inner.lstat(path)
     }
 

--- a/crates/kernel/src/pty.rs
+++ b/crates/kernel/src/pty.rs
@@ -979,6 +979,15 @@ fn deliver_input(
             if data.len() <= waiter.length {
                 waiter.result = Some(Some(data.to_vec()));
             } else {
+                // The waiter consumes `waiter.length` bytes directly; only the
+                // tail is buffered, so the buffer cap must be enforced on the
+                // tail. Otherwise a single large write past a pending reader
+                // bypasses MAX_PTY_BUFFER_BYTES entirely.
+                let tail_len = data.len() - waiter.length;
+                if tail_len > available_capacity(&pty.input_buffer) {
+                    pty.waiting_input_reads.push_front(waiter_id);
+                    return Err(PtyError::would_block("PTY input buffer full"));
+                }
                 let (head, tail) = data.split_at(waiter.length);
                 waiter.result = Some(Some(head.to_vec()));
                 pty.input_buffer.push_front(tail.to_vec());
@@ -1006,6 +1015,17 @@ fn deliver_output(
             if data.len() <= waiter.length {
                 waiter.result = Some(Some(data.to_vec()));
             } else {
+                // Enforce the buffer cap on the tail (see deliver_input).
+                let tail_len = data.len() - waiter.length;
+                if tail_len > available_capacity(&pty.output_buffer) {
+                    pty.waiting_output_reads.push_front(waiter_id);
+                    let message = if echo {
+                        "PTY output buffer full (echo backpressure)"
+                    } else {
+                        "PTY output buffer full"
+                    };
+                    return Err(PtyError::would_block(message));
+                }
                 let (head, tail) = data.split_at(waiter.length);
                 waiter.result = Some(Some(head.to_vec()));
                 pty.output_buffer.push_front(tail.to_vec());

--- a/crates/kernel/tests/mount_table.rs
+++ b/crates/kernel/tests/mount_table.rs
@@ -332,3 +332,45 @@ fn mount_table_unmount_succeeds_after_children_are_removed() {
     table.unmount("/a/b").expect("unmount child first");
     table.unmount("/a").expect("unmount parent after child");
 }
+
+#[test]
+fn mount_table_does_not_alias_paths_that_repeat_the_mount_segment() {
+    // Regression: `resolve_index` previously stripped the mount prefix with
+    // `trim_start_matches`, which removes *every* leading repetition. For a
+    // mount `/data`, `/data/database.sqlite` was mangled to `/base.sqlite`
+    // (because `/database.sqlite` still starts with `/data`), so a read of one
+    // file silently returned a different file within the mount.
+    let mut backing = MemoryFileSystem::new();
+    backing
+        .write_file("/database.sqlite", b"REAL".to_vec())
+        .expect("seed real file");
+    backing
+        .write_file("/base.sqlite", b"DECOY".to_vec())
+        .expect("seed decoy file");
+
+    let mut table = MountTable::new(MemoryFileSystem::new());
+    table
+        .mount("/data", backing, MountOptions::new("memory"))
+        .expect("mount memory filesystem");
+
+    assert_eq!(
+        table.read_file("/data/database.sqlite").expect("read file"),
+        b"REAL".to_vec(),
+        "path must map to the file the caller named, not an aliased one"
+    );
+
+    // A genuinely nested directory named like the mount must also resolve right.
+    let mut nested = MemoryFileSystem::new();
+    nested.mkdir("/data", true).expect("nested dir");
+    nested
+        .write_file("/data/file.txt", b"NESTED".to_vec())
+        .expect("seed nested file");
+    let mut table = MountTable::new(MemoryFileSystem::new());
+    table
+        .mount("/data", nested, MountOptions::new("memory"))
+        .expect("mount nested filesystem");
+    assert_eq!(
+        table.read_file("/data/data/file.txt").expect("read nested"),
+        b"NESTED".to_vec()
+    );
+}

--- a/crates/sidecar/src/plugins/google_drive.rs
+++ b/crates/sidecar/src/plugins/google_drive.rs
@@ -24,8 +24,6 @@ const LEGACY_AGENT_OS_MANIFEST_FORMAT: &str = "agent_os_google_drive_filesystem_
 const DRIVE_SCOPE: &str = "https://www.googleapis.com/auth/drive.file";
 const DEFAULT_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
 const DEFAULT_API_BASE_URL: &str = "https://www.googleapis.com";
-const GOOGLE_TOKEN_HOSTS: &[&str] = &["oauth2.googleapis.com"];
-const GOOGLE_API_BASE_HOSTS: &[&str] = &["www.googleapis.com"];
 const TOKEN_REFRESH_SKEW_SECONDS: u64 = 60;
 const MAX_PERSISTED_MANIFEST_BYTES: usize = 64 * 1024 * 1024;
 const MAX_PERSISTED_MANIFEST_FILE_BYTES: u64 = 1024 * 1024 * 1024;
@@ -282,7 +280,7 @@ impl GoogleDriveObjectStore {
         api_base_url: String,
     ) -> Result<Self, PluginError> {
         let api_base_url =
-            validate_google_drive_url(&api_base_url, "apiBaseUrl", GOOGLE_API_BASE_HOSTS, false)?;
+            validate_google_drive_url(&api_base_url, "apiBaseUrl", false)?;
 
         Ok(Self {
             auth: GoogleServiceAccountAuth::new(credentials, token_url)?,
@@ -545,7 +543,7 @@ impl GoogleServiceAccountAuth {
                 ))
             })?;
         let token_url =
-            validate_google_drive_url(&token_url, "tokenUrl", GOOGLE_TOKEN_HOSTS, true)?;
+            validate_google_drive_url(&token_url, "tokenUrl", true)?;
 
         Ok(Self {
             client_email: credentials.client_email,
@@ -986,9 +984,15 @@ fn normalize_base_url(raw: &str) -> Option<String> {
 fn validate_google_drive_url(
     raw: &str,
     field_name: &str,
-    allowed_hosts: &[&str],
     allow_path: bool,
 ) -> Result<String, PluginError> {
+    // tokenUrl / apiBaseUrl come only from the trusted mount config, never from
+    // untrusted guest code, so a strict host allowlist (SSRF hardening against
+    // trusted input) is dropped (see root CLAUDE.md). We keep well-formedness
+    // plus the credential-leak guards: these endpoints receive a signed
+    // service-account JWT and an OAuth bearer token, so https is required and
+    // embedded credentials / query / fragment are rejected to avoid leaking
+    // those secrets to an unintended host on a config typo.
     let normalized = normalize_base_url(raw).ok_or_else(|| {
         PluginError::invalid_input(format!("google_drive mount requires a valid {field_name}"))
     })?;
@@ -1012,11 +1016,6 @@ fn validate_google_drive_url(
             "google_drive mount {field_name} must include a host"
         )));
     }
-    if url.port().is_some() {
-        return Err(PluginError::invalid_input(format!(
-            "google_drive mount {field_name} must not override the default port"
-        )));
-    }
     if !url.username().is_empty() || url.password().is_some() {
         return Err(PluginError::invalid_input(format!(
             "google_drive mount {field_name} must not include user credentials"
@@ -1030,14 +1029,6 @@ fn validate_google_drive_url(
     if !allow_path && url.path() != "/" {
         return Err(PluginError::invalid_input(format!(
             "google_drive mount {field_name} must not include a path"
-        )));
-    }
-
-    let host = url.host_str().expect("host checked above");
-    if !allowed_hosts.iter().any(|candidate| candidate == &host) {
-        return Err(PluginError::invalid_input(format!(
-            "google_drive mount {field_name} host must be one of: {}",
-            allowed_hosts.join(", ")
         )));
     }
 

--- a/crates/sidecar/src/plugins/s3.rs
+++ b/crates/sidecar/src/plugins/s3.rs
@@ -17,7 +17,6 @@ use secure_exec_kernel::vfs::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
-use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use tokio::runtime::Runtime;
 use url::Url;
 
@@ -582,13 +581,11 @@ impl S3ObjectStore {
 }
 
 fn validate_s3_endpoint(raw: &str) -> Result<String, PluginError> {
-    validate_s3_endpoint_with_resolver(raw, resolve_s3_endpoint_host)
-}
-
-fn validate_s3_endpoint_with_resolver(
-    raw: &str,
-    resolve_host: impl FnOnce(&str, u16) -> std::io::Result<Vec<SocketAddr>>,
-) -> Result<String, PluginError> {
+    // The endpoint comes only from the trusted mount config (the client picks
+    // its own S3 host); untrusted guest code can never set it, so it is not an
+    // SSRF attack surface under the trust model (see root CLAUDE.md). Validate
+    // only well-formedness, so a misconfigured endpoint fails at mount time with
+    // a clear error instead of an opaque AWS SDK failure on the first object op.
     let normalized = raw.trim().trim_end_matches('/').to_owned();
     if normalized.is_empty() {
         return Err(PluginError::invalid_input(
@@ -599,144 +596,18 @@ fn validate_s3_endpoint_with_resolver(
     let url = Url::parse(&normalized).map_err(|error| {
         PluginError::invalid_input(format!("s3 mount endpoint is not a valid URL: {error}"))
     })?;
-    let host = url
-        .host_str()
-        .ok_or_else(|| PluginError::invalid_input("s3 mount endpoint must include a host"))?;
-    let host_for_address = host
-        .strip_prefix('[')
-        .and_then(|host| host.strip_suffix(']'))
-        .unwrap_or(host);
-    let scheme = url.scheme();
-    let port = match scheme {
-        "http" => url.port().unwrap_or(80),
-        "https" => url.port().unwrap_or(443),
-        _ => {
-            return Err(PluginError::invalid_input(
-                "s3 mount endpoint must use http or https",
-            ));
-        }
-    };
-
-    if is_allowed_test_endpoint_host(host_for_address) {
-        return Ok(normalized);
-    }
-
-    if host_for_address.eq_ignore_ascii_case("localhost") {
+    if url.host_str().is_none() {
         return Err(PluginError::invalid_input(
-            "s3 mount endpoint must not target localhost",
+            "s3 mount endpoint must include a host",
+        ));
+    }
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(PluginError::invalid_input(
+            "s3 mount endpoint must use http or https",
         ));
     }
 
-    match host_for_address.parse::<IpAddr>() {
-        Ok(ip) => {
-            if is_disallowed_s3_endpoint_ip(ip) {
-                return Err(PluginError::invalid_input(format!(
-                    "s3 mount endpoint must not target a private or local/non-global IP address ({host})"
-                )));
-            }
-        }
-        Err(_) => {
-            if scheme != "https" {
-                return Err(PluginError::invalid_input(
-                    "s3 mount hostname endpoints must use https",
-                ));
-            }
-            let addresses = resolve_host(host_for_address, port).map_err(|error| {
-                PluginError::invalid_input(format!(
-                    "could not resolve s3 mount endpoint host '{host}': {error}"
-                ))
-            })?;
-            if addresses.is_empty() {
-                return Err(PluginError::invalid_input(format!(
-                    "could not resolve s3 mount endpoint host '{host}'"
-                )));
-            }
-            for address in addresses {
-                if is_disallowed_s3_endpoint_ip(address.ip()) {
-                    return Err(PluginError::invalid_input(format!(
-                        "s3 mount endpoint host '{host}' resolved to a private or local/non-global IP address ({})",
-                        address.ip()
-                    )));
-                }
-            }
-        }
-    }
-
     Ok(normalized)
-}
-
-fn resolve_s3_endpoint_host(host: &str, port: u16) -> std::io::Result<Vec<SocketAddr>> {
-    (host, port)
-        .to_socket_addrs()
-        .map(|addresses| addresses.collect())
-}
-
-fn is_disallowed_s3_endpoint_ip(ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(ip) => {
-            let [first, second, third, fourth] = ip.octets();
-            ip.is_private()
-                || ip.is_loopback()
-                || ip.is_link_local()
-                || ip.is_multicast()
-                || ip.is_unspecified()
-                || first == 0
-                || (first == 100 && (second & 0b1100_0000) == 64)
-                || (first == 192
-                    && second == 0
-                    && third == 0
-                    && (fourth <= 8 || fourth == 170 || fourth == 171))
-                || (first == 192 && second == 0 && third == 2)
-                || (first == 192 && second == 88 && third == 99 && fourth == 2)
-                || (first == 198 && (second == 18 || second == 19))
-                || (first == 198 && second == 51 && third == 100)
-                || (first == 203 && second == 0 && third == 113)
-                || first >= 240
-                || (first == 255 && second == 255 && third == 255 && fourth == 255)
-        }
-        IpAddr::V6(ip) => {
-            if let Some(mapped) = ip.to_ipv4_mapped() {
-                return is_disallowed_s3_endpoint_ip(IpAddr::V4(mapped));
-            }
-
-            let segments = ip.segments();
-            ip.is_loopback()
-                || ip.is_unique_local()
-                || ip.is_unicast_link_local()
-                || ip.is_multicast()
-                || ip.is_unspecified()
-                || (segments[0] & 0xffc0) == 0xfec0
-                || (segments[0..6] == [0, 0, 0, 0, 0, 0])
-                || (segments[0] == 0x0064 && segments[1] == 0xff9b && segments[2] == 0x0001)
-                || (segments[0] == 0x0100
-                    && segments[1] == 0
-                    && segments[2] == 0
-                    && (segments[3] == 0 || segments[3] == 1))
-                || (segments[0] == 0x2001 && segments[1] == 0)
-                || (segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0)
-                || (segments[0] == 0x2001 && (segments[1] & 0xfff0) == 0x0010)
-                || (segments[0] == 0x2001 && segments[1] == 0x0db8)
-                || (segments[0] == 0x3fff && (segments[1] & 0xf000) == 0)
-                || segments[0] == 0x5f00
-                || segments[0] == 0x2002
-        }
-    }
-}
-
-fn is_allowed_test_endpoint_host(host: &str) -> bool {
-    if std::env::var_os("AGENT_OS_ALLOW_LOCAL_S3_ENDPOINTS").is_some() {
-        return matches!(host, "127.0.0.1" | "localhost" | "::1");
-    }
-
-    #[cfg(test)]
-    {
-        matches!(host, "127.0.0.1" | "localhost" | "::1")
-    }
-    #[cfg(not(test))]
-    {
-        let _ = host;
-        false
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/sidecar/src/plugins/sandbox_agent.rs
+++ b/crates/sidecar/src/plugins/sandbox_agent.rs
@@ -10,7 +10,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::io::Read;
-use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+use std::net::IpAddr;
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use url::Url;
@@ -1117,13 +1117,13 @@ fn response_into_bytes_limited(
 }
 
 fn validate_sandbox_agent_base_url(raw: &str) -> Result<String, PluginError> {
-    validate_sandbox_agent_base_url_with_resolver(raw, resolve_sandbox_agent_base_url_host)
-}
-
-fn validate_sandbox_agent_base_url_with_resolver(
-    raw: &str,
-    resolve_host: impl FnOnce(&str, u16) -> std::io::Result<Vec<SocketAddr>>,
-) -> Result<String, PluginError> {
+    // The baseUrl comes only from the trusted mount config, never from untrusted
+    // guest code, so it is not an SSRF surface (see root CLAUDE.md): the private
+    // -IP denylist and DNS re-resolution are dropped. We still validate
+    // well-formedness (clear errors + the trailing-slash trim that request
+    // building relies on) and still require https for non-local hosts, because
+    // the client's bearer token is sent in the Authorization header and must not
+    // traverse plaintext http.
     let normalized = raw.trim().trim_end_matches('/').to_owned();
     if normalized.is_empty() {
         return Err(PluginError::invalid_input(
@@ -1150,122 +1150,24 @@ fn validate_sandbox_agent_base_url_with_resolver(
     }
 
     let scheme = url.scheme();
-    let port = match scheme {
-        "http" => url.port().unwrap_or(80),
-        "https" => url.port().unwrap_or(443),
-        _ => {
-            return Err(PluginError::invalid_input(
-                "sandbox_agent mount baseUrl must use http or https",
-            ));
-        }
-    };
-
-    if host_for_address.eq_ignore_ascii_case("localhost") {
-        return Ok(normalized);
+    if !matches!(scheme, "http" | "https") {
+        return Err(PluginError::invalid_input(
+            "sandbox_agent mount baseUrl must use http or https",
+        ));
     }
 
-    match host_for_address.parse::<IpAddr>() {
-        Ok(ip) => {
-            if ip.is_loopback() {
-                return Ok(normalized);
-            }
-            if is_disallowed_sandbox_agent_base_url_ip(ip) {
-                return Err(PluginError::invalid_input(format!(
-                    "sandbox_agent mount baseUrl must not target a private or local/non-global IP address ({host})"
-                )));
-            }
-            if scheme != "https" {
-                return Err(PluginError::invalid_input(
-                    "sandbox_agent mount non-local baseUrl must use https",
-                ));
-            }
-        }
-        Err(_) => {
-            if scheme != "https" {
-                return Err(PluginError::invalid_input(
-                    "sandbox_agent mount hostname baseUrl must use https unless it targets localhost",
-                ));
-            }
-            let addresses = resolve_host(host_for_address, port).map_err(|error| {
-                PluginError::invalid_input(format!(
-                    "could not resolve sandbox_agent mount baseUrl host '{host}': {error}"
-                ))
-            })?;
-            if addresses.is_empty() {
-                return Err(PluginError::invalid_input(format!(
-                    "could not resolve sandbox_agent mount baseUrl host '{host}'"
-                )));
-            }
-            for address in addresses {
-                if is_disallowed_sandbox_agent_base_url_ip(address.ip()) {
-                    return Err(PluginError::invalid_input(format!(
-                        "sandbox_agent mount baseUrl host '{host}' resolved to a private or local/non-global IP address ({})",
-                        address.ip()
-                    )));
-                }
-            }
-        }
+    let is_local = host_for_address.eq_ignore_ascii_case("localhost")
+        || host_for_address
+            .parse::<IpAddr>()
+            .map(|ip| ip.is_loopback())
+            .unwrap_or(false);
+    if scheme != "https" && !is_local {
+        return Err(PluginError::invalid_input(
+            "sandbox_agent mount baseUrl must use https unless it targets localhost",
+        ));
     }
 
     Ok(normalized)
-}
-
-fn resolve_sandbox_agent_base_url_host(host: &str, port: u16) -> std::io::Result<Vec<SocketAddr>> {
-    (host, port)
-        .to_socket_addrs()
-        .map(|addresses| addresses.collect())
-}
-
-fn is_disallowed_sandbox_agent_base_url_ip(ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(ip) => {
-            let [first, second, third, fourth] = ip.octets();
-            ip.is_private()
-                || ip.is_loopback()
-                || ip.is_link_local()
-                || ip.is_multicast()
-                || ip.is_unspecified()
-                || first == 0
-                || (first == 100 && (second & 0b1100_0000) == 64)
-                || (first == 192
-                    && second == 0
-                    && third == 0
-                    && (fourth <= 8 || fourth == 170 || fourth == 171))
-                || (first == 192 && second == 0 && third == 2)
-                || (first == 192 && second == 88 && third == 99 && fourth == 2)
-                || (first == 198 && (second == 18 || second == 19))
-                || (first == 198 && second == 51 && third == 100)
-                || (first == 203 && second == 0 && third == 113)
-                || first >= 240
-                || (first == 255 && second == 255 && third == 255 && fourth == 255)
-        }
-        IpAddr::V6(ip) => {
-            if let Some(mapped) = ip.to_ipv4_mapped() {
-                return is_disallowed_sandbox_agent_base_url_ip(IpAddr::V4(mapped));
-            }
-
-            let segments = ip.segments();
-            ip.is_loopback()
-                || ip.is_unique_local()
-                || ip.is_unicast_link_local()
-                || ip.is_multicast()
-                || ip.is_unspecified()
-                || (segments[0] & 0xffc0) == 0xfec0
-                || (segments[0..6] == [0, 0, 0, 0, 0, 0])
-                || (segments[0] == 0x0064 && segments[1] == 0xff9b && segments[2] == 0x0001)
-                || (segments[0] == 0x0100
-                    && segments[1] == 0
-                    && segments[2] == 0
-                    && (segments[3] == 0 || segments[3] == 1))
-                || (segments[0] == 0x2001 && segments[1] == 0)
-                || (segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0)
-                || (segments[0] == 0x2001 && (segments[1] & 0xfff0) == 0x0010)
-                || (segments[0] == 0x2001 && segments[1] == 0x0db8)
-                || (segments[0] == 0x3fff && (segments[1] & 0xf000) == 0)
-                || segments[0] == 0x5f00
-                || segments[0] == 0x2002
-        }
-    }
 }
 
 fn sandbox_client_error_to_vfs(

--- a/crates/sidecar/tests/google_drive.rs
+++ b/crates/sidecar/tests/google_drive.rs
@@ -50,38 +50,34 @@ oFnGY0OFksX/ye0/XGpy2SFxYRwGU98HPYeBvAQQrVjdkzfy7BmXQQ==\n\
         }
 
         #[test]
-        fn google_drive_plugin_rejects_untrusted_token_hosts() {
-            let server = MockGoogleDriveServer::start();
-            let mut config = test_config(&server, "reject-token-host");
-            config.token_url = Some(String::from("https://evil.example/token"));
+        fn google_drive_url_drops_host_allowlist_but_keeps_credential_guards() {
+            // tokenUrl/apiBaseUrl are trusted mount config, so the strict host
+            // allowlist (SSRF hardening over trusted input) is gone: an arbitrary
+            // https host is now accepted.
+            validate_google_drive_url("https://drive.example.com", "apiBaseUrl", false)
+                .expect("arbitrary https host should now be accepted");
 
-            let error = match GoogleDriveBackedFilesystem::from_config(config) {
-                Ok(_) => panic!("untrusted token host should be rejected"),
-                Err(error) => error,
-            };
+            // The credential-leak guards stay, because these endpoints carry the
+            // OAuth bearer token and signed JWT assertion: http and embedded
+            // credentials are still rejected.
+            let http = validate_google_drive_url("http://oauth2.googleapis.com", "tokenUrl", true)
+                .expect_err("http tokenUrl should be rejected");
             assert!(
-                error
-                    .to_string()
-                    .contains("google_drive mount tokenUrl host must be one of"),
-                "unexpected error: {error}"
+                http.to_string().contains("tokenUrl must use https"),
+                "unexpected error: {http}"
             );
-        }
 
-        #[test]
-        fn google_drive_plugin_rejects_untrusted_api_base_hosts() {
-            let server = MockGoogleDriveServer::start();
-            let mut config = test_config(&server, "reject-api-host");
-            config.api_base_url = Some(String::from("https://metadata.google.internal"));
-
-            let error = match GoogleDriveBackedFilesystem::from_config(config) {
-                Ok(_) => panic!("untrusted api base host should be rejected"),
-                Err(error) => error,
-            };
+            let creds = validate_google_drive_url(
+                "https://user:pass@oauth2.googleapis.com",
+                "tokenUrl",
+                true,
+            )
+            .expect_err("tokenUrl with embedded credentials should be rejected");
             assert!(
-                error
+                creds
                     .to_string()
-                    .contains("google_drive mount apiBaseUrl host must be one of"),
-                "unexpected error: {error}"
+                    .contains("must not include user credentials"),
+                "unexpected error: {creds}"
             );
         }
 

--- a/crates/sidecar/tests/s3.rs
+++ b/crates/sidecar/tests/s3.rs
@@ -24,150 +24,23 @@ mod s3 {
         }
 
         #[test]
-        fn s3_plugin_rejects_private_ip_endpoints() {
-            let server = MockS3Server::start();
-            let mut config = test_config(&server, "reject-private-endpoint");
-            config.endpoint = Some(String::from("http://169.254.169.254/latest"));
-
-            let error = match S3BackedFilesystem::from_config(config) {
-                Ok(_) => panic!("private IP endpoint should fail"),
-                Err(error) => error,
-            };
-            assert!(
-                error.to_string().contains(
-                    "s3 mount endpoint must not target a private or local/non-global IP address"
-                ),
-                "unexpected error: {error}"
-            );
-        }
-
-        #[test]
-        fn s3_plugin_accepts_https_hostname_endpoints_with_public_dns() {
-            let endpoint = validate_s3_endpoint_with_resolver(
-                "https://s3-compatible.example.com",
-                |host, port| {
-                    assert_eq!(host, "s3-compatible.example.com");
-                    assert_eq!(port, 443);
-                    Ok(vec!["93.184.216.34:443".parse().expect("public address")])
-                },
-            )
-            .expect("https hostname endpoint with public DNS should pass");
-            assert_eq!(endpoint, "https://s3-compatible.example.com");
-        }
-
-        #[test]
-        fn s3_plugin_rejects_http_hostname_endpoints_to_avoid_dns_rebinding() {
-            let error = match validate_s3_endpoint_with_resolver(
-                "http://s3-compatible.example.com",
-                |_, _| panic!("http hostname endpoint should fail before DNS"),
-            ) {
-                Ok(_) => panic!("http hostname endpoint should fail"),
-                Err(error) => error,
-            };
-            assert_eq!(error.code(), "EINVAL");
-            assert!(
-                error
-                    .message()
-                    .contains("hostname endpoints must use https"),
-                "unexpected error: {}",
-                error.message()
-            );
-        }
-
-        #[test]
-        fn s3_plugin_rejects_endpoint_hosts_resolving_to_private_ips() {
-            let error = match validate_s3_endpoint_with_resolver(
-                "https://metadata.test/latest",
-                |host, port| {
-                    assert_eq!(host, "metadata.test");
-                    assert_eq!(port, 443);
-                    Ok(vec!["169.254.169.254:443"
-                        .parse()
-                        .expect("private address")])
-                },
-            ) {
-                Ok(_) => panic!("private DNS endpoint should fail"),
-                Err(error) => error,
-            };
-            assert_eq!(error.code(), "EINVAL");
-            assert!(
-                error
-                    .message()
-                    .contains("resolved to a private or local/non-global IP address"),
-                "unexpected error: {}",
-                error.message()
-            );
-        }
-
-        #[test]
-        fn s3_plugin_rejects_ipv4_mapped_private_ipv6_endpoint_hosts() {
-            let error = match validate_s3_endpoint("http://[::ffff:169.254.169.254]/latest") {
-                Ok(_) => panic!("IPv4-mapped private endpoint should fail"),
-                Err(error) => error,
-            };
-            assert_eq!(error.code(), "EINVAL");
-            assert!(
-                error
-                    .message()
-                    .contains("private or local/non-global IP address"),
-                "unexpected error: {}",
-                error.message()
-            );
-        }
-
-        #[test]
-        fn s3_plugin_accepts_global_literal_endpoint_ips() {
-            for endpoint in [
-                "https://93.184.216.34",
-                "https://192.0.0.9",
-                "https://192.0.0.10",
-                "https://[64:ff9b::808:808]",
-                "https://[2001:1::1]",
-                "https://[2001:3::1]",
-                "https://[2001:20::1]",
-                "https://[3ff0::1]",
-                "https://[2606:4700:4700::1111]",
+        fn s3_plugin_validates_endpoint_well_formedness_only() {
+            // The endpoint is trusted mount config, not an SSRF surface, so it is
+            // no longer checked against an IP denylist; only well-formedness is
+            // validated. Private/metadata/loopback hosts are accepted.
+            for ok in [
+                "https://s3.example.com",
+                "http://127.0.0.1:9000",
+                "https://169.254.169.254/latest",
+                "https://[2001:db8::1]",
             ] {
-                let normalized = validate_s3_endpoint(endpoint)
-                    .unwrap_or_else(|error| panic!("global endpoint {endpoint} failed: {error}"));
-                assert_eq!(normalized, endpoint);
+                validate_s3_endpoint(ok)
+                    .unwrap_or_else(|error| panic!("well-formed endpoint {ok} failed: {error}"));
             }
-        }
-
-        #[test]
-        fn s3_plugin_rejects_non_global_literal_endpoint_ips() {
-            for endpoint in [
-                "http://100.64.0.1",
-                "http://192.0.0.8",
-                "http://192.0.0.170",
-                "http://192.0.0.171",
-                "http://192.0.2.1",
-                "http://192.88.99.2",
-                "http://198.18.0.1",
-                "http://203.0.113.1",
-                "http://[100::1]",
-                "http://[100:0:0:1::1]",
-                "http://[fec0::1]",
-                "http://[2001:db8::1]",
-                "http://[2001::1]",
-                "http://[2001:2::1]",
-                "http://[2001:10::1]",
-                "http://[2002::1]",
-                "http://[3fff::1]",
-                "http://[5f00::1]",
-            ] {
-                let error = match validate_s3_endpoint(endpoint) {
-                    Ok(_) => panic!("non-global endpoint {endpoint} should fail"),
-                    Err(error) => error,
-                };
-                assert_eq!(error.code(), "EINVAL");
-                assert!(
-                    error
-                        .message()
-                        .contains("private or local/non-global IP address"),
-                    "unexpected error for {endpoint}: {}",
-                    error.message()
-                );
+            for bad in ["", "not a url", "ftp://example.com"] {
+                let error = validate_s3_endpoint(bad)
+                    .expect_err(&format!("malformed endpoint {bad:?} should fail"));
+                assert_eq!(error.code(), "EINVAL", "unexpected error for {bad:?}");
             }
         }
 
@@ -783,39 +656,9 @@ use secure_exec_sidecar::wire::{
     RootFilesystemEntryEncoding, RootFilesystemEntryKind,
 };
 use std::collections::HashMap;
-use std::ffi::OsString;
-use std::sync::{Mutex, MutexGuard, OnceLock};
 use support::{
     authenticate_wire, create_vm_wire, open_session_wire, temp_dir, wire_request, wire_vm,
 };
-
-struct LocalS3EndpointEnvGuard {
-    _lock: Option<MutexGuard<'static, ()>>,
-    previous: Option<OsString>,
-}
-
-impl Drop for LocalS3EndpointEnvGuard {
-    fn drop(&mut self) {
-        match &self.previous {
-            Some(previous) => std::env::set_var("AGENT_OS_ALLOW_LOCAL_S3_ENDPOINTS", previous),
-            None => std::env::remove_var("AGENT_OS_ALLOW_LOCAL_S3_ENDPOINTS"),
-        }
-    }
-}
-
-fn allow_local_s3_endpoints() -> LocalS3EndpointEnvGuard {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    let lock = LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .expect("lock local s3 endpoint env");
-    let previous = std::env::var_os("AGENT_OS_ALLOW_LOCAL_S3_ENDPOINTS");
-    std::env::set_var("AGENT_OS_ALLOW_LOCAL_S3_ENDPOINTS", "1");
-    LocalS3EndpointEnvGuard {
-        _lock: Some(lock),
-        previous,
-    }
-}
 
 fn structured_events(
     sidecar: &secure_exec_sidecar::NativeSidecar<support::RecordingBridge>,
@@ -827,7 +670,6 @@ fn structured_events(
 
 #[test]
 fn dispose_vm_surfaces_s3_flush_failures_as_structured_events() {
-    let _local_s3_guard = allow_local_s3_endpoints();
     let server = s3::test_support::MockS3Server::start();
     let mut sidecar = support::new_sidecar("s3-dispose-shutdown-failure");
     let cwd = temp_dir("s3-dispose-shutdown-failure-cwd");

--- a/crates/sidecar/tests/sandbox_agent.rs
+++ b/crates/sidecar/tests/sandbox_agent.rs
@@ -4,8 +4,8 @@ mod sandbox_agent {
     mod tests {
         use super::test_support::MockSandboxAgentServer;
         use super::{
-            validate_sandbox_agent_base_url_with_resolver, SandboxAgentFilesystem,
-            SandboxAgentMountConfig, SandboxAgentMountPlugin,
+            validate_sandbox_agent_base_url, SandboxAgentFilesystem, SandboxAgentMountConfig,
+            SandboxAgentMountPlugin,
         };
         use nix::unistd::{Gid, Uid};
         use secure_exec_kernel::mount_plugin::{
@@ -214,116 +214,63 @@ mod sandbox_agent {
         }
 
         #[test]
-        fn sandbox_agent_base_url_accepts_explicit_loopback_targets() {
+        fn sandbox_agent_base_url_accepts_loopback_over_http() {
             for base_url in [
                 "http://localhost:1234",
                 "http://127.0.0.1:1234",
                 "http://[::1]:1234",
             ] {
                 assert_eq!(
-                    validate_sandbox_agent_base_url_with_resolver(base_url, |_, _| {
-                        panic!("loopback literals should not need DNS")
-                    })
-                    .expect("loopback baseUrl should be accepted"),
+                    validate_sandbox_agent_base_url(base_url)
+                        .expect("loopback baseUrl should be accepted"),
                     base_url
                 );
             }
         }
 
         #[test]
-        fn sandbox_agent_base_url_rejects_private_and_local_non_loopback_literals() {
+        fn sandbox_agent_base_url_allows_private_and_public_https_hosts() {
+            // baseUrl is trusted mount config, not an SSRF surface, so private /
+            // metadata hosts are accepted as long as they are well-formed https.
             for base_url in [
-                "http://10.0.0.1:8080",
                 "https://169.254.169.254/latest",
-                "https://100.64.0.1:8080",
-                "https://192.0.0.8:8080",
-                "https://192.88.99.2:8080",
-                "https://[::ffff:10.0.0.1]:8080",
-                "https://[fc00::1]:8080",
-                "https://[fe80::1]:8080",
+                "https://10.0.0.1:8080",
                 "https://[2001:db8::1]:8080",
-                "https://[3fff::1]:8080",
+                "https://sandbox.example.com",
+                "https://93.184.216.34",
             ] {
-                let error = validate_sandbox_agent_base_url_with_resolver(base_url, |_, _| {
-                    panic!("literal baseUrl should not need DNS")
-                })
-                .expect_err("private or local baseUrl should be rejected");
+                validate_sandbox_agent_base_url(base_url).unwrap_or_else(|error| {
+                    panic!("https baseUrl {base_url} should be accepted: {error}")
+                });
+            }
+            // Trailing slash is trimmed (request building depends on this).
+            assert_eq!(
+                validate_sandbox_agent_base_url("https://sandbox.example.com/api/")
+                    .expect("trailing slash trimmed"),
+                "https://sandbox.example.com/api"
+            );
+        }
+
+        #[test]
+        fn sandbox_agent_base_url_requires_https_for_non_local_targets() {
+            // The bearer token rides the Authorization header, so non-local http
+            // is still rejected to avoid leaking it over plaintext.
+            for base_url in ["http://sandbox.example.com", "http://93.184.216.34"] {
+                let error = validate_sandbox_agent_base_url(base_url)
+                    .expect_err("non-local http baseUrl should be rejected");
                 assert!(
-                    error.to_string().contains("private or local/non-global"),
+                    error.to_string().contains("must use https"),
                     "unexpected error for {base_url}: {error}"
                 );
             }
         }
 
         #[test]
-        fn sandbox_agent_base_url_requires_https_for_non_local_targets() {
-            let error = validate_sandbox_agent_base_url_with_resolver(
-                "http://sandbox.example.com",
-                |_, _| panic!("http hostname should be rejected before DNS"),
-            )
-            .expect_err("http hostname should be rejected");
-            assert!(
-                error.to_string().contains("must use https"),
-                "unexpected hostname error: {error}"
-            );
-
-            let error =
-                validate_sandbox_agent_base_url_with_resolver("http://93.184.216.34", |_, _| {
-                    panic!("literal IP should not need DNS")
-                })
-                .expect_err("http public literal should be rejected");
-            assert!(
-                error.to_string().contains("must use https"),
-                "unexpected literal error: {error}"
-            );
-        }
-
-        #[test]
-        fn sandbox_agent_base_url_allows_https_public_targets() {
-            assert_eq!(
-                validate_sandbox_agent_base_url_with_resolver(
-                    "https://sandbox.example.com/api/",
-                    |host, port| {
-                        assert_eq!(host, "sandbox.example.com");
-                        assert_eq!(port, 443);
-                        Ok(vec!["93.184.216.34:443".parse().expect("socket addr")])
-                    },
-                )
-                .expect("public https hostname should be accepted"),
-                "https://sandbox.example.com/api"
-            );
-
-            assert_eq!(
-                validate_sandbox_agent_base_url_with_resolver(
-                    "https://93.184.216.34",
-                    |_, _| panic!("literal IP should not need DNS"),
-                )
-                .expect("public https literal should be accepted"),
-                "https://93.184.216.34"
-            );
-        }
-
-        #[test]
-        fn sandbox_agent_base_url_rejects_hostnames_resolving_private_or_local() {
-            for address in [
-                "127.0.0.1:443",
-                "10.0.0.1:443",
-                "169.254.169.254:443",
-                "[::1]:443",
-                "[fc00::1]:443",
-                "[2001:db8::1]:443",
-            ] {
-                let error = validate_sandbox_agent_base_url_with_resolver(
-                    "https://sandbox.example.com",
-                    |_, _| Ok(vec![address.parse().expect("socket addr")]),
-                )
-                .expect_err("private DNS result should be rejected");
-                assert!(
-                    error
-                        .to_string()
-                        .contains("resolved to a private or local/non-global"),
-                    "unexpected error for {address}: {error}"
-                );
+        fn sandbox_agent_base_url_rejects_malformed_urls() {
+            for base_url in ["", "not a url", "ftp://sandbox.example.com"] {
+                validate_sandbox_agent_base_url(base_url).expect_err(&format!(
+                    "malformed baseUrl {base_url:?} should be rejected"
+                ));
             }
         }
 

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/nathan/secure-exec/node_modules

--- a/packages/build-tools/node_modules
+++ b/packages/build-tools/node_modules
@@ -1,0 +1,1 @@
+/home/nathan/secure-exec/packages/build-tools/node_modules


### PR DESCRIPTION
Audit-driven security pass against the kernel isolation boundary, plus a cleanup of validation that only guarded trusted client config. Scoped per the documented trust model (client/config trusted; in-VM executor untrusted).

## Guest-reachable fixes (in-scope: untrusted executor → boundary)
- **Overlay symlink metadata bypass (HIGH)** `kernel/overlay_fs.rs`: the `/.secure-exec-overlay` guard was lexical; a guest symlink whose resolved target entered the reserved namespace could list whiteout markers and unlink them to resurrect deleted lower-layer files. Now resolves through symlinks before the guard.
- **Mount path aliasing** `kernel/mount_table.rs`: `trim_start_matches(&mount.path)` over-stripped repeated segments (`/data/database.sqlite` → `/base.sqlite`); replaced with single-prefix strip.
- **lstat/readlink permission bypass** `kernel/permissions.rs`: authorized the lexical path while operating on the parent-symlink-resolved target, leaking metadata of denied paths. Now authorizes the resolved subject.
- **PTY buffer-cap DoS** `kernel/pty.rs`: the waiter-handoff tail bypassed `MAX_PTY_BUFFER_BYTES`; now enforces the cap with backpressure.

Regression tests added (overlay symlink, mount aliasing).

## Remove over-defense against trusted config
Per the trust model, mount-plugin endpoints come only from the trusted client, so SSRF/denylist/DNS-rebinding guards over them are removed; well-formedness and credential-leak guards are kept.
- **s3**: drop IP denylist + DNS re-resolution + localhost/env escape hatch; keep URL/scheme validation.
- **sandbox_agent**: drop IP denylist + DNS re-resolution; keep https-for-non-local (bearer-token guard).
- **google_drive**: drop the strict host allowlist; keep https + no-embedded-credentials (replayable token/JWT guard).

## Docs
- Adds the **Trust Model** (client / sidecar / executor) to root `CLAUDE.md`.

All affected kernel and sidecar test suites pass.