### PR TITLE
ci: publish WASM command packages manually, not in CI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -102,50 +102,15 @@ jobs:
           path: ${{ steps.build.outputs.dir }}
           if-no-files-found: error
 
-  build-commands:
-    needs: [context]
-    name: "Build WASM commands"
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      # The Rust toolchain (nightly + wasm32-wasip1 target + rust-src) is pinned
-      # by registry/native/rust-toolchain.toml and auto-selected by rustup there.
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2026-03-01
-          targets: wasm32-wasip1
-          components: rust-src
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: registry/native -> target
-          key: wasm-commands-${{ needs.context.outputs.trigger }}
-      # Fetch a prebuilt wasm-opt binary instead of compiling the wasm-opt
-      # crate from source (`cargo install wasm-opt` took several minutes cold).
-      # The Makefile's wasm-opt-check then finds it on PATH and skips its own
-      # install. wasm-opt is optimization-only, so this never affects build
-      # correctness, only size and CI time.
-      - name: Install wasm-opt
-        uses: taiki-e/install-action@v2
-        with:
-          tool: wasm-opt
-      - name: Build WASM command binaries
-        run: make -C registry/native wasm
-      - name: Verify command set built
-        run: |
-          set -euo pipefail
-          dir="registry/native/target/wasm32-wasip1/release/commands"
-          test -f "$dir/sh" || { echo "::error::sh binary missing from $dir"; exit 1; }
-          echo "Built $(ls "$dir" | wc -l) command entries"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: wasm-commands
-          path: registry/native/target/wasm32-wasip1/release/commands
-          if-no-files-found: error
+  # NOTE: WASM command binaries are intentionally NOT built or published here.
+  # The wasm-bearing packages (@secure-exec/core, which vendors the command set,
+  # and the @agent-os-pkgs/* registry software) are always published MANUALLY.
+  # See CLAUDE.md → "Publishing" for the manual flow.
 
   publish-npm:
-    needs: [context, build-sidecar, build-commands]
+    needs: [context, build-sidecar]
     name: "Publish npm"
-    if: ${{ !cancelled() && needs.build-sidecar.result == 'success' && needs.build-commands.result == 'success' }}
+    if: ${{ !cancelled() && needs.build-sidecar.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -161,21 +126,6 @@ jobs:
         with:
           pattern: sidecar-*
           path: artifacts
-      - name: Place WASM commands for @secure-exec/core
-        uses: actions/download-artifact@v4
-        with:
-          name: wasm-commands
-          # Restore into the in-repo build path so the core `build` script's
-          # `copy-commands` step vendors them into packages/core/commands. The
-          # uploaded artifact dereferenced the build's alias symlinks to real
-          # files, so the full command set (sh, bash, the stub aliases) lands here.
-          path: registry/native/target/wasm32-wasip1/release/commands
-      - name: Verify WASM commands restored
-        run: |
-          set -euo pipefail
-          dir="registry/native/target/wasm32-wasip1/release/commands"
-          test -f "$dir/sh" || { echo "::error::sh missing after artifact restore"; exit 1; }
-          echo "Restored $(ls "$dir" | wc -l) command entries for packaging"
       - name: Place sidecar binaries into platform packages
         run: |
           set -euo pipefail

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,13 @@ Two corollaries that are easy to get wrong:
 - Publish platform binary packages with `npm publish`, not `pnpm publish`, so executable bits are preserved.
 - Resolver packages must return an absolute binary path. Callers pass that typed path to process spawning instead of relying on global environment mutation.
 
+## Publishing
+
+- CI (`.github/workflows/publish.yaml`) does NOT build or publish the WASM command binaries. There is no `build-commands` job and nothing restores a `wasm-commands` artifact — the workflow only builds/publishes the sidecar binary and the pure-TS packages.
+- WASM-bearing packages are ALWAYS published MANUALLY: `@secure-exec/core` (which vendors `registry/native` commands into `packages/core/commands` via `copy-wasm-commands.mjs`, guarded by its `prepack --require`) and the `@agent-os-pkgs/*` registry software. `@secure-exec/core` is in `EXCLUDED` in `scripts/publish/src/lib/packages.ts`, so CI never publishes it.
+- Manual core flow: build the commands locally (`make -C registry/native wasm`), then `npm publish` (not `pnpm publish`) `@secure-exec/core` at the **same version** CI used for that release so dependents resolving `@secure-exec/core@<version>` succeed. `prepack` vendors the commands and fails loud if they are absent.
+- Rationale: building WASM in CI was slow/flaky and repeatedly shipped tarballs missing the command set (the `wasm/` output is a gitignored build artifact). Keeping the WASM publish manual makes the vendored command set authoritative and avoids empty-package regressions.
+
 ## Website
 
 - `website/` is `@secure-exec/website`, a unified Astro app serving the public site at **secureexec.dev**: `/` is the React/Tailwind landing page and `/docs/*` is the Starlight documentation.

--- a/scripts/publish/src/lib/packages.ts
+++ b/scripts/publish/src/lib/packages.ts
@@ -20,6 +20,13 @@ export interface DiscoverPackagesOptions {
 
 export const EXCLUDED = new Set<string>([
 	"publish",
+	// @secure-exec/core vendors the WASM command binaries (packages/core/commands)
+	// and its `prepack --require` refuses to ship without them. CI no longer
+	// builds WASM, so core — like the @agent-os-pkgs/* registry software — is
+	// always published MANUALLY: build the commands locally, then publish core at
+	// the matching release version so dependents resolve. See CLAUDE.md →
+	// "Publishing".
+	"@secure-exec/core",
 ]);
 
 export interface MetaPackageSpec {
@@ -149,9 +156,10 @@ export function buildMetaPlatformMap(
 
 export function assertDiscoverySanity(packages: Package[]): void {
 	const byName = new Set(packages.map((p) => p.name));
+	// @secure-exec/core is intentionally absent: it vendors WASM commands and is
+	// published manually (see EXCLUDED above), so it is not part of the CI set.
 	const required = [
 		"@secure-exec/browser",
-		"@secure-exec/core",
 		"@secure-exec/google-drive",
 		"@secure-exec/registry-types",
 		"@secure-exec/s3",


### PR DESCRIPTION
## What

CI no longer builds or publishes WASM command binaries.

- Removes the `build-commands` job from `.github/workflows/publish.yaml` (and the artifact restore steps in `publish-npm`).
- Excludes `@secure-exec/core` from the CI publish set (`scripts/publish/src/lib/packages.ts`), since it vendors the WASM commands and its `prepack --require` refuses to ship without them.
- Documents the manual-publish policy in `CLAUDE.md → Publishing`.

## Why

Building WASM in CI was slow/flaky and repeatedly shipped tarballs missing the command set (the `wasm/` output is a gitignored build artifact). WASM-bearing packages (`@secure-exec/core` + the `@agent-os-pkgs/*` registry software) are now always published **manually**.

## Note / follow-up

With `@secure-exec/core` excluded from CI publish, after a CI release you must **manually publish `@secure-exec/core` at the matching version** or dependents resolving `@secure-exec/core@<version>` will fail.