### PR TITLE
feat: SidecarProcess.onStderr for live adapter log forwarding

### DIFF
--- a/crates/execution/assets/v8-bridge.source.js
+++ b/crates/execution/assets/v8-bridge.source.js
@@ -16477,6 +16477,8 @@ ${headerLines}\r
     }
     validateHttp2ConnectOptions(options);
     const socketId = options.createConnection ? resolveHttp2SocketId(options.createConnection()) : void 0;
+    const rawPort = options.port ?? authority.port;
+    const port = rawPort === "" || rawPort === void 0 || rawPort === null ? void 0 : Number(rawPort);
     const response = JSON.parse(
       _networkHttp2SessionConnectRaw.applySyncPromise(
         void 0,
@@ -16485,7 +16487,7 @@ ${headerLines}\r
             authority: authority.toString(),
             protocol: authority.protocol,
             host: options.host ?? options.hostname ?? authority.hostname,
-            port: options.port ?? authority.port,
+            port,
             localAddress: options.localAddress,
             family: options.family,
             socketId,

--- a/packages/core/src/sidecar-process.ts
+++ b/packages/core/src/sidecar-process.ts
@@ -289,6 +289,23 @@ export class SidecarProcess {
 		return this.protocolClient.onEvent(handler);
 	}
 
+	/**
+	 * Subscribe to the sidecar process's stderr (live). The sidecar re-emits the
+	 * in-VM agent adapter's stderr on this channel (tagged "ACP adapter stderr"),
+	 * so this is how embedders route adapter logs to their own logger. Coexists
+	 * with the internal stderr buffering used for exit diagnostics. Returns an
+	 * unsubscribe function.
+	 */
+	onStderr(handler: (chunk: Buffer) => void): () => void {
+		const onData = (chunk: Buffer | string) => {
+			handler(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+		};
+		this.protocolClient.child.stderr.on("data", onData);
+		return () => {
+			this.protocolClient.child.stderr.off("data", onData);
+		};
+	}
+
 	async authenticateAndOpenSession(
 		sessionMetadata: Record<string, string> = {},
 	): Promise<AuthenticatedSession> {


### PR DESCRIPTION
Paired with agent-os `abc/fixes-1`.

Adds `SidecarProcess.onStderr(handler)` so embedders can stream the sidecar's stderr live — the sidecar re-emits the in-VM agent adapter's stderr on this channel (tagged `ACP adapter stderr`), but it was previously only buffered and surfaced on process exit. Delegates to the protocol client's already-public child stderr; coexists with the internal exit-diagnostics buffering.

(Also contains the http2 default-port coercion commit, whose content already landed on `main` via #117; this PR's net new change is `onStderr`.)