### PR TITLE
feat(tools): binding.invoke tracing for tool-call visibility

### DIFF
--- a/crates/sidecar/src/tools.rs
+++ b/crates/sidecar/src/tools.rs
@@ -232,12 +232,14 @@ fn resolve_toolkit_command(
         )));
     };
     let callback_key = format!("{toolkit_name}:{tool_name}");
+    tracing::debug!(callback_key = %callback_key, "binding.invoke: resolving tool callback");
     let Some(tool) = vm
         .toolkits
         .get(toolkit_name)
         .and_then(|toolkit| toolkit.callbacks.get(tool_name))
         .cloned()
     else {
+        tracing::warn!(callback_key = %callback_key, "binding.invoke: unknown tool callback");
         return Ok(ToolCommandResolution::Failure(format!(
             "unknown tool callback {callback_key}"
         )));
@@ -251,6 +253,7 @@ fn resolve_toolkit_command(
         ),
         PermissionMode::Allow
     ) {
+        tracing::warn!(callback_key = %callback_key, "binding.invoke: blocked by policy");
         return Ok(ToolCommandResolution::Failure(format!(
             "blocked by binding.invoke policy for {callback_key}"
         )));
@@ -269,6 +272,11 @@ fn resolve_toolkit_command(
         return Ok(ToolCommandResolution::Failure(message));
     }
     let timeout_ms = tool.timeout_ms.unwrap_or(DEFAULT_TOOL_TIMEOUT_MS);
+    tracing::info!(
+        callback_key = %callback_key,
+        timeout_ms,
+        "binding.invoke: resolved tool callback"
+    );
 
     Ok(build_command_callback_resolution(
         &callback_key,


### PR DESCRIPTION
## What

Add tracing to `resolve_toolkit_command` in `crates/sidecar/src/tools.rs` — the `binding.invoke` resolution + policy gate that runs when a guest invokes a registered host tool. Today this path is completely silent, so a host-tool call can't be observed.

New events (target `secure_exec_sidecar::tools`):
- `debug!` — resolving tool callback (`callback_key`)
- `warn!` — unknown tool callback
- `warn!` — blocked by binding.invoke policy
- `info!` — resolved tool callback (`callback_key`, `timeout_ms`)

## Why

Debugging a tool-call hang in a consumer (`timed out waiting for sidecar protocol frame for ext`, "hangs before the tool fires"), the sidecar emitted nothing on the tool path. These four events make the hop visible: was the tool resolved, was it unknown, or was it blocked by policy — which splits "stuck in resolution/policy" from "stuck in the host round-trip."

## Notes
- Purely additive (tracing only); no control-flow change.
- Surfaces only when the consuming sidecar enables `RUST_LOG`/`EnvFilter` — pairs with the agent-os PR that makes `agentos-sidecar` logging configurable (rivet/agentos#1517).
- `cargo check` passes.