### PR TITLE
fix(core): restore Sidecar public export + sidecar-client subpath

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,9 +68,9 @@
 			"default": "./dist/process.js"
 		},
 		"./sidecar-client": {
-			"types": "./dist/sidecar-client.d.ts",
-			"import": "./dist/sidecar-client.js",
-			"default": "./dist/sidecar-client.js"
+			"types": "./dist/sidecar-process.d.ts",
+			"import": "./dist/sidecar-process.js",
+			"default": "./dist/sidecar-process.js"
 		},
 		"./test-runtime": {
 			"types": "./dist/test-runtime.d.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,7 +19,7 @@ export * from "./protocol-client.js";
 export * from "./protocol-frames.js";
 export * from "./request-payloads.js";
 export * from "./response-payloads.js";
-export { SidecarProcess } from "./sidecar-process.js";
+export { SidecarProcess, Sidecar } from "./sidecar-process.js";
 export type { SidecarSpawnOptions } from "./sidecar-process.js";
 export * from "./state.js";
 export * as protocol from "./generated-protocol.js";

--- a/packages/core/src/sidecar-process.ts
+++ b/packages/core/src/sidecar-process.ts
@@ -54,6 +54,10 @@ export {
 	SidecarProcessExited,
 } from "./process.js";
 export { SidecarEventBufferOverflow } from "./event-buffer.js";
+// `Sidecar` is the public name for the native sidecar process client. The class
+// is `SidecarProcess` internally; consumers import it as `Sidecar` via the
+// `@secure-exec/core/sidecar-client` subpath and the package root.
+export { SidecarProcess as Sidecar };
 
 const BRIDGE_CONTRACT_VERSION = 1;
 


### PR DESCRIPTION
## What

`@secure-exec/core` was renamed internally (`sidecar-client.ts` → `sidecar-process.ts`, class `Sidecar` → `SidecarProcess`) but the public surface wasn't updated, so on `main`:

- `@secure-exec/core` no longer exports `Sidecar` (only `SidecarProcess`)
- the `./sidecar-client` export still points at the now-nonexistent `dist/sidecar-client.js` (the source builds to `dist/sidecar-process.js`)

Consumers that import `Sidecar` / `@secure-exec/core/sidecar-client` (the `secure-exec` facade, the `native-client` example, and `@rivet-dev/agentos-core`) fail to build with TS2305 / TS2307.

## Fix (3 small edits, no consumer changes)

- `sidecar-process.ts`: `export { SidecarProcess as Sidecar }`
- `index.ts`: also export `Sidecar` from the package root
- `package.json`: repoint the `./sidecar-client` export to `./dist/sidecar-process.{js,d.ts}`

`sidecar-process.ts` already re-exports the full prior `sidecar-client` surface (`SidecarProcessError`, `SidecarProcessExited`, `SidecarEventBufferOverflow`, the types), so the public API is preserved exactly.

## Verification

With this change, `@secure-exec/core` builds, the `secure-exec` facade builds, and the `native-client` example typechecks clean.