### PR TITLE
fix: create crate asset dirs during publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -411,6 +411,7 @@ jobs:
             node packages/build-tools/scripts/build-v8-bridge.mjs --out-dir "$out"
           done
           git add -f crates/execution/assets/generated crates/v8-runtime/assets/generated
+          mkdir -p crates/kernel/assets crates/sidecar/assets
           cp packages/core/fixtures/base-filesystem.json crates/kernel/assets/base-filesystem.json
           cp packages/core/fixtures/base-filesystem.json crates/sidecar/assets/base-filesystem.json
       - name: Dry-run crate publish


### PR DESCRIPTION
## Summary\n- create crate asset directories before staging generated base filesystem files during crates.io publish\n\n## Validation\n- workflow-only fix; previous release run failed at the missing directory copy step\n