### PR TITLE
fix: publish secure-exec vfs crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ secure-exec-v8-runtime = { path = "crates/v8-runtime", version = "0.3.0-rc.1" }
 secure-exec-client = { path = "crates/secure-exec-client", version = "0.3.0-rc.1" }
 secure-exec-sidecar = { path = "crates/sidecar", version = "0.3.0-rc.1" }
 secure-exec-vfs = { path = "crates/secure-exec-vfs", version = "0.3.0-rc.1" }
-vfs = { path = "crates/vfs", version = "0.3.0-rc.1" }
+vfs = { package = "secure-exec-vfs-core", path = "crates/vfs", version = "0.3.0-rc.1" }
 vbare = "0.0.4"
 vbare-compiler = { package = "rivet-vbare-compiler", version = "0.0.5" }

--- a/crates/vfs/Cargo.toml
+++ b/crates/vfs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vfs"
+name = "secure-exec-vfs-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/scripts/publish/src/lib/rust-crates.ts
+++ b/scripts/publish/src/lib/rust-crates.ts
@@ -4,10 +4,12 @@ import { join } from "node:path";
 // Internal crates published to crates.io in dependency order.
 export const RUST_CRATE_ORDER = [
 	"secure-exec-bridge",
+	"secure-exec-vfs-core",
 	"secure-exec-kernel",
 	"secure-exec-v8-runtime",
 	"secure-exec-execution",
 	"secure-exec-vm-config",
+	"secure-exec-vfs",
 	"secure-exec-sidecar",
 	"secure-exec-client",
 ] as const;

--- a/scripts/publish/src/lib/version.ts
+++ b/scripts/publish/src/lib/version.ts
@@ -162,7 +162,7 @@ export async function bumpCargoVersions(
 	// the old `^0.3.0-rc.1` while the crate itself moved to the preview version,
 	// which fails cargo resolution ("failed to select a version for `vfs`").
 	next = next.replace(
-		/^([a-zA-Z0-9_-]+ = \{ path = "[^"]+", version = ")[^"]+(" \})/gm,
+		/^([a-zA-Z0-9_-]+ = \{ [^}\n]*path = "[^"]+", [^}\n]*version = ")[^"]+("[^}\n]*\})/gm,
 		`$1${version}$2`,
 	);
 


### PR DESCRIPTION
## Summary\n- restore the crates/vfs package name to secure-exec-vfs-core for crates.io\n- keep the workspace alias as vfs via package = "secure-exec-vfs-core"\n- include secure-exec-vfs-core and secure-exec-vfs in the crates.io publish order\n- make the version bumper handle package/path/version inline tables\n\n## Validation\n- pnpm --dir scripts/publish test\n- cargo metadata shows secure-exec-vfs-core and secure-exec-vfs workspace packages\n