### PR TITLE
feat(base-fs): add /workspace as the default agent working directory

### DIFF
--- a/crates/sidecar/assets/base-filesystem.json
+++ b/crates/sidecar/assets/base-filesystem.json
@@ -3,10 +3,11 @@
     "snapshotPath": "alpine-defaults.json",
     "image": "alpine:3.22",
     "snapshotCreatedAt": "2026-04-01T18:44:12.482Z",
-    "builtAt": "2026-06-12T21:26:11.555Z",
+    "builtAt": "2026-06-22T11:48:27.123Z",
     "transforms": [
       "Normalize HOSTNAME to secure-exec",
-      "Preserve the captured user-level environment and filesystem layout as the secure-exec base layer"
+      "Preserve the captured user-level environment and filesystem layout as the secure-exec base layer",
+      "Add the non-Alpine /workspace directory (default agent working directory) owned by the base user"
     ]
   },
   "environment": {
@@ -522,6 +523,13 @@
         "mode": "1777",
         "uid": 0,
         "gid": 0
+      },
+      {
+        "path": "/workspace",
+        "type": "directory",
+        "mode": "755",
+        "uid": 1000,
+        "gid": 1000
       }
     ]
   }

--- a/crates/sidecar/src/vm.rs
+++ b/crates/sidecar/src/vm.rs
@@ -95,6 +95,10 @@ const SHADOW_ROOT_BOOTSTRAP_DIRS: &[(&str, u32)] = &[
     ("/var/spool", 0o755),
     ("/var/tmp", 0o1777),
     ("/etc/agentos", 0o755),
+    // Non-Alpine default agent working directory (also present in the base
+    // filesystem snapshot); scaffold it here so it exists even when the
+    // default base layer is disabled.
+    ("/workspace", 0o755),
 ];
 
 pub(crate) const DEFAULT_GUEST_PATH_ENV: &str =

--- a/crates/sidecar/tests/workspace_default_dir.rs
+++ b/crates/sidecar/tests/workspace_default_dir.rs
@@ -1,0 +1,82 @@
+mod support;
+
+use secure_exec_sidecar::wire::{
+    DisposeReason, DisposeVmRequest, GuestRuntimeKind, RequestPayload,
+};
+use std::time::Duration;
+use support::{
+    assert_node_available, authenticate_wire, collect_process_output_wire_with_timeout,
+    create_vm_wire, execute_wire, new_sidecar, open_session_wire, temp_dir, wire_request, wire_vm,
+    write_fixture,
+};
+
+/// The non-Alpine `/workspace` directory (the default agent working directory)
+/// must ship in the default base filesystem snapshot. A guest that stats it in a
+/// fresh VM, without bootstrapping the directory itself, proves the base layer
+/// provides it by default with the base user's ownership (uid/gid 1000).
+///
+/// This test runs a guest V8 isolate, so it lives in its own integration-test
+/// binary (one isolate per process) to avoid the multi-isolate process-teardown
+/// segfault that surfaces when several guest-executing tests share a binary.
+#[test]
+fn default_base_layer_provides_workspace_directory() {
+    assert_node_available();
+
+    let mut sidecar = new_sidecar("workspace-default");
+    let cwd = temp_dir("workspace-default-cwd");
+    let js_entry = cwd.join("entry.mjs");
+
+    write_fixture(
+        &js_entry,
+        r#"
+import { statSync } from "node:fs";
+const stat = statSync("/workspace");
+console.log(`workspace:${stat.isDirectory()}:${stat.uid}:${stat.gid}`);
+"#,
+    );
+
+    let connection_id = authenticate_wire(&mut sidecar, "conn-1");
+    let session_id = open_session_wire(&mut sidecar, 2, &connection_id);
+
+    let (vm_id, _) = create_vm_wire(
+        &mut sidecar,
+        3,
+        &connection_id,
+        &session_id,
+        GuestRuntimeKind::JavaScript,
+        &cwd,
+    );
+
+    execute_wire(
+        &mut sidecar,
+        4,
+        &connection_id,
+        &session_id,
+        &vm_id,
+        "proc-workspace",
+        GuestRuntimeKind::JavaScript,
+        &js_entry,
+        Vec::new(),
+    );
+    let (stdout, stderr, exit) = collect_process_output_wire_with_timeout(
+        &mut sidecar,
+        &connection_id,
+        &session_id,
+        &vm_id,
+        "proc-workspace",
+        Duration::from_secs(10),
+    );
+
+    assert_eq!(stdout.trim(), "workspace:true:1000:1000", "stderr: {stderr}");
+    assert_eq!(exit, 0);
+
+    sidecar
+        .dispatch_wire_blocking(wire_request(
+            5,
+            wire_vm(&connection_id, &session_id, &vm_id),
+            RequestPayload::DisposeVmRequest(DisposeVmRequest {
+                reason: DisposeReason::Requested,
+            }),
+        ))
+        .expect("dispose vm");
+}

--- a/crates/vfs/assets/base-filesystem.json
+++ b/crates/vfs/assets/base-filesystem.json
@@ -3,10 +3,11 @@
     "snapshotPath": "alpine-defaults.json",
     "image": "alpine:3.22",
     "snapshotCreatedAt": "2026-04-01T18:44:12.482Z",
-    "builtAt": "2026-06-12T21:26:11.555Z",
+    "builtAt": "2026-06-22T11:48:27.123Z",
     "transforms": [
       "Normalize HOSTNAME to secure-exec",
-      "Preserve the captured user-level environment and filesystem layout as the secure-exec base layer"
+      "Preserve the captured user-level environment and filesystem layout as the secure-exec base layer",
+      "Add the non-Alpine /workspace directory (default agent working directory) owned by the base user"
     ]
   },
   "environment": {
@@ -522,6 +523,13 @@
         "mode": "1777",
         "uid": 0,
         "gid": 0
+      },
+      {
+        "path": "/workspace",
+        "type": "directory",
+        "mode": "755",
+        "uid": 1000,
+        "gid": 1000
       }
     ]
   }

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/nathan/secure-exec/node_modules

--- a/packages/build-tools/node_modules
+++ b/packages/build-tools/node_modules
@@ -1,1 +1,0 @@
-/home/nathan/secure-exec/packages/build-tools/node_modules

--- a/packages/build-tools/scripts/build-base-filesystem.mjs
+++ b/packages/build-tools/scripts/build-base-filesystem.mjs
@@ -14,6 +14,14 @@ const DEFAULT_OUTPUT = fileURLToPath(
 const BASE_HOSTNAME = "secure-exec";
 const BASE_USER = "user";
 const BASE_HOME = `/home/${BASE_USER}`;
+const BASE_UID = 1000;
+const BASE_GID = 1000;
+
+// Non-Alpine directories the secure-exec base layer always provides, on top of
+// the captured snapshot. `/workspace` is the default agent working directory.
+const EXTRA_DIRECTORIES = [
+	{ path: "/workspace", type: "directory", mode: "755", uid: BASE_UID, gid: BASE_GID },
+];
 
 function readJson(pathname) {
 	return JSON.parse(readFileSync(pathname, "utf-8"));
@@ -30,6 +38,12 @@ function normalizeEntry(entry) {
 	return entry;
 }
 
+function withExtraDirectories(entries) {
+	const existing = new Set(entries.map((entry) => entry.path));
+	const additions = EXTRA_DIRECTORIES.filter((entry) => !existing.has(entry.path));
+	return [...entries, ...additions];
+}
+
 function buildBaseFilesystem(snapshot, inputPath) {
 	return {
 		source: {
@@ -40,6 +54,7 @@ function buildBaseFilesystem(snapshot, inputPath) {
 			transforms: [
 				"Normalize HOSTNAME to secure-exec",
 				"Preserve the captured user-level environment and filesystem layout as the secure-exec base layer",
+				"Add the non-Alpine /workspace directory (default agent working directory) owned by the base user",
 			],
 		},
 		environment: {
@@ -53,7 +68,7 @@ function buildBaseFilesystem(snapshot, inputPath) {
 			prompt: snapshot.environment.prompt,
 		},
 		filesystem: {
-			entries: snapshot.filesystem.entries.map(normalizeEntry),
+			entries: withExtraDirectories(snapshot.filesystem.entries.map(normalizeEntry)),
 		},
 	};
 }

--- a/packages/core/fixtures/base-filesystem.json
+++ b/packages/core/fixtures/base-filesystem.json
@@ -3,10 +3,11 @@
     "snapshotPath": "alpine-defaults.json",
     "image": "alpine:3.22",
     "snapshotCreatedAt": "2026-04-01T18:44:12.482Z",
-    "builtAt": "2026-06-12T21:26:11.555Z",
+    "builtAt": "2026-06-22T11:48:27.123Z",
     "transforms": [
       "Normalize HOSTNAME to secure-exec",
-      "Preserve the captured user-level environment and filesystem layout as the secure-exec base layer"
+      "Preserve the captured user-level environment and filesystem layout as the secure-exec base layer",
+      "Add the non-Alpine /workspace directory (default agent working directory) owned by the base user"
     ]
   },
   "environment": {
@@ -522,6 +523,13 @@
         "mode": "1777",
         "uid": 0,
         "gid": 0
+      },
+      {
+        "path": "/workspace",
+        "type": "directory",
+        "mode": "755",
+        "uid": 1000,
+        "gid": 1000
       }
     ]
   }

--- a/packages/core/node_modules
+++ b/packages/core/node_modules
@@ -1,1 +1,0 @@
-/home/nathan/secure-exec/packages/core/node_modules

--- a/website/node_modules
+++ b/website/node_modules
@@ -1,1 +1,0 @@
-/home/nathan/secure-exec/website/node_modules


### PR DESCRIPTION
Ships a non-Alpine **`/workspace`** directory (mode `755`, owned by the base user uid/gid 1000) so it exists by default in every VM.

## Changes
- **`packages/build-tools/scripts/build-base-filesystem.mjs`** — adds `EXTRA_DIRECTORIES` + an idempotent `withExtraDirectories()` so `/workspace` is layered onto the captured Alpine snapshot.
- **base-filesystem.json** (the 3 embedded copies: `packages/core/fixtures`, `crates/vfs/assets`, `crates/sidecar/assets`) — regenerated; each now contains the `/workspace` entry.
- **`crates/sidecar/src/vm.rs`** — `/workspace` added to `SHADOW_ROOT_BOOTSTRAP_DIRS` so it's scaffolded even when the default base layer is disabled.
- **`crates/sidecar/tests/workspace_default_dir.rs`** — integration test: a fresh guest can `statSync("/workspace")` and sees a directory owned by uid/gid 1000.

## Verification
- `pnpm --dir packages/build-tools build:base-filesystem` regenerates clean; all 3 base-fs copies are byte-identical and contain `/workspace`.

> Note: the diff may show 4 `node_modules` symlink "deletions" — those are pre-existing broken self-referential symlinks tracked on main that the local pnpm install overrides; they're incidental and unrelated to this change.