### PR TITLE
fix: coerce default http2.connect port to a number

### DIFF
--- a/crates/execution/assets/v8-bridge.source.js
+++ b/crates/execution/assets/v8-bridge.source.js
@@ -16477,6 +16477,8 @@ ${headerLines}\r
     }
     validateHttp2ConnectOptions(options);
     const socketId = options.createConnection ? resolveHttp2SocketId(options.createConnection()) : void 0;
+    const rawPort = options.port ?? authority.port;
+    const port = rawPort === "" || rawPort === void 0 || rawPort === null ? void 0 : Number(rawPort);
     const response = JSON.parse(
       _networkHttp2SessionConnectRaw.applySyncPromise(
         void 0,
@@ -16485,7 +16487,7 @@ ${headerLines}\r
             authority: authority.toString(),
             protocol: authority.protocol,
             host: options.host ?? options.hostname ?? authority.hostname,
-            port: options.port ?? authority.port,
+            port,
             localAddress: options.localAddress,
             family: options.family,
             socketId,


### PR DESCRIPTION
http2.connect() with no explicit port shipped `port: ""` to the sidecar (WHATWG URL.port is the empty string for protocol-default ports, and `??` only falls back on null/undefined). The sidecar then failed to deserialize `""` into `Option<u16>`:

    ERR_AGENTOS_NODE_SYNC_RPC: net.http2_session_connect payload must be valid JSON: invalid type: string "", expected u16

Coerce the raw port to a number, mapping ""/undefined/null to undefined so the field is omitted. The sidecar already defaults an absent port via url.port()/scheme, so no Rust change is required. Fixes AWS Bedrock (HTTP/2 via @smithy/node-http-handler) connections.