### PR TITLE
fix(resolver): actionable "module not found" + host-mounted node_modules symlink coverage

### DIFF
--- a/crates/execution/tests/module_resolution.rs
+++ b/crates/execution/tests/module_resolution.rs
@@ -145,6 +145,26 @@ fn directory_import_uses_package_main_field() {
 }
 
 #[test]
+fn bare_package_main_only_type_module_resolves() {
+    // Regression guard: a bare ESM package whose package.json has `main` but NO
+    // `exports` map (e.g. @agentclientprotocol/sdk@0.16.1) must still resolve via
+    // the `main` fallback. `exports` and `main` are separate code paths; this case
+    // exercises the latter for a scoped package looked up through node_modules.
+    let fixture = Fixture::new();
+    fixture.write_json(
+        "node_modules/@scope/pkg/package.json",
+        serde_json::json!({ "type": "module", "main": "dist/acp.js" }),
+    );
+    fixture.write("node_modules/@scope/pkg/dist/acp.js", "export default 1;");
+    assert_import(
+        &fixture,
+        "@scope/pkg",
+        "/root/project/src/adapter.js",
+        "/root/node_modules/@scope/pkg/dist/acp.js",
+    );
+}
+
+#[test]
 fn directory_import_falls_back_to_index_file() {
     let fixture = Fixture::new();
     fixture.write("project/lib/index.cjs", "module.exports = 1;");

--- a/crates/sidecar/tests/node_modules_symlink_resolution.rs
+++ b/crates/sidecar/tests/node_modules_symlink_resolution.rs
@@ -1,0 +1,224 @@
+mod support;
+
+use secure_exec_sidecar::wire::{
+    BootstrapRootFilesystemRequest, ConfigureVmRequest, DisposeReason, DisposeVmRequest,
+    GuestFilesystemCallRequest, GuestFilesystemOperation, GuestRuntimeKind, MountDescriptor,
+    MountPluginDescriptor, RequestPayload, ResponsePayload, RootFilesystemEntry,
+    RootFilesystemEntryEncoding, RootFilesystemEntryKind,
+};
+use std::collections::HashMap;
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::time::Duration;
+use support::{
+    authenticate_wire, collect_process_output_wire_with_timeout, create_vm_wire, execute_wire,
+    new_sidecar, open_session_wire, temp_dir, wire_request, wire_vm,
+};
+
+/// Companion to `node_modules_host_mount_resolution.rs` (issue #109): that test
+/// projects a *plain* host `node_modules` (real package directories). Real
+/// installs are rarely plain — pnpm (and yarn's node-linker) lay out
+/// `node_modules` as symlinks into a virtual `.pnpm` store, with scoped
+/// packages nested under an `@scope/` directory. This locks in that the
+/// `host_dir` mount `NodeRuntime.create({ nodeModules })` projects follows those
+/// in-tree relative symlinks, so a pnpm-installed package resolves from guest
+/// `import` exactly like the plain layout does.
+///
+/// Note the boundary this does *not* relax: the mount confines reads to its
+/// root (anchored `openat2(RESOLVE_BENEATH)`), so a symlink that escapes the
+/// mounted tree (a workspace/`file:` dep linked to the workspace root or an
+/// external store) is deliberately not followed. The fix for that case is to
+/// mount a directory that contains the symlink targets, not to widen the mount.
+///
+/// One guest V8 isolate per process, so this lives in its own integration-test
+/// binary (see the sibling test for the multi-isolate teardown rationale).
+#[test]
+fn pnpm_symlinked_packages_resolve_from_guest_import() {
+    support::assert_node_available();
+
+    let mut sidecar = new_sidecar("node-modules-symlink");
+
+    // Seed a host `node_modules` shaped like a pnpm install: real package
+    // directories live in the `.pnpm` virtual store, and the top-level entries
+    // are relative symlinks pointing into it. Both a plain and a scoped package
+    // are covered, since scoped packages take a separate `@scope/` resolution
+    // path.
+    let host_root = temp_dir("node-modules-symlink-host");
+    let node_modules = host_root.join("node_modules");
+    let store = node_modules.join(".pnpm");
+
+    let plain_real = store.join("is-number@7.0.0/node_modules/is-number");
+    fs::create_dir_all(&plain_real).expect("create plain store dir");
+    fs::write(
+        plain_real.join("package.json"),
+        r#"{"name":"is-number","version":"7.0.0","type":"module","main":"index.js"}"#,
+    )
+    .expect("write plain package.json");
+    fs::write(
+        plain_real.join("index.js"),
+        "export default () => \"plain-symlink-resolved\";\n",
+    )
+    .expect("write plain entry");
+
+    let scoped_real = store.join("@scope+pkg@1.0.0/node_modules/@scope/pkg");
+    fs::create_dir_all(&scoped_real).expect("create scoped store dir");
+    fs::write(
+        scoped_real.join("package.json"),
+        r#"{"name":"@scope/pkg","version":"1.0.0","type":"module","main":"index.js"}"#,
+    )
+    .expect("write scoped package.json");
+    fs::write(
+        scoped_real.join("index.js"),
+        "export default () => \"scoped-symlink-resolved\";\n",
+    )
+    .expect("write scoped entry");
+
+    // Top-level symlinks, relative and contained within `node_modules` exactly
+    // as pnpm writes them.
+    symlink(
+        "./.pnpm/is-number@7.0.0/node_modules/is-number",
+        node_modules.join("is-number"),
+    )
+    .expect("link plain package");
+    fs::create_dir_all(node_modules.join("@scope")).expect("create @scope dir");
+    symlink(
+        "../.pnpm/@scope+pkg@1.0.0/node_modules/@scope/pkg",
+        node_modules.join("@scope/pkg"),
+    )
+    .expect("link scoped package");
+
+    let cwd = temp_dir("node-modules-symlink-cwd");
+
+    let connection_id = authenticate_wire(&mut sidecar, "conn-1");
+    let session_id = open_session_wire(&mut sidecar, 2, &connection_id);
+    let (vm_id, _) = create_vm_wire(
+        &mut sidecar,
+        3,
+        &connection_id,
+        &session_id,
+        GuestRuntimeKind::JavaScript,
+        &cwd,
+    );
+
+    // Provide the mountpoint, then project the host `node_modules` at guest
+    // `/tmp/node_modules` (read-only) — the default `nodeModules` projection.
+    sidecar
+        .dispatch_wire_blocking(wire_request(
+            4,
+            wire_vm(&connection_id, &session_id, &vm_id),
+            RequestPayload::BootstrapRootFilesystemRequest(BootstrapRootFilesystemRequest {
+                entries: vec![RootFilesystemEntry {
+                    path: String::from("/tmp/node_modules"),
+                    kind: RootFilesystemEntryKind::Directory,
+                    mode: None,
+                    uid: None,
+                    gid: None,
+                    content: None,
+                    encoding: None,
+                    target: None,
+                    executable: false,
+                }],
+            }),
+        ))
+        .expect("bootstrap mountpoint");
+
+    sidecar
+        .dispatch_wire_blocking(wire_request(
+            5,
+            wire_vm(&connection_id, &session_id, &vm_id),
+            RequestPayload::ConfigureVmRequest(ConfigureVmRequest {
+                mounts: vec![MountDescriptor {
+                    guest_path: String::from("/tmp/node_modules"),
+                    read_only: true,
+                    plugin: MountPluginDescriptor {
+                        id: String::from("host_dir"),
+                        config: serde_json::to_string(&serde_json::json!({
+                            "hostPath": node_modules.to_string_lossy(),
+                            "readOnly": true,
+                        }))
+                        .expect("serialize host_dir mount config"),
+                    },
+                }],
+                software: Vec::new(),
+                permissions: None,
+                module_access_cwd: None,
+                instructions: Vec::new(),
+                projected_modules: Vec::new(),
+                command_permissions: HashMap::new(),
+                loopback_exempt_ports: Vec::new(),
+            }),
+        ))
+        .expect("mount host node_modules");
+
+    // Program under `/tmp` so the resolution walk reaches `/tmp/node_modules`,
+    // importing both the plain and the scoped symlinked package.
+    let entry_source = r#"
+import plain from "is-number";
+import scoped from "@scope/pkg";
+console.log(plain());
+console.log(scoped());
+"#;
+    let write = sidecar
+        .dispatch_wire_blocking(wire_request(
+            6,
+            wire_vm(&connection_id, &session_id, &vm_id),
+            RequestPayload::GuestFilesystemCallRequest(GuestFilesystemCallRequest {
+                operation: GuestFilesystemOperation::WriteFile,
+                path: String::from("/tmp/entry.mjs"),
+                destination_path: None,
+                target: None,
+                content: Some(String::from(entry_source)),
+                encoding: Some(RootFilesystemEntryEncoding::Utf8),
+                recursive: false,
+                mode: None,
+                uid: None,
+                gid: None,
+                atime_ms: None,
+                mtime_ms: None,
+                len: None,
+                offset: None,
+            }),
+        ))
+        .expect("write guest entry");
+    match write.response.payload {
+        ResponsePayload::GuestFilesystemResultResponse(_) => {}
+        other => panic!("unexpected guest write response: {other:?}"),
+    }
+
+    execute_wire(
+        &mut sidecar,
+        7,
+        &connection_id,
+        &session_id,
+        &vm_id,
+        "proc-resolve",
+        GuestRuntimeKind::JavaScript,
+        std::path::Path::new("/tmp/entry.mjs"),
+        Vec::new(),
+    );
+    let (stdout, stderr, exit) = collect_process_output_wire_with_timeout(
+        &mut sidecar,
+        &connection_id,
+        &session_id,
+        &vm_id,
+        "proc-resolve",
+        Duration::from_secs(10),
+    );
+
+    assert_eq!(
+        stdout.trim(),
+        "plain-symlink-resolved\nscoped-symlink-resolved",
+        "guest import of pnpm-symlinked packages should resolve; stderr: {stderr}"
+    );
+    assert_eq!(exit, 0, "stderr: {stderr}");
+
+    sidecar
+        .dispatch_wire_blocking(wire_request(
+            8,
+            wire_vm(&connection_id, &session_id, &vm_id),
+            RequestPayload::DisposeVmRequest(DisposeVmRequest {
+                reason: DisposeReason::Requested,
+            }),
+        ))
+        .expect("dispose vm");
+}

--- a/crates/v8-runtime/src/execution.rs
+++ b/crates/v8-runtime/src/execution.rs
@@ -1772,9 +1772,29 @@ fn resolve_module_via_ipc(
                 if val.is_string() {
                     Some(val.to_rust_string_lossy(scope))
                 } else {
+                    // A non-string (null) return means the host resolver found no
+                    // match — i.e. the module could not be located, NOT a type error.
+                    // Name the importer so node_modules layout/discovery problems are
+                    // diagnosable (e.g. a bare package installed off the importer's
+                    // ancestor chain), since that is the common real cause here.
+                    //
+                    // Call out the host-mounted node_modules case too: a host_dir
+                    // mount (what NodeRuntime `nodeModules` projects) confines reads
+                    // to the mount root, so a package symlinked OUT of the mounted
+                    // tree (pnpm/yarn workspace or `file:` deps that link to the
+                    // workspace root or an external store) cannot be followed and
+                    // surfaces here as not-found.
                     throw_module_error(
                         scope,
-                        &format!("_resolveModule returned non-string for '{}'", specifier),
+                        &format!(
+                            "Cannot resolve module '{specifier}' (imported from \
+                             '{referrer}'): not found. For a bare package, ensure it is \
+                             installed in a node_modules directory on an ancestor of the \
+                             importer (or bundle the entrypoint). If you mounted a host \
+                             node_modules, point it at a directory that contains every \
+                             symlink target (e.g. the workspace root): symlinks that \
+                             escape the mount root are not followed."
+                        ),
                     );
                     None
                 }

--- a/website/src/content/docs/docs/features/module-loading.mdx
+++ b/website/src/content/docs/docs/features/module-loading.mdx
@@ -132,6 +132,8 @@ When a guest filesystem contains `node_modules`, the resolver matches naive Node
 
 No package-manager-specific heuristics: pnpm/yarn layouts resolve because the VFS exposes their symlinks, not because the resolver special-cases them.
 
+<Aside type="caution">A `nodeModules` (or `mounts`) host mount confines reads to the mounted directory: symlinks are followed only while they stay **inside** the mount root. A single-project `npm`/`pnpm` install resolves fine because its symlinks (including the `.pnpm` store) live inside `node_modules`. A workspace/monorepo install is different: pnpm/yarn and `file:` deps symlink packages to the workspace root or an external store, **outside** the leaf `node_modules`. Those targets are not followed, and the guest import fails with `Cannot resolve module '<pkg>': not found`. Fix it by pointing the mount at a directory that contains every symlink target (for example the workspace root, mounted at the guest path the program resolves from) instead of the leaf `node_modules`.</Aside>
+
 ## Seeding files directly
 
 When you don't have a host directory to mount, write bytes into the VM:


### PR DESCRIPTION
## Summary

Follow-up to #109 (`NodeRuntime nodeModules` resolution). Closes the gap a user hit on `0.3.1-rc.2`: the JS SDK `NodeRuntime.create({ nodeModules })` path still surfaced `_resolveModule returned non-string for '<pkg>'`.

Two things were missing on `main`:

1. **The actionable error never merged.** The reword that turns the cryptic `_resolveModule returned non-string` into a real "module not found" message was authored but unmerged, so users still saw the internal-type-error-looking message.
2. **The regression test only covered a plain layout.** #113 projects a host `node_modules` of *real package directories*. Real installs are not plain: pnpm/yarn lay `node_modules` out as **symlinks** into a `.pnpm` store, and that symlinked layout is what the TypeScript `nodeModules` option actually produces. It was never tested end-to-end.

## What this does

- **Reword the not-found error** (`crates/v8-runtime/src/execution.rs`): name the importer, state it as not-found with remediation. Also call out the **host-mounted `node_modules`** case explicitly: a `host_dir` mount confines reads to its root (anchored `openat2(RESOLVE_BENEATH)`), so a package **symlinked out of the mounted tree** (pnpm/yarn workspace or `file:` deps linking to the workspace root or an external store) is not followed and surfaces as not-found. Remediation: mount a directory that contains every symlink target (e.g. the workspace root), not the leaf `node_modules`.
- **End-to-end symlink regression** (`crates/sidecar/tests/node_modules_symlink_resolution.rs`): boots a real VM, projects a pnpm-style `node_modules` (top-level relative symlinks into `.pnpm`, plus a scoped package) at guest `/tmp/node_modules` via the same `host_dir` mount the TS `nodeModules` option emits, and asserts both a plain and a scoped symlinked package resolve from guest `import`.
- **Main-only ESM test** (`crates/execution/tests/module_resolution.rs`): a bare package whose `package.json` has `main` but no `exports` map (separate code path from `exports`).
- **Docs** (`features/module-loading`): note the escaping-symlink confinement and the mount-the-workspace-root fix.

## Not changed (by design)

The mount still confines reads to its root. We do **not** follow symlinks that escape the mounted tree: a malicious package installed by the client could plant a symlink to an arbitrary host path, and the read-only mount must not become a host-fs read primitive for guest code. The correct fix for workspace layouts is a wider mount root, which the docs and error now state.

## Verification

- `cargo test -p secure-exec-sidecar --test node_modules_symlink_resolution` → pnpm-symlinked plain + scoped packages resolve from guest `import`.
- `cargo test -p secure-exec-execution --test module_resolution` → 37 passed (incl. `faithful_pnpm_symlink_layout_resolves_via_realpath_walk`, `symlinked_package_escape_is_not_resolved`).
- Reproduced the user's path against published `secure-exec@0.3.1-rc.2`: plain, transitive, CJS `require`, `createRequire`, pnpm-symlink, `exports`-map, and scoped layouts all resolve; the only repros of the exact error are (a) `hostPath` pointed at the wrong directory and (b) a symlink escaping the mount root.

Refs #109.