### PR TITLE
fix: backpressure bounded queues instead of destroying the session/sidecar + centralized queue tracker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,16 @@ Two corollaries that are easy to get wrong:
 - Every guest syscall goes through kernel-owned VFS, process, socket, pipe, PTY, permission, and DNS paths.
 - Present normal Linux semantics to tools. Fix runtime compatibility in secure-exec instead of patching callers around runtime quirks.
 
+## Limits, Bounds & Observability
+
+Every bound that protects a shared resource — memory/heap, CPU/wall-clock, fd/process/socket/pipe/pty counts, filesystem bytes/inodes, queue/buffer capacities, payload/frame sizes, timeouts, registration counts — MUST satisfy all of the following. A new `MAX_*`/`*_LIMIT`/`*_CAPACITY`/timeout/cap added without them is incomplete.
+
+- **Bounded by default.** Never `None`/`0`/unbounded (matches the Workers-style memory/CPU rule). Operators may raise a cap; they don't get an unbounded default. If a `0`/`None` genuinely means "engine default" (e.g. Pyodide old-space), say so in the inventory rationale.
+- **Config-wired + audited.** Operator-tunable bounds flow through `VmLimits` → `vm-config` (`limits_struct!`, Rust is the single source; TS mirrors via ts-rs). Every limit-shaped constant is classified in `crates/sidecar/tests/fixtures/limits-inventory.json` as `policy` (must name its `wired` config path) / `policy-deferred` / `invariant`, enforced by `crates/sidecar/tests/limits_audit.rs`. Never let a hardcoded operator bound accumulate uncatalogued.
+- **Registered for observability.** Register the bound with the central limit tracker (`secure_exec_bridge::queue_tracker`, generalizing to a limit registry) so usage/high-water are inspectable and it emits a **structured, edge-triggered warning as it approaches** (default ≥80% fill, re-arm <50%) naming the limit, observed/cap, fill%, and the `wired` config path. Note: the sidecar tracing level must be at least `WARN` for these to surface (`ERROR`-only swallows them).
+- **Clear, typed error on breach.** Fail with a typed error that names the limit and the observed-vs-cap value **with units**, plus how to raise it: `"<limit> exceeded: <observed><unit> > <cap><unit> (raise via limits.<wired>)"`. Map consistently — errno for kernel limits (but attach the limit name; no bare/opaque `EAGAIN`), `ExecutionAbortReason` for runtime kills, `SidecarError`/codec errors for config/protocol. No generic "invalid"/silent failure that hides which limit fired.
+- **No catastrophic reaction to transient fullness.** A full bounded queue/buffer applies **backpressure** (block the producer until the consumer drains) or returns the named error — never silently drop, silently evict, destroy the session, or crash the process. Raising a capacity is not a fix by itself; the warning + typed error must exist first. See PR #123 (event channel + stdout frame queue) for the reference pattern; audit every other channel/`VecDeque`/buffer against it.
+
 ## Project Boundaries
 
 - Keep this repo Agent OS-agnostic: no ACP, agents, sessions, `agentos-protocol`, `agentos-client`, or `agentos-sidecar` dependencies in secure-exec code.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,6 +2896,7 @@ version = "0.3.0-rc.1"
 dependencies = [
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -9,3 +9,4 @@ description = "Shared bridge contracts between the secure-exec kernel and execut
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
+tracing = "0.1"

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -2,6 +2,8 @@
 
 //! Shared bridge contracts between the secure-exec kernel and execution planes.
 
+pub mod queue_tracker;
+
 use std::collections::BTreeMap;
 use std::sync::OnceLock;
 use std::time::{Duration, SystemTime};

--- a/crates/bridge/src/queue_tracker.rs
+++ b/crates/bridge/src/queue_tracker.rs
@@ -1,0 +1,675 @@
+//! Centralized bounded-queue usage tracker.
+//!
+//! secure-exec streams guest output through a *chain* of bounded queues: the
+//! V8 -> host event channel, the sidecar stdout/stdin frame queues, and so on.
+//! Each queue applies backpressure when full (it parks the producer until the
+//! consumer drains) rather than crashing, but backpressure is invisible: a slow
+//! host consumer silently stalls a session with nothing in the logs.
+//!
+//! This module gives that whole chain a single, inspectable home:
+//!
+//! * Every bounded queue registers a [`QueueGauge`] (with a stable name and its
+//!   capacity) in a process-global [`QueueRegistry`].
+//! * Producers report depth as they enqueue (either by an exact count for
+//!   manually-tracked queues via [`TrackedSyncSender`], or by sampling the live
+//!   depth of a Tokio channel via [`QueueGauge::observe_depth`]).
+//! * When a queue crosses [`WARN_FILL_PERCENT`] of capacity the gauge emits a
+//!   single `warn!`, so "the consumer is falling behind" shows up *before* the
+//!   queue saturates and backpressure stalls the session. It re-arms once the
+//!   queue drains back below [`REARM_FILL_PERCENT`].
+//! * [`queue_snapshot`] returns the live depth / high-water / capacity of every
+//!   registered queue for debugging or a status endpoint.
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::mpsc::{Receiver, RecvError, SendError, SyncSender, TrySendError};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+
+/// Fill fraction (percent of capacity) at or above which a queue is considered
+/// "near full" and emits a warning. Edge-triggered so a steadily-full queue logs
+/// once, not on every enqueue.
+pub const WARN_FILL_PERCENT: usize = 80;
+
+/// Fill fraction a near-full queue must drain back below before it will warn
+/// again. The gap to [`WARN_FILL_PERCENT`] provides hysteresis so a queue
+/// hovering at the threshold does not flap.
+pub const REARM_FILL_PERCENT: usize = 50;
+
+/// What class of bounded resource a gauge tracks. Lets a snapshot / a host hook
+/// group and reason about limits beyond just queues.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LimitCategory {
+    /// A bounded channel/buffer with enqueue/dequeue flow (the default).
+    Queue,
+    /// A saturating resource counter (fds, processes, sockets, bytes in use).
+    Resource,
+    /// A memory/heap envelope.
+    Memory,
+    /// A CPU or wall-clock execution budget.
+    Cpu,
+}
+
+impl LimitCategory {
+    /// Stable lowercase tag for logs and snapshots.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LimitCategory::Queue => "queue",
+            LimitCategory::Resource => "resource",
+            LimitCategory::Memory => "memory",
+            LimitCategory::Cpu => "cpu",
+        }
+    }
+}
+
+/// Stable catalog of tracked limits that may emit near-capacity or exhaustion
+/// warnings. Keep `website/src/content/docs/docs/features/resource-limits.mdx`
+/// in sync when adding, removing, or renaming variants so host-visible warning
+/// names and the documented constants do not drift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TrackedLimit {
+    JavascriptEventChannel,
+    V8SessionFrames,
+    SidecarStdinFrames,
+    SidecarStdoutFrames,
+    CompletedSidecarResponses,
+    PendingProcessEvents,
+    PendingSidecarResponses,
+    OutboundSidecarRequests,
+    VmProcesses,
+    VmOpenFds,
+    VmPipes,
+    VmPtys,
+    VmSockets,
+    VmConnections,
+    VmSocketBufferedBytes,
+    VmSocketDatagramQueueLen,
+    VmFilesystemBytes,
+    VmInodes,
+    V8HeapBytes,
+    V8CpuTimeMs,
+    V8WallClockMs,
+    WasmFuelMs,
+    WasmMemoryBytes,
+}
+
+impl TrackedLimit {
+    /// Stable lowercase tag emitted in logs, snapshots, and host
+    /// `limit_warning` events.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TrackedLimit::JavascriptEventChannel => "javascript_event_channel",
+            TrackedLimit::V8SessionFrames => "v8_session_frames",
+            TrackedLimit::SidecarStdinFrames => "sidecar_stdin_frames",
+            TrackedLimit::SidecarStdoutFrames => "sidecar_stdout_frames",
+            TrackedLimit::CompletedSidecarResponses => "completed_sidecar_responses",
+            TrackedLimit::PendingProcessEvents => "pending_process_events",
+            TrackedLimit::PendingSidecarResponses => "pending_sidecar_responses",
+            TrackedLimit::OutboundSidecarRequests => "outbound_sidecar_requests",
+            TrackedLimit::VmProcesses => "vm_processes",
+            TrackedLimit::VmOpenFds => "vm_open_fds",
+            TrackedLimit::VmPipes => "vm_pipes",
+            TrackedLimit::VmPtys => "vm_ptys",
+            TrackedLimit::VmSockets => "vm_sockets",
+            TrackedLimit::VmConnections => "vm_connections",
+            TrackedLimit::VmSocketBufferedBytes => "vm_socket_buffered_bytes",
+            TrackedLimit::VmSocketDatagramQueueLen => "vm_socket_datagram_queue_len",
+            TrackedLimit::VmFilesystemBytes => "vm_filesystem_bytes",
+            TrackedLimit::VmInodes => "vm_inodes",
+            TrackedLimit::V8HeapBytes => "v8_heap_bytes",
+            TrackedLimit::V8CpuTimeMs => "v8_cpu_time_ms",
+            TrackedLimit::V8WallClockMs => "v8_wall_clock_ms",
+            TrackedLimit::WasmFuelMs => "wasm_fuel_ms",
+            TrackedLimit::WasmMemoryBytes => "wasm_memory_bytes",
+        }
+    }
+
+    pub fn category(self) -> LimitCategory {
+        match self {
+            TrackedLimit::JavascriptEventChannel
+            | TrackedLimit::V8SessionFrames
+            | TrackedLimit::SidecarStdinFrames
+            | TrackedLimit::SidecarStdoutFrames
+            | TrackedLimit::CompletedSidecarResponses
+            | TrackedLimit::PendingProcessEvents
+            | TrackedLimit::PendingSidecarResponses
+            | TrackedLimit::OutboundSidecarRequests => LimitCategory::Queue,
+            TrackedLimit::VmProcesses
+            | TrackedLimit::VmOpenFds
+            | TrackedLimit::VmPipes
+            | TrackedLimit::VmPtys
+            | TrackedLimit::VmSockets
+            | TrackedLimit::VmConnections
+            | TrackedLimit::VmSocketBufferedBytes
+            | TrackedLimit::VmSocketDatagramQueueLen
+            | TrackedLimit::VmFilesystemBytes
+            | TrackedLimit::VmInodes => LimitCategory::Resource,
+            TrackedLimit::V8HeapBytes | TrackedLimit::WasmMemoryBytes => LimitCategory::Memory,
+            TrackedLimit::V8CpuTimeMs | TrackedLimit::V8WallClockMs | TrackedLimit::WasmFuelMs => {
+                LimitCategory::Cpu
+            }
+        }
+    }
+}
+
+/// A near-capacity event for one limit, delivered to the global warning sink at
+/// the same edge as the `tracing::warn!`. This is the structured payload a host
+/// hook (e.g. agentOS `onLimitWarning`) is built from.
+#[derive(Debug, Clone)]
+pub struct LimitWarning {
+    pub name: TrackedLimit,
+    pub category: LimitCategory,
+    pub observed: usize,
+    pub capacity: usize,
+    pub fill_percent: usize,
+}
+
+type LimitWarningHandler = Arc<dyn Fn(&LimitWarning) + Send + Sync>;
+
+fn warning_handler_slot() -> &'static Mutex<Option<LimitWarningHandler>> {
+    static HANDLER: OnceLock<Mutex<Option<LimitWarningHandler>>> = OnceLock::new();
+    HANDLER.get_or_init(|| Mutex::new(None))
+}
+
+/// Install a process-global sink that is invoked on the same edge-triggered,
+/// hysteresis-gated boundary as the `tracing::warn!` whenever a tracked limit
+/// crosses [`WARN_FILL_PERCENT`]. The sidecar uses this to forward limit warnings
+/// to the host as structured events (the `onLimitWarning` hook). The handler must
+/// be cheap and non-blocking; it runs on the producer's thread.
+pub fn set_limit_warning_handler(handler: Box<dyn Fn(&LimitWarning) + Send + Sync>) {
+    if let Ok(mut slot) = warning_handler_slot().lock() {
+        *slot = Some(Arc::from(handler));
+    }
+}
+
+fn dispatch_warning(warning: &LimitWarning) {
+    // Clone the handler Arc out and DROP the registry mutex before invoking it,
+    // so the handler never runs while we hold the global lock. The sink can be
+    // reached while a kernel lock is held (e.g. fd_tables -> warning_mutex ->
+    // handler); keeping the invocation outside the mutex avoids a lock-order
+    // hazard if the handler ever does non-trivial work.
+    let handler = match warning_handler_slot().lock() {
+        Ok(slot) => slot.as_ref().cloned(),
+        Err(_) => None,
+    };
+    if let Some(handler) = handler {
+        handler(warning);
+    }
+}
+
+/// Emit a structured/logged warning for a limit that has already been exhausted.
+/// Use this for runtime caps such as CPU or heap exhaustion where there is no
+/// continuously sampled queue depth to observe before the terminal edge.
+pub fn warn_limit_exhausted(name: TrackedLimit, observed: usize, capacity: usize) {
+    let fill_percent = if capacity == 0 {
+        0
+    } else {
+        observed.saturating_mul(100) / capacity
+    };
+    let category = name.category();
+    tracing::warn!(
+        limit = name.as_str(),
+        category = category.as_str(),
+        observed,
+        capacity,
+        fill_percent,
+        "bounded limit exhausted"
+    );
+    dispatch_warning(&LimitWarning {
+        name,
+        category,
+        observed,
+        capacity,
+        fill_percent,
+    });
+}
+
+/// Live usage gauge for a single bounded queue.
+///
+/// Cloneable handles share one gauge through an [`Arc`]; the registry keeps a
+/// [`Weak`] so a gauge is auto-pruned from snapshots once its queue is dropped.
+#[derive(Debug)]
+pub struct QueueGauge {
+    name: TrackedLimit,
+    category: LimitCategory,
+    capacity: usize,
+    depth: AtomicUsize,
+    high_water: AtomicUsize,
+    warned: AtomicBool,
+}
+
+impl QueueGauge {
+    fn new(name: TrackedLimit, capacity: usize, category: LimitCategory) -> Self {
+        Self {
+            name,
+            category,
+            capacity,
+            depth: AtomicUsize::new(0),
+            high_water: AtomicUsize::new(0),
+            warned: AtomicBool::new(false),
+        }
+    }
+
+    /// Stable limit name (used in logs and snapshots).
+    pub fn name(&self) -> TrackedLimit {
+        self.name
+    }
+
+    /// The class of bounded resource this gauge tracks.
+    pub fn category(&self) -> LimitCategory {
+        self.category
+    }
+
+    /// Configured queue capacity (slots). `0` means unbounded / untracked.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Current observed depth.
+    pub fn depth(&self) -> usize {
+        self.depth.load(Ordering::Acquire)
+    }
+
+    /// Highest depth observed over the gauge's lifetime.
+    pub fn high_water(&self) -> usize {
+        self.high_water.load(Ordering::Acquire)
+    }
+
+    /// Fill fraction (0–100) at the given depth. Saturates rather than dividing
+    /// by zero for untracked (capacity 0) queues.
+    fn fill_percent(&self, depth: usize) -> usize {
+        if self.capacity == 0 {
+            0
+        } else {
+            depth.saturating_mul(100) / self.capacity
+        }
+    }
+
+    /// Record a new depth: refresh the high-water mark and emit an edge-triggered
+    /// near-capacity warning (or recovery debug line).
+    fn evaluate(&self, depth: usize) {
+        self.high_water.fetch_max(depth, Ordering::AcqRel);
+        if self.capacity == 0 {
+            return;
+        }
+        let percent = self.fill_percent(depth);
+        if percent >= WARN_FILL_PERCENT {
+            if !self.warned.swap(true, Ordering::AcqRel) {
+                tracing::warn!(
+                    limit = self.name.as_str(),
+                    category = self.category.as_str(),
+                    observed = depth,
+                    capacity = self.capacity,
+                    fill_percent = percent,
+                    "bounded limit near capacity"
+                );
+                // Same edge as the log: notify the structured warning sink so the
+                // host can surface it (e.g. an onLimitWarning hook). Edge-triggered
+                // + hysteresis keep this from firing more than once per crossing.
+                dispatch_warning(&LimitWarning {
+                    name: self.name,
+                    category: self.category,
+                    observed: depth,
+                    capacity: self.capacity,
+                    fill_percent: percent,
+                });
+            }
+        } else if percent <= REARM_FILL_PERCENT && self.warned.swap(false, Ordering::AcqRel) {
+            tracing::debug!(
+                limit = self.name.as_str(),
+                category = self.category.as_str(),
+                depth,
+                capacity = self.capacity,
+                fill_percent = percent,
+                "bounded limit drained back below threshold"
+            );
+        }
+    }
+
+    /// Report the queue's exact current depth (for queues whose backing channel
+    /// exposes its live length, e.g. a Tokio mpsc via `max_capacity - capacity`).
+    pub fn observe_depth(&self, depth: usize) {
+        self.depth.store(depth, Ordering::Release);
+        self.evaluate(depth);
+    }
+
+    /// Account for one item entering the queue (for manually-tracked queues).
+    pub fn record_enqueue(&self) {
+        let depth = self.depth.fetch_add(1, Ordering::AcqRel) + 1;
+        self.evaluate(depth);
+    }
+
+    /// Account for one item leaving the queue. Saturates at zero so a stray
+    /// dequeue can never underflow the depth counter. Re-evaluates so a gauge
+    /// that latched "warned" while full re-arms once the queue drains back below
+    /// the re-arm threshold, even if the producer has since gone idle.
+    pub fn record_dequeue(&self) {
+        let mut current = self.depth.load(Ordering::Acquire);
+        loop {
+            if current == 0 {
+                return;
+            }
+            match self.depth.compare_exchange_weak(
+                current,
+                current - 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    self.evaluate(current - 1);
+                    break;
+                }
+                Err(actual) => current = actual,
+            }
+        }
+    }
+}
+
+/// Immutable view of a tracked limit's usage, returned by [`queue_snapshot`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueueSnapshot {
+    pub name: TrackedLimit,
+    pub category: LimitCategory,
+    pub depth: usize,
+    pub high_water: usize,
+    pub capacity: usize,
+    pub fill_percent: usize,
+}
+
+/// Process-global registry of every live [`QueueGauge`].
+#[derive(Default)]
+pub struct QueueRegistry {
+    gauges: Mutex<Vec<Weak<QueueGauge>>>,
+}
+
+impl QueueRegistry {
+    /// The shared registry. All `secure-exec` bounded queues register here so
+    /// their usage can be inspected from one place.
+    pub fn global() -> &'static QueueRegistry {
+        static REGISTRY: OnceLock<QueueRegistry> = OnceLock::new();
+        REGISTRY.get_or_init(QueueRegistry::default)
+    }
+
+    /// Register a new bounded limit and return its gauge. Dropping the returned
+    /// `Arc` (and all clones) removes the limit from future snapshots.
+    pub fn register(&self, name: TrackedLimit, capacity: usize) -> Arc<QueueGauge> {
+        let category = name.category();
+        let gauge = Arc::new(QueueGauge::new(name, capacity, category));
+        let mut gauges = self.gauges.lock().expect("queue registry mutex poisoned");
+        gauges.retain(|weak| weak.strong_count() > 0);
+        gauges.push(Arc::downgrade(&gauge));
+        gauge
+    }
+
+    /// Snapshot the live usage of every registered queue, pruning dead entries.
+    pub fn snapshot(&self) -> Vec<QueueSnapshot> {
+        let mut gauges = self.gauges.lock().expect("queue registry mutex poisoned");
+        gauges.retain(|weak| weak.strong_count() > 0);
+        gauges
+            .iter()
+            .filter_map(Weak::upgrade)
+            .map(|gauge| {
+                let depth = gauge.depth();
+                QueueSnapshot {
+                    name: gauge.name(),
+                    category: gauge.category(),
+                    depth,
+                    high_water: gauge.high_water(),
+                    capacity: gauge.capacity(),
+                    fill_percent: gauge.fill_percent(depth),
+                }
+            })
+            .collect()
+    }
+}
+
+/// Register a bounded queue (the [`LimitCategory::Queue`] case) with the global
+/// registry. Convenience over [`QueueRegistry::global`] + [`QueueRegistry::register`].
+pub fn register_queue(name: TrackedLimit, capacity: usize) -> Arc<QueueGauge> {
+    debug_assert_eq!(name.category(), LimitCategory::Queue);
+    QueueRegistry::global().register(name, capacity)
+}
+
+/// Register a non-queue bounded limit (a saturating resource or memory envelope)
+/// with the global registry, so it shares the same approach-warning + snapshot
+/// machinery as queues. Observe usage with [`QueueGauge::observe_depth`].
+pub fn register_limit(name: TrackedLimit, capacity: usize) -> Arc<QueueGauge> {
+    QueueRegistry::global().register(name, capacity)
+}
+
+/// Snapshot every registered queue from the global registry.
+pub fn queue_snapshot() -> Vec<QueueSnapshot> {
+    QueueRegistry::global().snapshot()
+}
+
+/// Emit a `debug!` line for every registered queue. Useful for an on-demand dump
+/// of the queue chain when diagnosing a stall.
+pub fn log_queue_snapshot() {
+    for stat in queue_snapshot() {
+        tracing::debug!(
+            limit = stat.name.as_str(),
+            category = stat.category.as_str(),
+            depth = stat.depth,
+            high_water = stat.high_water,
+            capacity = stat.capacity,
+            fill_percent = stat.fill_percent,
+            "limit usage"
+        );
+    }
+}
+
+/// A `std::sync::mpsc::SyncSender` that feeds a [`QueueGauge`] as items flow
+/// through it, so a queue whose backing channel cannot report its own length
+/// still participates in the centralized tracker.
+///
+/// `send` keeps the underlying blocking-backpressure semantics; it just records
+/// the enqueue first so near-capacity warnings fire as the queue fills.
+#[derive(Debug)]
+pub struct TrackedSyncSender<T> {
+    inner: SyncSender<T>,
+    gauge: Arc<QueueGauge>,
+}
+
+impl<T> Clone for TrackedSyncSender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            gauge: Arc::clone(&self.gauge),
+        }
+    }
+}
+
+impl<T> TrackedSyncSender<T> {
+    /// Blocking send: record the enqueue, then hand off to the bounded channel
+    /// (which parks the caller until a slot is free: clean backpressure).
+    pub fn send(&self, value: T) -> Result<(), SendError<T>> {
+        self.gauge.record_enqueue();
+        self.inner.send(value)
+    }
+
+    /// Non-blocking send: record the enqueue only on success. Lets a caller with
+    /// its own deadline poll instead of parking indefinitely on a full queue.
+    pub fn try_send(&self, value: T) -> Result<(), TrySendError<T>> {
+        match self.inner.try_send(value) {
+            Ok(()) => {
+                self.gauge.record_enqueue();
+                Ok(())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    /// The gauge backing this sender.
+    pub fn gauge(&self) -> &Arc<QueueGauge> {
+        &self.gauge
+    }
+}
+
+/// Receiver half of a [`tracked_sync_channel`]; records a dequeue for every
+/// item it yields so the gauge depth tracks the real backlog.
+#[derive(Debug)]
+pub struct TrackedReceiver<T> {
+    inner: Receiver<T>,
+    gauge: Arc<QueueGauge>,
+}
+
+impl<T> TrackedReceiver<T> {
+    /// Blocking receive that decrements the gauge for the item it returns.
+    pub fn recv(&self) -> Result<T, RecvError> {
+        let value = self.inner.recv()?;
+        self.gauge.record_dequeue();
+        Ok(value)
+    }
+}
+
+/// Create a bounded `std::sync::mpsc` sync-channel whose depth is tracked by a
+/// registered [`QueueGauge`]. Drop-in for `std::sync::mpsc::sync_channel` plus
+/// centralized usage tracking + near-capacity warnings.
+pub fn tracked_sync_channel<T>(
+    name: TrackedLimit,
+    capacity: usize,
+) -> (TrackedSyncSender<T>, TrackedReceiver<T>) {
+    let (tx, rx) = std::sync::mpsc::sync_channel(capacity);
+    let gauge = register_queue(name, capacity);
+    (
+        TrackedSyncSender {
+            inner: tx,
+            gauge: Arc::clone(&gauge),
+        },
+        TrackedReceiver { inner: rx, gauge },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gauge_tracks_depth_and_high_water() {
+        let gauge = QueueGauge::new(
+            TrackedLimit::JavascriptEventChannel,
+            10,
+            LimitCategory::Queue,
+        );
+        assert_eq!(gauge.depth(), 0);
+        gauge.record_enqueue();
+        gauge.record_enqueue();
+        assert_eq!(gauge.depth(), 2);
+        assert_eq!(gauge.high_water(), 2);
+        gauge.record_dequeue();
+        assert_eq!(gauge.depth(), 1);
+        // High-water never regresses.
+        assert_eq!(gauge.high_water(), 2);
+        // Dequeue never underflows below zero.
+        gauge.record_dequeue();
+        gauge.record_dequeue();
+        assert_eq!(gauge.depth(), 0);
+    }
+
+    #[test]
+    fn gauge_warn_flag_is_edge_triggered_with_hysteresis() {
+        let gauge = QueueGauge::new(TrackedLimit::V8SessionFrames, 10, LimitCategory::Queue);
+        // Below 80%: not warned.
+        gauge.observe_depth(7);
+        assert!(!gauge.warned.load(Ordering::Acquire));
+        // Cross 80%: warned.
+        gauge.observe_depth(8);
+        assert!(gauge.warned.load(Ordering::Acquire));
+        // Still near full: stays armed (single warning, not re-fired).
+        gauge.observe_depth(9);
+        assert!(gauge.warned.load(Ordering::Acquire));
+        // Drain to <=50%: re-arms.
+        gauge.observe_depth(5);
+        assert!(!gauge.warned.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn gauge_rearms_on_dequeue_drain() {
+        // record_enqueue/record_dequeue gauges (TrackedSyncSender/Receiver) must
+        // also re-arm as they drain, not only stay latched after the producer idles.
+        let gauge = QueueGauge::new(TrackedLimit::SidecarStdoutFrames, 10, LimitCategory::Queue);
+        for _ in 0..9 {
+            gauge.record_enqueue(); // climbs to 90% -> warned
+        }
+        assert_eq!(gauge.depth(), 9);
+        assert!(gauge.warned.load(Ordering::Acquire));
+        for _ in 0..6 {
+            gauge.record_dequeue(); // drains to 30% (<=50%) -> re-arm on dequeue
+        }
+        assert_eq!(gauge.depth(), 3);
+        assert!(!gauge.warned.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn tracked_channel_reports_usage_through_registry() {
+        let (tx, rx) = tracked_sync_channel::<u32>(TrackedLimit::SidecarStdoutFrames, 4);
+        tx.send(1).unwrap();
+        tx.send(2).unwrap();
+
+        let snapshot = queue_snapshot();
+        let entry = snapshot
+            .iter()
+            .find(|stat| stat.name == TrackedLimit::SidecarStdoutFrames)
+            .expect("registered queue should appear in snapshot");
+        assert_eq!(entry.depth, 2);
+        assert_eq!(entry.capacity, 4);
+        assert_eq!(entry.high_water, 2);
+        assert_eq!(entry.fill_percent, 50);
+        assert_eq!(entry.category, LimitCategory::Queue);
+
+        assert_eq!(rx.recv().unwrap(), 1);
+        assert_eq!(tx.gauge().depth(), 1);
+
+        // Dropping the channel removes it from later snapshots.
+        drop(tx);
+        drop(rx);
+        assert!(queue_snapshot()
+            .iter()
+            .all(|stat| stat.name != TrackedLimit::SidecarStdoutFrames));
+    }
+
+    #[test]
+    fn warning_sink_fires_once_per_crossing() {
+        let captured: Arc<Mutex<Vec<LimitWarning>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&captured);
+        // The handler is global; filter by our unique name so a gauge from a
+        // concurrently-running test can never pollute this assertion.
+        set_limit_warning_handler(Box::new(move |warning| {
+            if warning.name == TrackedLimit::VmPipes {
+                sink.lock().expect("sink mutex").push(warning.clone());
+            }
+        }));
+
+        let gauge = register_limit(TrackedLimit::VmPipes, 10);
+        gauge.observe_depth(7); // below 80%: no warning
+        assert!(captured.lock().unwrap().is_empty());
+        gauge.observe_depth(9); // crosses 80%: fires once
+        gauge.observe_depth(10); // still near full: must NOT re-fire (edge-triggered)
+
+        let warnings = captured.lock().unwrap();
+        assert_eq!(
+            warnings.len(),
+            1,
+            "warning sink must fire once per crossing"
+        );
+        assert_eq!(warnings[0].category, LimitCategory::Resource);
+        assert_eq!(warnings[0].capacity, 10);
+        assert!(warnings[0].fill_percent >= WARN_FILL_PERCENT);
+    }
+
+    #[test]
+    fn exhausted_warning_sink_fires_immediately() {
+        let captured: Arc<Mutex<Vec<LimitWarning>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&captured);
+        set_limit_warning_handler(Box::new(move |warning| {
+            if warning.name == TrackedLimit::V8CpuTimeMs {
+                sink.lock().expect("sink mutex").push(warning.clone());
+            }
+        }));
+
+        warn_limit_exhausted(TrackedLimit::V8CpuTimeMs, 30_000, 30_000);
+
+        let warnings = captured.lock().unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].category, LimitCategory::Cpu);
+        assert_eq!(warnings[0].fill_percent, 100);
+    }
+}

--- a/crates/execution/src/javascript.rs
+++ b/crates/execution/src/javascript.rs
@@ -11,6 +11,7 @@ use crate::v8_host::{V8RuntimeHost, V8SessionHandle};
 use crate::v8_ipc::BinaryFrame;
 use crate::v8_runtime;
 use getrandom::getrandom;
+use secure_exec_bridge::queue_tracker::{register_queue, TrackedLimit, TrackedReceiver};
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -28,9 +29,7 @@ use std::sync::{
 use std::thread;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{
-    channel,
-    error::{TryRecvError as TokioTryRecvError, TrySendError as TokioTrySendError},
-    Receiver as TokioReceiver,
+    channel, error::TryRecvError as TokioTryRecvError, Receiver as TokioReceiver,
 };
 use tokio::time;
 
@@ -82,7 +81,10 @@ const V8_WALL_CLOCK_LIMIT_MS_ENV: &str = "AGENTOS_V8_WALL_CLOCK_LIMIT_MS";
 const NODE_SYNC_RPC_DEFAULT_DATA_BYTES: usize = 4 * 1024 * 1024;
 const NODE_SYNC_RPC_DEFAULT_WAIT_TIMEOUT_MS: u64 = 30_000;
 const NODE_SYNC_RPC_RESPONSE_QUEUE_CAPACITY: usize = 1;
-const JAVASCRIPT_EVENT_CHANNEL_CAPACITY: usize = 64;
+// Defense-in-depth headroom: a transient burst of guest events (e.g. a chatty
+// tool/skill turn) should be absorbed by the buffer, so the producer only ever
+// hits backpressure under a genuinely stuck consumer rather than on every spike.
+const JAVASCRIPT_EVENT_CHANNEL_CAPACITY: usize = 512;
 const JAVASCRIPT_EVENT_PAYLOAD_LIMIT_BYTES: usize = 1024 * 1024;
 const JAVASCRIPT_CAPTURED_OUTPUT_LIMIT_BYTES: usize = 16 * 1024 * 1024;
 const KERNEL_STDIN_BUFFER_LIMIT_BYTES: usize = 16 * 1024 * 1024;
@@ -1587,7 +1589,7 @@ impl Drop for V8SessionRegistrationGuard<'_> {
 }
 
 struct PendingV8SessionRegistration<'a> {
-    frame_receiver: Receiver<BinaryFrame>,
+    frame_receiver: TrackedReceiver<BinaryFrame>,
     registration_guard: V8SessionRegistrationGuard<'a>,
 }
 
@@ -1728,15 +1730,18 @@ impl JavascriptExecutionEngine {
             "v8-{execution_id}-{}",
             NEXT_V8_SESSION_ID.fetch_add(1, Ordering::Relaxed)
         );
+        let heap_limit_mb = javascript_heap_limit_mb(&request);
+        let cpu_time_limit_ms = javascript_cpu_time_limit_ms(&request);
+        let wall_clock_limit_ms = javascript_wall_clock_limit_ms(&request);
         let PendingV8SessionRegistration {
             frame_receiver,
             mut registration_guard,
         } = register_v8_session(
             v8_host,
             session_id.clone(),
-            javascript_heap_limit_mb(&request),
-            javascript_cpu_time_limit_ms(&request),
-            javascript_wall_clock_limit_ms(&request),
+            heap_limit_mb,
+            cpu_time_limit_ms,
+            wall_clock_limit_ms,
             |frame| v8_host.send_frame(frame),
         )?;
 
@@ -1803,7 +1808,7 @@ impl JavascriptExecutionEngine {
             &process_argv,
             translator.guest_cwd(),
             &request.env,
-            javascript_heap_limit_mb(&request),
+            heap_limit_mb,
             &request.guest_runtime,
         );
 
@@ -2649,13 +2654,17 @@ fn prepend_v8_runtime_shim(
 /// by the event bridge. Kernel operations (fs, net, child_process, dns) are
 /// forwarded to the sidecar via SyncRpcRequest events.
 fn spawn_v8_event_bridge(
-    frame_receiver: mpsc::Receiver<BinaryFrame>,
+    frame_receiver: TrackedReceiver<BinaryFrame>,
     pending_sync_rpc: Arc<Mutex<Option<PendingSyncRpcState>>>,
     _sync_rpc_timeout: Duration,
     v8_session: V8SessionHandle,
     mut local_bridge: LocalBridgeState,
 ) -> TokioReceiver<JavascriptExecutionEvent> {
     let (sender, receiver) = channel(JAVASCRIPT_EVENT_CHANNEL_CAPACITY);
+    let event_gauge = register_queue(
+        TrackedLimit::JavascriptEventChannel,
+        JAVASCRIPT_EVENT_CHANNEL_CAPACITY,
+    );
 
     thread::spawn(move || {
         let mut emitted_exit = false;
@@ -2720,6 +2729,7 @@ fn spawn_v8_event_bridge(
                             if !send_javascript_event(
                                 &sender,
                                 &v8_session,
+                                &event_gauge,
                                 JavascriptExecutionEvent::Stdout(output),
                             ) {
                                 break;
@@ -2728,6 +2738,7 @@ fn spawn_v8_event_bridge(
                             if !send_javascript_event(
                                 &sender,
                                 &v8_session,
+                                &event_gauge,
                                 JavascriptExecutionEvent::Stderr(output),
                             ) {
                                 break;
@@ -2790,6 +2801,7 @@ fn spawn_v8_event_bridge(
                         if !send_javascript_event(
                             &sender,
                             &v8_session,
+                            &event_gauge,
                             JavascriptExecutionEvent::Stderr(error_msg.into_bytes()),
                         ) {
                             break;
@@ -2803,15 +2815,19 @@ fn spawn_v8_event_bridge(
             };
 
             if let Some(event) = event {
-                if !send_javascript_event(&sender, &v8_session, event) {
+                if !send_javascript_event(&sender, &v8_session, &event_gauge, event) {
                     break;
                 }
             }
         }
 
         if !emitted_exit {
-            let _ =
-                send_javascript_event(&sender, &v8_session, JavascriptExecutionEvent::Exited(1));
+            let _ = send_javascript_event(
+                &sender,
+                &v8_session,
+                &event_gauge,
+                JavascriptExecutionEvent::Exited(1),
+            );
         }
     });
 
@@ -2821,6 +2837,7 @@ fn spawn_v8_event_bridge(
 fn send_javascript_event(
     sender: &tokio::sync::mpsc::Sender<JavascriptExecutionEvent>,
     v8_session: &V8SessionHandle,
+    gauge: &secure_exec_bridge::queue_tracker::QueueGauge,
     event: JavascriptExecutionEvent,
 ) -> bool {
     if javascript_event_payload_len(&event) > JAVASCRIPT_EVENT_PAYLOAD_LIMIT_BYTES {
@@ -2828,13 +2845,24 @@ fn send_javascript_event(
         return false;
     }
 
-    match sender.try_send(event) {
-        Ok(()) => true,
-        Err(TokioTrySendError::Full(_)) => {
-            let _ = v8_session.destroy();
-            false
+    // Apply backpressure instead of self-destructing when the host consumer is
+    // slow. A burst of guest events that briefly outpaces the host draining this
+    // channel is normal; previously a single `try_send` returning `Full` tore the
+    // whole session down (`destroy()` -> Shutdown -> `Exited(1)`), turning a
+    // transient backlog into a fatal crash. This bridge runs on its own dedicated
+    // OS thread (never a Tokio runtime worker), so a blocking send is safe: it
+    // parks this thread — and, in turn, the guest producing into it — until the
+    // host drains capacity. The only terminal condition is the receiver being
+    // dropped (host gone for good), which surfaces as `Closed` and stops the loop.
+    match sender.blocking_send(event) {
+        Ok(()) => {
+            // Sample the live channel depth so the centralized queue tracker can
+            // warn before the host consumer falls far enough behind to stall the
+            // session (and surface the high-water mark for debugging).
+            gauge.observe_depth(sender.max_capacity().saturating_sub(sender.capacity()));
+            true
         }
-        Err(TokioTrySendError::Closed(_)) => false,
+        Err(_closed) => false,
     }
 }
 
@@ -6629,15 +6657,20 @@ mod tests {
         drop(receiver);
         let host = V8RuntimeHost::spawn().expect("spawn V8 runtime host");
         let session = host.session_handle(String::from("closed-event-sender-test"));
+        let gauge = register_queue(TrackedLimit::JavascriptEventChannel, 1);
         assert!(!send_javascript_event(
             &sender,
             &session,
+            &gauge,
             JavascriptExecutionEvent::Exited(1)
         ));
     }
 
+    // Regression: a full event channel must apply backpressure, not destroy the
+    // session. The old code called `v8_session.destroy()` on the first `Full`,
+    // truncating the stream and tearing the session down.
     #[test]
-    fn javascript_event_sender_destroys_session_when_channel_is_full() {
+    fn javascript_event_sender_backpressures_instead_of_destroying_when_full() {
         let host = V8RuntimeHost::spawn().expect("spawn V8 runtime host");
         let session_id = format!(
             "event-overflow-{}",
@@ -6646,28 +6679,42 @@ mod tests {
                 .expect("system time")
                 .as_nanos()
         );
-        let receiver = host
+        let _session_receiver = host
             .register_session(&session_id)
             .expect("register event overflow session");
         let session = host.session_handle(session_id.clone());
-        let (sender, _event_receiver) = channel(1);
+        let gauge = register_queue(TrackedLimit::JavascriptEventChannel, 1);
+        let (sender, mut event_receiver) = channel(1);
 
-        assert!(send_javascript_event(
-            &sender,
-            &session,
-            JavascriptExecutionEvent::Stdout(Vec::new())
-        ));
-        assert!(!send_javascript_event(
-            &sender,
-            &session,
-            JavascriptExecutionEvent::Stdout(Vec::new())
-        ));
+        // Drain slowly on another thread so the producer is forced onto the
+        // blocking-backpressure path the old destroy-on-full code never reached.
+        let drainer = std::thread::spawn(move || {
+            let mut drained = 0usize;
+            while event_receiver.blocking_recv().is_some() {
+                drained += 1;
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            drained
+        });
 
-        drop(receiver);
-        let recovered = host
-            .register_session(&session_id)
-            .expect("overflow should destroy and deregister the session");
-        drop(recovered);
+        // Far more events than the 1-slot channel holds; every send must succeed.
+        const SENDS: usize = 16;
+        for _ in 0..SENDS {
+            assert!(send_javascript_event(
+                &sender,
+                &session,
+                &gauge,
+                JavascriptExecutionEvent::Stdout(Vec::new())
+            ));
+        }
+        drop(sender);
+        let drained = drainer.join().expect("drainer thread panicked");
+        assert_eq!(drained, SENDS, "every event must survive backpressure");
+
+        // The session must NOT have been destroyed: it is still registered, so a
+        // re-registration attempt fails.
+        host.register_session(&session_id)
+            .expect_err("session must survive backpressure (not be destroyed)");
         host.unregister_session(&session_id);
     }
 
@@ -6686,10 +6733,15 @@ mod tests {
             .expect("register oversized event session");
         let session = host.session_handle(session_id.clone());
         let (sender, _event_receiver) = channel(JAVASCRIPT_EVENT_CHANNEL_CAPACITY);
+        let gauge = register_queue(
+            TrackedLimit::JavascriptEventChannel,
+            JAVASCRIPT_EVENT_CHANNEL_CAPACITY,
+        );
 
         assert!(!send_javascript_event(
             &sender,
             &session,
+            &gauge,
             JavascriptExecutionEvent::Stdout(vec![0; JAVASCRIPT_EVENT_PAYLOAD_LIMIT_BYTES + 1])
         ));
 

--- a/crates/execution/src/v8_host.rs
+++ b/crates/execution/src/v8_host.rs
@@ -1,12 +1,13 @@
 //! V8 runtime host — manages a shared embedded V8 runtime with session multiplexing.
 
 use crate::v8_ipc::{self, BinaryFrame};
+use secure_exec_bridge::queue_tracker::{tracked_sync_channel, TrackedLimit, TrackedReceiver};
 use secure_exec_v8_runtime::embedded_runtime::{
     shared_embedded_runtime, EmbeddedV8Runtime, EmbeddedV8SessionHandle,
 };
 use secure_exec_v8_runtime::runtime_protocol::{RuntimeCommand, RuntimeEvent};
 use std::io::{self, Cursor};
-use std::sync::{mpsc, Arc, OnceLock};
+use std::sync::{Arc, OnceLock};
 use std::thread;
 
 const V8_SESSION_FRAME_CHANNEL_CAPACITY: usize = 1024;
@@ -36,12 +37,15 @@ impl V8RuntimeHost {
     }
 
     /// Register a session and return a receiver for its frames.
-    pub fn register_session(&self, session_id: &str) -> io::Result<mpsc::Receiver<BinaryFrame>> {
+    pub fn register_session(&self, session_id: &str) -> io::Result<TrackedReceiver<BinaryFrame>> {
         let (runtime_receiver, registration) = self
             .shared
             .runtime
             .register_session_with_output_registration(session_id)?;
-        let (sender, receiver) = mpsc::sync_channel(V8_SESSION_FRAME_CHANNEL_CAPACITY);
+        let (sender, receiver) = tracked_sync_channel(
+            TrackedLimit::V8SessionFrames,
+            V8_SESSION_FRAME_CHANNEL_CAPACITY,
+        );
         let thread_name = format!("secure-exec-v8-session-{session_id}");
         let runtime = Arc::clone(&self.shared.runtime);
         let runtime_for_thread = Arc::clone(&runtime);
@@ -51,17 +55,18 @@ impl V8RuntimeHost {
             while let Ok(frame) = runtime_receiver.recv() {
                 match from_runtime_event(frame) {
                     Ok(frame) => {
-                        if let Err(error) = sender.try_send(frame) {
-                            match error {
-                                mpsc::TrySendError::Full(_) => {
-                                    let _ = runtime_for_thread
-                                        .destroy_session_if_output_current(&registration);
-                                }
-                                mpsc::TrySendError::Disconnected(_) => {
-                                    let _ = runtime_for_thread
-                                        .destroy_session_if_output_current(&registration);
-                                }
-                            }
+                        // Apply backpressure instead of destroying the session when
+                        // the downstream consumer is slow. This thread is dedicated
+                        // to one session, so a blocking send safely parks it — and,
+                        // in turn, backpressures the V8 runtime — until a slot frees.
+                        // Previously a `try_send` that hit the full channel called
+                        // destroy_session_if_output_current(), tearing the session
+                        // down on a transient backlog (the same anti-pattern fixed
+                        // for the event/stdout queues). Only a dropped receiver
+                        // (the consumer is gone for good) is terminal.
+                        if sender.send(frame).is_err() {
+                            let _ =
+                                runtime_for_thread.destroy_session_if_output_current(&registration);
                             break;
                         }
                     }

--- a/crates/execution/src/wasm.rs
+++ b/crates/execution/src/wasm.rs
@@ -12,6 +12,9 @@ use crate::signal::{NodeSignalDispositionAction, NodeSignalHandlerRegistration};
 use crate::v8_host::V8SessionHandle;
 use crate::v8_runtime;
 use base64::Engine as _;
+use secure_exec_bridge::queue_tracker::{
+    register_limit, warn_limit_exhausted, QueueGauge, TrackedLimit,
+};
 use serde_json::{json, Value};
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt;
@@ -20,6 +23,7 @@ use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::os::unix::fs::{FileExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 const WASM_MODULE_PATH_ENV: &str = "AGENTOS_WASM_MODULE_PATH";
@@ -341,6 +345,7 @@ pub struct WasmExecution {
     execution_timeout: Option<Duration>,
     execution_started_at: Instant,
     timeout_reported: bool,
+    fuel_gauge: Option<Arc<QueueGauge>>,
     internal_sync_rpc: WasmInternalSyncRpc,
     pending_events: VecDeque<WasmExecutionEvent>,
     stdout_stream_buffer: Vec<u8>,
@@ -562,12 +567,20 @@ impl WasmExecution {
         let Some(limit) = self.execution_timeout else {
             return Ok(None);
         };
-        if self.execution_started_at.elapsed() < limit {
+        let elapsed = self.execution_started_at.elapsed();
+        // Sample elapsed budget each poll so the gauge fires its edge-triggered
+        // ~80% approach warning before the terminal exhaustion below.
+        if let Some(gauge) = &self.fuel_gauge {
+            gauge.observe_depth(duration_millis_saturating_usize(elapsed));
+        }
+        if elapsed < limit {
             return Ok(None);
         }
 
         let _ = self.inner.terminate();
         self.timeout_reported = true;
+        let capacity = duration_millis_saturating_usize(limit);
+        warn_limit_exhausted(TrackedLimit::WasmFuelMs, capacity, capacity);
         self.enqueue_wasm_event(WasmExecutionEvent::Stderr(
             b"WebAssembly fuel budget exhausted\n".to_vec(),
         ))?;
@@ -866,6 +879,14 @@ impl WasmExecutionEngine {
             execution_timeout,
             execution_started_at: Instant::now(),
             timeout_reported: false,
+            // Approach-warn (~80%) before the WASM execution budget is exhausted;
+            // only registered when a timeout is actually set.
+            fuel_gauge: execution_timeout.map(|limit| {
+                register_limit(
+                    TrackedLimit::WasmFuelMs,
+                    duration_millis_saturating_usize(limit),
+                )
+            }),
             pending_events: VecDeque::new(),
             stdout_stream_buffer: Vec::new(),
             stderr_stream_buffer: Vec::new(),
@@ -5145,6 +5166,11 @@ fn validate_module_limits(
 
     if let Some(initial_bytes) = module_limits.initial_memory_bytes {
         if initial_bytes > memory_limit {
+            warn_limit_exhausted(
+                TrackedLimit::WasmMemoryBytes,
+                usize_saturating_from_u64(initial_bytes),
+                usize_saturating_from_u64(memory_limit),
+            );
             return Err(WasmExecutionError::InvalidModule(format!(
                 "initial WebAssembly memory of {initial_bytes} bytes exceeds the configured limit of {memory_limit} bytes"
             )));
@@ -5153,6 +5179,11 @@ fn validate_module_limits(
 
     match module_limits.maximum_memory_bytes {
         Some(maximum_bytes) if maximum_bytes > memory_limit => {
+            warn_limit_exhausted(
+                TrackedLimit::WasmMemoryBytes,
+                usize_saturating_from_u64(maximum_bytes),
+                usize_saturating_from_u64(memory_limit),
+            );
             Err(WasmExecutionError::InvalidModule(format!(
                 "WebAssembly memory maximum of {maximum_bytes} bytes exceeds the configured limit of {memory_limit} bytes"
             )))
@@ -5160,6 +5191,14 @@ fn validate_module_limits(
         Some(_) => Ok(()),
         None => Ok(()),
     }
+}
+
+fn duration_millis_saturating_usize(duration: Duration) -> usize {
+    usize::try_from(duration.as_millis()).unwrap_or(usize::MAX)
+}
+
+fn usize_saturating_from_u64(value: u64) -> usize {
+    usize::try_from(value).unwrap_or(usize::MAX)
 }
 
 #[derive(Debug, Default)]

--- a/crates/execution/tests/javascript_v8.rs
+++ b/crates/execution/tests/javascript_v8.rs
@@ -3990,6 +3990,110 @@ if (isWritable(socket)) {
     assert!(stderr.is_empty(), "unexpected stderr: {stderr}");
 }
 
+// Regression: when the host briefly stops draining the V8 -> host event channel
+// (capacity = JAVASCRIPT_EVENT_CHANNEL_CAPACITY = 512), a burst of guest events
+// must apply backpressure, not tear the session down. The original code called
+// `v8_session.destroy()` the instant `try_send` returned `Full`, turning a
+// transient backlog into `Exited(1)` with a truncated event stream.
+//
+// The guest synchronously logs far more lines than the event channel holds. The
+// host deliberately does not drain for a window, forcing the bridge onto the
+// formerly fatal full path, then drains everything. With backpressure every line
+// survives and the session exits cleanly; with the destroy-on-full bug the stream
+// is truncated and the session never reaches a clean exit.
+//
+// Note: this exercises the V8->host event channel (JAVASCRIPT_EVENT_CHANNEL_CAPACITY).
+// The upstream per-session v8_session_frames channel does NOT overflow here because
+// each guest `console.log` is a synchronous `applySync` that blocks until the bridge
+// drains it — so the guest cannot run ahead and only ~1 frame is ever in flight. That
+// channel's backpressure (v8_host.rs) only engages under async runtime frame bursts;
+// it shares the same TrackedSyncSender blocking-send mechanism covered by the bridge
+// queue_tracker unit tests.
+fn javascript_execution_v8_event_channel_backpressures_instead_of_destroying_session() {
+    const LINE_COUNT: usize = 1000;
+    let temp = tempdir().expect("create temp dir");
+
+    let mut engine = JavascriptExecutionEngine::default();
+    let context = engine.create_context(CreateJavascriptContextRequest {
+        vm_id: String::from("vm-js"),
+        bootstrap_module: None,
+        compile_cache_root: None,
+    });
+
+    let mut execution = engine
+        .start_execution(StartJavascriptExecutionRequest {
+            limits: Default::default(),
+            guest_runtime: Default::default(),
+            vm_id: String::from("vm-js"),
+            context_id: context.context_id,
+            argv: vec![String::from("./entry.mjs")],
+            env: BTreeMap::new(),
+            cwd: temp.path().to_path_buf(),
+            // Inline code avoids host-serviced module-resolution RPCs, so the
+            // guest runs autonomously and fills the event channel during the
+            // no-drain window below without the host's involvement.
+            inline_code: Some(format!(
+                "for (let i = 0; i < {LINE_COUNT}; i++) {{ console.log('LINE:' + i); }}\n"
+            )),
+        })
+        .expect("start JavaScript execution");
+
+    // Stop draining long enough for the guest burst to overrun the 512-slot
+    // channel and exercise the full path.
+    std::thread::sleep(Duration::from_millis(500));
+
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut exit_code = None;
+    loop {
+        // A poll error (e.g. EventChannelClosed) means the session was torn down
+        // out from under us — exactly the destroy-on-full regression — so stop and
+        // let the assertions below report the truncation rather than panicking.
+        let event = match execution.poll_event_blocking(Duration::from_secs(10)) {
+            Ok(event) => event,
+            Err(_session_died) => break,
+        };
+        match event {
+            Some(JavascriptExecutionEvent::Stdout(chunk)) => stdout.extend(chunk),
+            Some(JavascriptExecutionEvent::Stderr(chunk)) => stderr.extend(chunk),
+            Some(JavascriptExecutionEvent::SignalState { .. }) => {}
+            Some(JavascriptExecutionEvent::SyncRpcRequest(request)) => {
+                // No host RPCs are expected on this path; service module RPCs if
+                // any surface and answer anything else with null so a stray RPC
+                // cannot wedge the guest.
+                if execution
+                    .try_service_standalone_module_sync_rpc(&request)
+                    .expect("service module sync RPC")
+                {
+                    continue;
+                }
+                execution
+                    .respond_sync_rpc_success(request.id, Value::Null)
+                    .expect("respond to unexpected sync RPC");
+            }
+            Some(JavascriptExecutionEvent::Exited(code)) => {
+                exit_code = Some(code);
+                break;
+            }
+            None => break,
+        }
+    }
+
+    let stdout = String::from_utf8_lossy(&stdout);
+    let stderr = String::from_utf8_lossy(&stderr);
+    let lines = stdout.matches("LINE:").count();
+    assert_eq!(
+        exit_code,
+        Some(0),
+        "session must exit cleanly under backpressure (destroy-on-full regression?); \
+         lines={lines}/{LINE_COUNT}, stderr: {stderr}"
+    );
+    assert_eq!(
+        lines, LINE_COUNT,
+        "every event must survive backpressure with no truncation; stderr: {stderr}"
+    );
+}
+
 fn javascript_execution_v8_dynamic_import_accepts_file_urls() {
     let temp = tempdir().expect("create temp dir");
     write_fixture(
@@ -5297,6 +5401,7 @@ fn javascript_v8_suite() {
     javascript_execution_v8_commonjs_require_exposes_node_metadata();
     javascript_execution_v8_https_agents_expose_options_objects();
     javascript_execution_v8_net_socket_readable_state_tracks_ssh2_writable_shape();
+    javascript_execution_v8_event_channel_backpressures_instead_of_destroying_session();
     javascript_execution_v8_dynamic_import_accepts_file_urls();
     javascript_execution_v8_wasm_instantiate_streaming_never_hangs();
     javascript_execution_v8_structured_clone_rebinds_to_sandbox_realm();

--- a/crates/kernel/src/resource_accounting.rs
+++ b/crates/kernel/src/resource_accounting.rs
@@ -3,9 +3,11 @@ use crate::pipe_manager::PipeManager;
 use crate::process_table::{ProcessStatus, ProcessTable};
 use crate::pty::PtyManager;
 use crate::socket_table::{SocketState, SocketTable};
+use secure_exec_bridge::queue_tracker::{register_limit, QueueGauge, TrackedLimit};
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt;
+use std::sync::Arc;
 use vfs::posix::usage::RootFilesystemResourceLimits;
 
 pub use vfs::posix::usage::{
@@ -167,13 +169,102 @@ impl fmt::Display for ResourceError {
 impl Error for ResourceError {}
 
 #[derive(Debug, Clone, Default)]
+/// Per-VM gauges for the saturating resource limits, registered with the central
+/// limit registry so their usage is inspectable and they emit an edge-triggered
+/// approach warning (~80%) before the guest hits the hard cap. Only limits that
+/// are actually set get a gauge; unbounded (`None`) limits are skipped.
+struct ResourceGauges {
+    processes: Option<Arc<QueueGauge>>,
+    open_fds: Option<Arc<QueueGauge>>,
+    pipes: Option<Arc<QueueGauge>>,
+    ptys: Option<Arc<QueueGauge>>,
+    sockets: Option<Arc<QueueGauge>>,
+    connections: Option<Arc<QueueGauge>>,
+    socket_buffered_bytes: Option<Arc<QueueGauge>>,
+    socket_datagram_queue_len: Option<Arc<QueueGauge>>,
+    filesystem_bytes: Option<Arc<QueueGauge>>,
+    inodes: Option<Arc<QueueGauge>>,
+}
+
+fn register_resource_gauge(name: TrackedLimit, limit: Option<usize>) -> Option<Arc<QueueGauge>> {
+    limit.map(|capacity| register_limit(name, capacity))
+}
+
+fn register_resource_gauge_u64(name: TrackedLimit, limit: Option<u64>) -> Option<Arc<QueueGauge>> {
+    limit.map(|capacity| register_limit(name, usize_saturating_from_u64(capacity)))
+}
+
+fn usize_saturating_from_u64(value: u64) -> usize {
+    usize::try_from(value).unwrap_or(usize::MAX)
+}
+
+impl ResourceGauges {
+    fn new(limits: &ResourceLimits) -> Self {
+        Self {
+            processes: register_resource_gauge(TrackedLimit::VmProcesses, limits.max_processes),
+            open_fds: register_resource_gauge(TrackedLimit::VmOpenFds, limits.max_open_fds),
+            pipes: register_resource_gauge(TrackedLimit::VmPipes, limits.max_pipes),
+            ptys: register_resource_gauge(TrackedLimit::VmPtys, limits.max_ptys),
+            sockets: register_resource_gauge(TrackedLimit::VmSockets, limits.max_sockets),
+            connections: register_resource_gauge(
+                TrackedLimit::VmConnections,
+                limits.max_connections,
+            ),
+            socket_buffered_bytes: register_resource_gauge(
+                TrackedLimit::VmSocketBufferedBytes,
+                limits.max_socket_buffered_bytes,
+            ),
+            socket_datagram_queue_len: register_resource_gauge(
+                TrackedLimit::VmSocketDatagramQueueLen,
+                limits.max_socket_datagram_queue_len,
+            ),
+            filesystem_bytes: register_resource_gauge_u64(
+                TrackedLimit::VmFilesystemBytes,
+                limits.max_filesystem_bytes,
+            ),
+            inodes: register_resource_gauge(TrackedLimit::VmInodes, limits.max_inode_count),
+        }
+    }
+}
+
 pub struct ResourceAccountant {
     limits: ResourceLimits,
+    gauges: ResourceGauges,
 }
 
 impl ResourceAccountant {
     pub fn new(limits: ResourceLimits) -> Self {
-        Self { limits }
+        let gauges = ResourceGauges::new(&limits);
+        Self { limits, gauges }
+    }
+
+    /// Sample the saturating-resource gauges from a fresh snapshot so the central
+    /// registry tracks usage and warns before any cap is reached.
+    fn observe_resource_gauges(&self, snapshot: &ResourceSnapshot) {
+        if let Some(gauge) = &self.gauges.processes {
+            gauge.observe_depth(snapshot.running_processes + snapshot.exited_processes);
+        }
+        if let Some(gauge) = &self.gauges.open_fds {
+            gauge.observe_depth(snapshot.open_fds);
+        }
+        if let Some(gauge) = &self.gauges.pipes {
+            gauge.observe_depth(snapshot.pipes);
+        }
+        if let Some(gauge) = &self.gauges.ptys {
+            gauge.observe_depth(snapshot.ptys);
+        }
+        if let Some(gauge) = &self.gauges.sockets {
+            gauge.observe_depth(snapshot.sockets);
+        }
+        if let Some(gauge) = &self.gauges.connections {
+            gauge.observe_depth(snapshot.socket_connections);
+        }
+        if let Some(gauge) = &self.gauges.socket_buffered_bytes {
+            gauge.observe_depth(snapshot.socket_buffered_bytes);
+        }
+        if let Some(gauge) = &self.gauges.socket_datagram_queue_len {
+            gauge.observe_depth(snapshot.socket_datagram_queue_len);
+        }
     }
 
     pub fn limits(&self) -> &ResourceLimits {
@@ -199,7 +290,7 @@ impl ResourceAccountant {
             .count();
         let socket_snapshot = sockets.snapshot();
 
-        ResourceSnapshot {
+        let snapshot = ResourceSnapshot {
             running_processes,
             exited_processes,
             fd_tables: fd_tables.len(),
@@ -214,7 +305,9 @@ impl ResourceAccountant {
             socket_connections: socket_snapshot.connections,
             socket_buffered_bytes: socket_snapshot.buffered_bytes,
             socket_datagram_queue_len: socket_snapshot.datagram_queue_len,
-        }
+        };
+        self.observe_resource_gauges(&snapshot);
+        snapshot
     }
 
     pub fn check_process_spawn(
@@ -437,6 +530,16 @@ impl ResourceAccountant {
                 ));
             }
         }
+
+        // Sample the gauges only on the success path: observing the *projected*
+        // value before the bounds check would latch a spurious near/at-capacity
+        // warning for a write that is then rejected and never actually applied.
+        if let Some(gauge) = &self.gauges.filesystem_bytes {
+            gauge.observe_depth(usize_saturating_from_u64(resulting_bytes));
+        }
+        if let Some(gauge) = &self.gauges.inodes {
+            gauge.observe_depth(resulting_inodes);
+        }
         Ok(())
     }
 }
@@ -474,4 +577,106 @@ fn merged_env_payload_bytes(
     }
 
     total
+}
+
+#[cfg(test)]
+mod gauge_tests {
+    use super::*;
+    use secure_exec_bridge::queue_tracker::{
+        set_limit_warning_handler, LimitWarning, TrackedLimit,
+    };
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn resource_gauges_track_usage_and_warn_on_approach() {
+        let captured: Arc<Mutex<Vec<LimitWarning>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&captured);
+        // Filter by name so a gauge from a concurrently-running test can't pollute.
+        set_limit_warning_handler(Box::new(move |warning| {
+            if warning.name == TrackedLimit::VmOpenFds {
+                sink.lock().expect("sink mutex").push(warning.clone());
+            }
+        }));
+
+        let limits = ResourceLimits {
+            max_open_fds: Some(10),
+            ..ResourceLimits::default()
+        };
+        let accountant = ResourceAccountant::new(limits);
+        let snapshot = ResourceSnapshot {
+            open_fds: 9, // 90% of the cap
+            ..ResourceSnapshot::default()
+        };
+        accountant.observe_resource_gauges(&snapshot);
+
+        // The gauge reflects the sampled usage...
+        let gauge = accountant
+            .gauges
+            .open_fds
+            .as_ref()
+            .expect("open_fds gauge registered when the limit is set");
+        assert_eq!(gauge.depth(), 9);
+        assert_eq!(gauge.capacity(), 10);
+        assert_eq!(gauge.high_water(), 9);
+
+        // ...and crossing ~80% emits the approach warning to the host sink.
+        assert!(
+            captured
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|warning| warning.name == TrackedLimit::VmOpenFds),
+            "open_fds at 90% of cap must emit an approach warning"
+        );
+    }
+
+    #[test]
+    fn unset_limit_registers_no_gauge() {
+        let limits = ResourceLimits {
+            max_ptys: None,
+            ..ResourceLimits::default()
+        };
+        let accountant = ResourceAccountant::new(limits);
+        assert!(
+            accountant.gauges.ptys.is_none(),
+            "an unbounded (None) limit must not register a gauge"
+        );
+    }
+
+    #[test]
+    fn filesystem_gauge_not_latched_by_rejected_write() {
+        let limits = ResourceLimits {
+            max_filesystem_bytes: Some(1000),
+            max_inode_count: Some(100),
+            ..ResourceLimits::default()
+        };
+        let accountant = ResourceAccountant::new(limits);
+        let usage = FileSystemUsage::default();
+
+        // A write that would exceed the byte cap is rejected and must NOT latch
+        // the gauge to the projected (never-applied) value.
+        let rejected = accountant.check_filesystem_usage(&usage, 2000, 0);
+        assert!(rejected.is_err());
+        let bytes_gauge = accountant
+            .gauges
+            .filesystem_bytes
+            .as_ref()
+            .expect("filesystem_bytes gauge registered");
+        assert_eq!(
+            bytes_gauge.depth(),
+            0,
+            "a rejected over-limit write must not bump the gauge"
+        );
+
+        // A successful write does update it.
+        accountant
+            .check_filesystem_usage(&usage, 500, 7)
+            .expect("under-limit write is accepted");
+        assert_eq!(bytes_gauge.depth(), 500);
+        assert_eq!(
+            accountant.gauges.inodes.as_ref().unwrap().depth(),
+            7,
+            "inode gauge tracks the accepted value"
+        );
+    }
 }

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -1,6 +1,15 @@
 fn main() {
+    // Default to WARN so near-limit / backpressure warnings actually surface
+    // (they were swallowed at ERROR-only); operators can tune via SECURE_EXEC_LOG
+    // (e.g. `error` to quiet, `debug` for queue snapshots). Logs MUST go to stderr:
+    // stdout is the framed wire-protocol channel, so logging there would corrupt it.
+    let level = std::env::var("SECURE_EXEC_LOG")
+        .ok()
+        .and_then(|value| value.parse::<tracing::Level>().ok())
+        .unwrap_or(tracing::Level::WARN);
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::ERROR)
+        .with_writer(std::io::stderr)
+        .with_max_level(level)
         .init();
     if let Err(error) = secure_exec_sidecar::stdio::run() {
         tracing::error!(?error, "secure-exec-sidecar startup failed");

--- a/crates/sidecar/src/service.rs
+++ b/crates/sidecar/src/service.rs
@@ -36,6 +36,7 @@ use crate::state::{
 };
 use crate::tools::register_host_callbacks;
 use crate::NativeSidecarBridge;
+use secure_exec_bridge::queue_tracker::{register_queue, QueueGauge, TrackedLimit};
 use secure_exec_bridge::{
     CommandPermissionRequest, EnvironmentAccess, EnvironmentPermissionRequest, FilesystemAccess,
     FilesystemPermissionRequest, LifecycleEventRecord, LifecycleState, LogLevel, LogRecord,
@@ -864,6 +865,10 @@ pub struct NativeSidecar<B> {
     pub(crate) outbound_sidecar_requests: VecDeque<SidecarRequestFrame>,
     pub(crate) completed_sidecar_responses: BTreeMap<RequestId, SidecarResponseFrame>,
     pub(crate) completed_sidecar_response_order: VecDeque<RequestId>,
+    pub(crate) completed_sidecar_responses_gauge: Arc<QueueGauge>,
+    pub(crate) pending_process_events_gauge: Arc<QueueGauge>,
+    pub(crate) pending_sidecar_responses_gauge: Arc<QueueGauge>,
+    pub(crate) outbound_sidecar_requests_gauge: Arc<QueueGauge>,
     pub(crate) sidecar_requests: SharedSidecarRequestClient,
     pub(crate) extensions: BTreeMap<String, Arc<dyn Extension>>,
     pub(crate) extension_sessions: BTreeMap<(String, String), ExtensionSessionResources>,
@@ -954,6 +959,22 @@ where
             outbound_sidecar_requests: VecDeque::new(),
             completed_sidecar_responses: BTreeMap::new(),
             completed_sidecar_response_order: VecDeque::new(),
+            completed_sidecar_responses_gauge: register_queue(
+                TrackedLimit::CompletedSidecarResponses,
+                MAX_COMPLETED_SIDECAR_RESPONSES,
+            ),
+            pending_process_events_gauge: register_queue(
+                TrackedLimit::PendingProcessEvents,
+                MAX_PROCESS_EVENT_QUEUE,
+            ),
+            pending_sidecar_responses_gauge: register_queue(
+                TrackedLimit::PendingSidecarResponses,
+                MAX_PENDING_SIDECAR_RESPONSES,
+            ),
+            outbound_sidecar_requests_gauge: register_queue(
+                TrackedLimit::OutboundSidecarRequests,
+                MAX_OUTBOUND_SIDECAR_REQUESTS,
+            ),
             sidecar_requests: SharedSidecarRequestClient::default(),
             extensions: BTreeMap::new(),
             extension_sessions: BTreeMap::new(),
@@ -1195,6 +1216,8 @@ where
             return Err(process_event_queue_overflow_error());
         }
         self.pending_process_events.push_back(envelope);
+        self.pending_process_events_gauge
+            .observe_depth(self.pending_process_events.len());
         Ok(())
     }
 
@@ -1206,6 +1229,8 @@ where
             return Err(process_event_queue_overflow_error());
         }
         self.pending_process_events.push_front(envelope);
+        self.pending_process_events_gauge
+            .observe_depth(self.pending_process_events.len());
         Ok(())
     }
 
@@ -2540,6 +2565,10 @@ where
             .register_request(&request)
             .map_err(sidecar_response_tracker_error)?;
         self.outbound_sidecar_requests.push_back(request);
+        self.outbound_sidecar_requests_gauge
+            .observe_depth(self.outbound_sidecar_requests.len());
+        self.pending_sidecar_responses_gauge
+            .observe_depth(self.pending_sidecar_responses.pending_count());
         Ok(request_id)
     }
 
@@ -2555,7 +2584,10 @@ where
     }
 
     pub fn pop_sidecar_request(&mut self) -> Option<SidecarRequestFrame> {
-        self.outbound_sidecar_requests.pop_front()
+        let request = self.outbound_sidecar_requests.pop_front();
+        self.outbound_sidecar_requests_gauge
+            .observe_depth(self.outbound_sidecar_requests.len());
+        request
     }
 
     pub fn pop_wire_sidecar_request(
@@ -2574,13 +2606,32 @@ where
         self.pending_sidecar_responses
             .accept_response(&response)
             .map_err(sidecar_response_tracker_error)?;
+        self.pending_sidecar_responses_gauge
+            .observe_depth(self.pending_sidecar_responses.pending_count());
         self.completed_sidecar_response_order
             .push_back(response.request_id);
         self.completed_sidecar_responses
             .insert(response.request_id, response);
+        self.completed_sidecar_responses_gauge
+            .observe_depth(self.completed_sidecar_responses.len());
         while self.completed_sidecar_responses.len() > MAX_COMPLETED_SIDECAR_RESPONSES {
-            if let Some(evicted) = self.completed_sidecar_response_order.pop_front() {
-                self.completed_sidecar_responses.remove(&evicted);
+            match self.completed_sidecar_response_order.pop_front() {
+                // Only a response that was never retrieved is a real loss; an id
+                // already taken via take_sidecar_response leaves a stale order
+                // entry that removes to None and is not a dropped response.
+                Some(evicted) => {
+                    if self.completed_sidecar_responses.remove(&evicted).is_some() {
+                        tracing::warn!(
+                            queue = "completed_sidecar_responses",
+                            evicted_request_id = evicted,
+                            capacity = MAX_COMPLETED_SIDECAR_RESPONSES,
+                            "dropping an unretrieved completed sidecar response to stay within cap; the host can no longer fetch it (response lost)"
+                        );
+                        self.completed_sidecar_responses_gauge
+                            .observe_depth(self.completed_sidecar_responses.len());
+                    }
+                }
+                None => break,
             }
         }
         Ok(())
@@ -2600,6 +2651,8 @@ where
         if response.is_some() {
             self.completed_sidecar_response_order
                 .retain(|completed_id| completed_id != &request_id);
+            self.completed_sidecar_responses_gauge
+                .observe_depth(self.completed_sidecar_responses.len());
         }
         response
     }
@@ -3003,6 +3056,29 @@ pub(crate) fn emit_security_audit_event<B>(
     let _ = emit_structured_event(bridge, vm_id, name, fields);
 }
 
+/// Build a wire `EventFrame` carrying a `StructuredEvent` (name + string-map
+/// detail) scoped to a connection. Used to forward limit-registry warnings to the
+/// host as `{type:"structured", name:"limit_warning", detail}` events without a
+/// protocol schema change. Emitted directly to the host (not via the polled,
+/// per-session bridge queue, which is a no-op in the stdio sidecar), so a
+/// process-global signal is delivered against the active connection.
+pub(crate) fn structured_event_frame(
+    connection_id: &str,
+    name: &str,
+    detail: std::collections::HashMap<String, String>,
+) -> Result<crate::wire::EventFrame, SidecarError> {
+    let event = EventFrame::new(
+        OwnershipScope::connection(connection_id),
+        EventPayload::Structured(crate::protocol::StructuredEvent {
+            name: name.to_owned(),
+            detail,
+        }),
+    );
+    crate::wire::event_frame_from_compat(event).map_err(|error| {
+        SidecarError::InvalidState(format!("invalid structured event frame: {error}"))
+    })
+}
+
 pub(crate) fn log_stale_process_event<B>(
     bridge: &SharedBridge<B>,
     vm_id: &str,
@@ -3248,5 +3324,44 @@ mod symlinked_node_modules_hint_tests {
     fn ignores_unrelated_failure() {
         let stderr = "Error: connect ECONNREFUSED 127.0.0.1:443";
         assert!(symlinked_node_modules_hint(stderr).is_none());
+    }
+}
+
+#[cfg(test)]
+mod structured_event_frame_tests {
+    use super::*;
+
+    #[test]
+    fn structured_event_frame_round_trips_limit_warning() {
+        let mut detail = std::collections::HashMap::new();
+        // Pin a real emitted limit name rather than a fictional string.
+        let limit_name = TrackedLimit::JavascriptEventChannel.as_str();
+        detail.insert(String::from("limit"), String::from(limit_name));
+        detail.insert(String::from("fillPercent"), String::from("82"));
+
+        let wire = structured_event_frame("conn-1", "limit_warning", detail)
+            .expect("build structured event frame");
+        let compat = crate::wire::event_frame_to_compat(wire).expect("convert to compat");
+
+        match compat.payload {
+            EventPayload::Structured(event) => {
+                assert_eq!(event.name, "limit_warning");
+                assert_eq!(
+                    event.detail.get("limit").map(String::as_str),
+                    Some(limit_name)
+                );
+                assert_eq!(
+                    event.detail.get("fillPercent").map(String::as_str),
+                    Some("82")
+                );
+            }
+            other => panic!("expected structured payload, got {other:?}"),
+        }
+        match compat.ownership {
+            OwnershipScope::ConnectionOwnership(inner) => {
+                assert_eq!(inner.connection_id, "conn-1");
+            }
+            other => panic!("expected connection ownership, got {other:?}"),
+        }
     }
 }

--- a/crates/sidecar/src/stdio.rs
+++ b/crates/sidecar/src/stdio.rs
@@ -7,6 +7,7 @@ use crate::{
     Extension, ExtensionInterruptRequest, NativeSidecar, NativeSidecarConfig, SidecarError,
     SidecarRequestTransport,
 };
+use secure_exec_bridge::queue_tracker::{tracked_sync_channel, TrackedLimit, TrackedSyncSender};
 use secure_exec_bridge::{
     BridgeTypes, ChmodRequest, ClockBridge, ClockRequest, CommandPermissionRequest,
     CreateDirRequest, CreateJavascriptContextRequest, CreateWasmContextRequest, DiagnosticRecord,
@@ -42,7 +43,10 @@ use tokio::time;
 const EVENT_PUMP_INTERVAL: Duration = Duration::from_micros(250);
 const MAX_STDIN_FRAME_QUEUE: usize = 128;
 const MAX_EVENT_READY_QUEUE: usize = 1;
-const MAX_STDOUT_FRAME_QUEUE: usize = 128;
+// Defense-in-depth headroom for the host-bound frame queue: a burst of output
+// frames from a busy turn should be buffered, so the writer only backpressures
+// when the host genuinely stops reading stdout rather than on every spike.
+const MAX_STDOUT_FRAME_QUEUE: usize = 4096;
 
 #[cfg(test)]
 fn request_frame(
@@ -121,9 +125,27 @@ async fn run_async(extensions: Vec<Box<dyn Extension>>) -> Result<(), Box<dyn Er
     let mut active_connections = BTreeSet::<String>::new();
     let (stdin_tx, mut stdin_rx) =
         channel::<Result<Option<ProtocolFrame>, String>>(MAX_STDIN_FRAME_QUEUE);
+    let stdin_gauge = secure_exec_bridge::queue_tracker::register_queue(
+        TrackedLimit::SidecarStdinFrames,
+        MAX_STDIN_FRAME_QUEUE,
+    );
     let (event_ready_tx, mut event_ready_rx) = channel::<()>(MAX_EVENT_READY_QUEUE);
-    let (write_tx, write_rx) = mpsc::sync_channel::<ProtocolFrame>(MAX_STDOUT_FRAME_QUEUE);
+    let (write_tx, write_rx) = tracked_sync_channel::<ProtocolFrame>(
+        TrackedLimit::SidecarStdoutFrames,
+        MAX_STDOUT_FRAME_QUEUE,
+    );
     let (write_error_tx, mut write_error_rx) = unbounded_channel::<String>();
+
+    // Forward limit-registry near-capacity warnings to the host: the global sink
+    // fires (edge-triggered, from arbitrary threads) into this channel, and the
+    // event loop below drains it and emits a `StructuredEvent` (name
+    // "limit_warning"). The unbounded sender is Send+Sync and lives for the whole
+    // process inside the global handler, so the receiver never sees a hangup.
+    let (limit_warning_tx, mut limit_warning_rx) =
+        unbounded_channel::<secure_exec_bridge::queue_tracker::LimitWarning>();
+    secure_exec_bridge::queue_tracker::set_limit_warning_handler(Box::new(move |warning| {
+        let _ = limit_warning_tx.send(warning.clone());
+    }));
     let callback_transport = Arc::new(FrameSidecarRequestTransport::new(write_tx.clone()));
     sidecar.set_sidecar_request_transport(callback_transport.clone());
     let mut event_pump = time::interval(EVENT_PUMP_INTERVAL);
@@ -159,7 +181,13 @@ async fn run_async(extensions: Vec<Box<dyn Extension>>) -> Result<(), Box<dyn Er
                 .map_err(|error: Box<dyn Error>| error.to_string());
                 let should_stop = matches!(frame, Ok(None) | Err(_));
                 match enqueue_stdin_frame(&stdin_tx, frame) {
-                    Ok(()) => {}
+                    Ok(()) => {
+                        // Sample inbound queue depth so the centralized tracker
+                        // can warn before host requests back up on the sidecar.
+                        stdin_gauge.observe_depth(
+                            stdin_tx.max_capacity().saturating_sub(stdin_tx.capacity()),
+                        );
+                    }
                     Err(StdinFrameQueueError::Full(message)) => {
                         let _ = read_error_tx.send(message);
                         break;
@@ -175,6 +203,7 @@ async fn run_async(extensions: Vec<Box<dyn Extension>>) -> Result<(), Box<dyn Er
 
     flush_sidecar_requests(&mut sidecar, &write_tx)?;
     let mut pending_frame: Option<ProtocolFrame> = None;
+    let mut limit_warning_closed = false;
 
     loop {
         if let Some(frame) = pending_frame.take() {
@@ -208,6 +237,44 @@ async fn run_async(extensions: Vec<Box<dyn Extension>>) -> Result<(), Box<dyn Er
                     &mut active_sessions,
                     &mut active_connections,
                 ).await?;
+            }
+            maybe_warning = limit_warning_rx.recv(), if !limit_warning_closed => {
+                match maybe_warning {
+                    Some(warning) => {
+                        // A limit warning is process-global; deliver it ONCE. The
+                        // stdio transport is single-client, so emit it to the first
+                        // active connection (if any) rather than fanning out a copy
+                        // per connection. Dropped if no client has authenticated yet
+                        // (only the tracing log survives, which is acceptable).
+                        if let Some(connection_id) = active_connections.iter().next() {
+                            let mut detail = std::collections::HashMap::new();
+                            detail.insert(String::from("limit"), warning.name.as_str().to_string());
+                            detail.insert(
+                                String::from("category"),
+                                warning.category.as_str().to_string(),
+                            );
+                            detail.insert(String::from("observed"), warning.observed.to_string());
+                            detail.insert(String::from("capacity"), warning.capacity.to_string());
+                            detail.insert(
+                                String::from("fillPercent"),
+                                warning.fill_percent.to_string(),
+                            );
+                            let frame = crate::service::structured_event_frame(
+                                connection_id,
+                                "limit_warning",
+                                detail,
+                            )?;
+                            send_output_frame(&write_tx, ProtocolFrame::EventFrame(frame))?;
+                        }
+                    }
+                    None => {
+                        // Sender dropped (only possible if another sidecar replaced
+                        // the global handler in-process). Disarm this branch so the
+                        // select! does not hot-spin on an always-ready closed
+                        // receiver; do NOT break — that would tear down the sidecar.
+                        limit_warning_closed = true;
+                    }
+                }
             }
             maybe_ready = event_ready_rx.recv() => {
                 let Some(()) = maybe_ready else {
@@ -256,7 +323,7 @@ async fn handle_protocol_frame(
     sidecar: &mut NativeSidecar<LocalBridge>,
     stdin_rx: &mut Receiver<Result<Option<ProtocolFrame>, String>>,
     pending_frame: &mut Option<ProtocolFrame>,
-    write_tx: &mpsc::SyncSender<ProtocolFrame>,
+    write_tx: &TrackedSyncSender<ProtocolFrame>,
     active_sessions: &mut BTreeSet<SessionScope>,
     active_connections: &mut BTreeSet<String>,
 ) -> Result<(), Box<dyn Error>> {
@@ -605,7 +672,7 @@ fn enqueue_stdin_frame(
 
 fn flush_sidecar_requests(
     sidecar: &mut NativeSidecar<LocalBridge>,
-    writer: &mpsc::SyncSender<ProtocolFrame>,
+    writer: &TrackedSyncSender<ProtocolFrame>,
 ) -> Result<(), Box<dyn Error>> {
     while let Some(request) = sidecar.pop_wire_sidecar_request()? {
         send_output_frame(writer, ProtocolFrame::SidecarRequestFrame(request))?;
@@ -614,17 +681,21 @@ fn flush_sidecar_requests(
 }
 
 fn send_output_frame(
-    writer: &mpsc::SyncSender<ProtocolFrame>,
+    writer: &TrackedSyncSender<ProtocolFrame>,
     frame: ProtocolFrame,
 ) -> Result<(), io::Error> {
-    writer.try_send(frame).map_err(|error| {
-        let message = match error {
-            mpsc::TrySendError::Full(_) => {
-                format!("stdout frame queue exceeded {MAX_STDOUT_FRAME_QUEUE} pending frames")
-            }
-            mpsc::TrySendError::Disconnected(_) => String::from("stdout writer disconnected"),
-        };
-        io::Error::new(io::ErrorKind::BrokenPipe, message)
+    // Apply backpressure rather than killing the sidecar when the host reads
+    // stdout slowly. A full queue means the dedicated writer thread is blocked on
+    // the stdout pipe (the host has not drained it yet) — a transient, recoverable
+    // condition. Previously `try_send` turned that backlog into a `BrokenPipe`
+    // error that propagated up and exited the whole sidecar process (code 1),
+    // taking every session with it. A blocking `send` parks the producer until the
+    // writer drains a slot, which transitively backpressures the V8 event bridge
+    // and the guest. It never deadlocks: the writer thread runs independently, and
+    // if it dies (real broken pipe) the receiver is dropped and `send` returns
+    // `Disconnected`, which we still surface as a terminal `BrokenPipe`.
+    writer.send(frame).map_err(|_disconnected| {
+        io::Error::new(io::ErrorKind::BrokenPipe, "stdout writer disconnected")
     })
 }
 
@@ -683,28 +754,19 @@ mod tests {
             event_ready_tx.try_send(()),
             Err(tokio::sync::mpsc::error::TrySendError::Full(_))
         ));
+    }
 
-        let (stdout_tx, _stdout_rx) = mpsc::sync_channel(MAX_STDOUT_FRAME_QUEUE);
-        for request_id in 0..MAX_STDOUT_FRAME_QUEUE {
-            send_output_frame(
-                &stdout_tx,
-                ProtocolFrame::RequestFrame(request_frame(
-                    request_id as RequestId,
-                    connection_ownership("conn-queue"),
-                    RequestPayload::AuthenticateRequest(AuthenticateRequest {
-                        client_name: String::from("queue-test"),
-                        auth_token: String::from("token"),
-                        protocol_version: wire::PROTOCOL_VERSION,
-                        bridge_version: secure_exec_bridge::bridge_contract().version,
-                    }),
-                )),
-            )
-            .expect("stdout frame queue should accept capacity");
-        }
-        let error = send_output_frame(
-            &stdout_tx,
+    // Regression: a full stdout frame queue must apply backpressure (block the
+    // producer until the writer drains a slot), NOT tear the sidecar down. The
+    // old `try_send` turned a slow host reader into a `BrokenPipe` error that
+    // propagated up and exited the whole sidecar process (code 1). Here a slow
+    // drainer forces the queue past capacity; with backpressure every send
+    // succeeds, and overflow only fails when the writer (receiver) is gone.
+    #[test]
+    fn stdout_frame_queue_applies_backpressure_instead_of_crashing() {
+        let queue_frame = |request_id: RequestId| {
             ProtocolFrame::RequestFrame(request_frame(
-                MAX_STDOUT_FRAME_QUEUE as RequestId,
+                request_id,
                 connection_ownership("conn-queue"),
                 RequestPayload::AuthenticateRequest(AuthenticateRequest {
                     client_name: String::from("queue-test"),
@@ -712,13 +774,45 @@ mod tests {
                     protocol_version: wire::PROTOCOL_VERSION,
                     bridge_version: secure_exec_bridge::bridge_contract().version,
                 }),
-            )),
-        )
-        .expect_err("stdout frame queue should reject overflow");
-        assert!(
-            error.to_string().contains("stdout frame queue exceeded"),
-            "unexpected stdout queue error: {error}"
+            ))
+        };
+
+        // Small fixed capacity (independent of the production constant) with a
+        // drainer slow enough that the queue fills and the producer is forced
+        // onto the blocking path. The old try_send path errored on the
+        // (capacity + 1)th frame; backpressure accepts all of them.
+        let queue_cap = 8usize;
+        let total_frames = queue_cap * 3;
+        let (stdout_tx, stdout_rx) =
+            tracked_sync_channel::<ProtocolFrame>(TrackedLimit::SidecarStdoutFrames, queue_cap);
+        let drainer = std::thread::spawn(move || {
+            let mut drained = 0usize;
+            while stdout_rx.recv().is_ok() {
+                drained += 1;
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            drained
+        });
+
+        for request_id in 0..total_frames {
+            send_output_frame(&stdout_tx, queue_frame(request_id as RequestId))
+                .expect("backpressured stdout queue must accept frames, not crash");
+        }
+        drop(stdout_tx);
+        let drained = drainer.join().expect("drainer thread panicked");
+        assert_eq!(
+            drained, total_frames,
+            "every frame must survive the backpressured queue"
         );
+
+        // When the writer (receiver) is gone, overflow is genuinely terminal and
+        // still surfaces as a BrokenPipe error rather than blocking forever.
+        let (closed_tx, closed_rx) =
+            tracked_sync_channel::<ProtocolFrame>(TrackedLimit::SidecarStdoutFrames, queue_cap);
+        drop(closed_rx);
+        let error = send_output_frame(&closed_tx, queue_frame(0))
+            .expect_err("send to a dropped writer must error");
+        assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
     }
 
     #[test]
@@ -1227,12 +1321,12 @@ impl SessionScope {
 }
 
 struct FrameSidecarRequestTransport {
-    writer: mpsc::SyncSender<ProtocolFrame>,
+    writer: TrackedSyncSender<ProtocolFrame>,
     pending: Arc<Mutex<BTreeMap<RequestId, mpsc::SyncSender<SidecarResponseFrame>>>>,
 }
 
 impl FrameSidecarRequestTransport {
-    fn new(writer: mpsc::SyncSender<ProtocolFrame>) -> Self {
+    fn new(writer: TrackedSyncSender<ProtocolFrame>) -> Self {
         Self {
             writer,
             pending: Arc::new(Mutex::new(BTreeMap::new())),
@@ -1270,16 +1364,39 @@ impl SidecarRequestTransport for FrameSidecarRequestTransport {
                 SidecarError::Bridge(String::from("sidecar callback waiter map lock poisoned"))
             })?
             .insert(request.request_id, sender);
-        if let Err(error) = send_output_frame(
-            &self.writer,
-            ProtocolFrame::SidecarRequestFrame(request.clone()),
-        ) {
+        // Bound the request-frame WRITE by the caller's deadline. The shared
+        // `send_output_frame` blocks (correct backpressure for the fire-and-forget
+        // event/response paths), but this request path has a `timeout` that the
+        // response wait below already honors — so a stalled host stdout must not
+        // make the *send* block past it. Poll try_send until a slot frees or the
+        // deadline passes.
+        let write_deadline = Instant::now() + timeout;
+        let mut frame = ProtocolFrame::SidecarRequestFrame(request.clone());
+        let write_result = loop {
+            match self.writer.try_send(frame) {
+                Ok(()) => break Ok(()),
+                Err(mpsc::TrySendError::Disconnected(_)) => {
+                    break Err(String::from("stdout writer disconnected"));
+                }
+                Err(mpsc::TrySendError::Full(returned)) => {
+                    if Instant::now() >= write_deadline {
+                        break Err(format!(
+                            "timed out writing sidecar request frame after {}s",
+                            timeout.as_secs()
+                        ));
+                    }
+                    frame = returned;
+                    thread::sleep(Duration::from_millis(1));
+                }
+            }
+        };
+        if let Err(message) = write_result {
             let _ = self
                 .pending
                 .lock()
                 .map(|mut pending| pending.remove(&request.request_id));
             return Err(SidecarError::Io(format!(
-                "failed to write sidecar request frame: {error}"
+                "failed to write sidecar request frame: {message}"
             )));
         }
         match receiver.recv_timeout(timeout) {

--- a/crates/sidecar/tests/service.rs
+++ b/crates/sidecar/tests/service.rs
@@ -292,6 +292,112 @@ ykAheWCsAteSEWVc0w==\n\
                 .insert(process_id.to_owned(), process);
         }
 
+        fn ext_sidecar_request_payload() -> SidecarRequestPayload {
+            SidecarRequestPayload::Ext(crate::protocol::ExtEnvelope {
+                namespace: String::from("test.completion.evict"),
+                payload: Vec::new(),
+            })
+        }
+
+        fn ext_sidecar_response_frame(
+            request_id: crate::protocol::RequestId,
+            ownership: &OwnershipScope,
+        ) -> crate::protocol::SidecarResponseFrame {
+            crate::protocol::SidecarResponseFrame::new(
+                request_id,
+                ownership.clone(),
+                SidecarResponsePayload::ExtResult(crate::protocol::ExtEnvelope {
+                    namespace: String::from("test.completion.evict"),
+                    payload: Vec::new(),
+                }),
+            )
+        }
+
+        // Drive one full sidecar request -> outbound drain -> response-accept
+        // cycle, mirroring how the stdio loop hands a request to the host and
+        // then records the host's reply. Returns the request id so the caller
+        // can later assert whether that completed response is still retrievable.
+        fn complete_one_sidecar_response(
+            sidecar: &mut NativeSidecar<RecordingBridge>,
+            ownership: &OwnershipScope,
+        ) -> crate::protocol::RequestId {
+            let request_id = sidecar
+                .queue_sidecar_request(ownership.clone(), ext_sidecar_request_payload())
+                .expect("queue sidecar request");
+            sidecar
+                .pop_sidecar_request()
+                .expect("outbound sidecar request should be queued for the host");
+            sidecar
+                .accept_sidecar_response(ext_sidecar_response_frame(request_id, ownership))
+                .expect("accept sidecar response");
+            request_id
+        }
+
+        // The completed-response map is bounded: once more responses complete
+        // than the cap, the oldest *unretrieved* response is evicted (and the
+        // host can no longer fetch it) so the map cannot grow without bound.
+        fn completed_sidecar_responses_evict_oldest_beyond_cap() {
+            let mut sidecar = create_test_sidecar();
+            let ownership = OwnershipScope::connection("conn-completion-evict");
+            let cap = crate::service::MAX_COMPLETED_SIDECAR_RESPONSES;
+
+            // The first completion is the oldest; everything after it pushes the
+            // map past the cap and must evict from the front.
+            let oldest_request_id = complete_one_sidecar_response(&mut sidecar, &ownership);
+            for _ in 1..(cap + 5) {
+                complete_one_sidecar_response(&mut sidecar, &ownership);
+            }
+
+            assert_eq!(
+                sidecar.completed_sidecar_responses.len(),
+                cap,
+                "completed sidecar responses must stay bounded at the cap"
+            );
+            assert_eq!(
+                sidecar.completed_sidecar_responses_gauge.depth(),
+                cap,
+                "the completion gauge must track the bounded map depth"
+            );
+            assert!(
+                sidecar.take_sidecar_response(oldest_request_id).is_none(),
+                "the oldest unretrieved response should be evicted once the cap is exceeded"
+            );
+
+            // A response completed after the cap was reached is still retrievable,
+            // proving eviction drops the front and keeps the most recent entries.
+            let recent_request_id = complete_one_sidecar_response(&mut sidecar, &ownership);
+            assert!(
+                sidecar.take_sidecar_response(recent_request_id).is_some(),
+                "a freshly completed response should remain retrievable after eviction"
+            );
+        }
+
+        // Retrieving completed responses must keep the gauge in sync so the
+        // limit registry never reports phantom backlog after the host drains.
+        fn taking_sidecar_responses_releases_completion_gauge() {
+            let mut sidecar = create_test_sidecar();
+            let ownership = OwnershipScope::connection("conn-completion-drain");
+
+            let mut request_ids = Vec::new();
+            for _ in 0..8 {
+                request_ids.push(complete_one_sidecar_response(&mut sidecar, &ownership));
+            }
+            assert_eq!(sidecar.completed_sidecar_responses_gauge.depth(), 8);
+
+            for request_id in request_ids {
+                assert!(
+                    sidecar.take_sidecar_response(request_id).is_some(),
+                    "each completed response should be retrievable exactly once"
+                );
+            }
+            assert_eq!(
+                sidecar.completed_sidecar_responses_gauge.depth(),
+                0,
+                "draining every completed response must return the gauge to zero"
+            );
+            assert_eq!(sidecar.completed_sidecar_responses.len(), 0);
+        }
+
         fn process_event_sender_is_bounded() {
             let sidecar = create_test_sidecar();
 
@@ -17232,6 +17338,12 @@ console.log(JSON.stringify({
             javascript_child_process_internal_bootstrap_env_is_allowlisted();
             javascript_net_poll_clamps_guest_wait_to_sidecar_ceiling();
             javascript_net_poll_timeout_does_not_block_concurrent_vm_dispose();
+        }
+
+        #[test]
+        fn service_sidecar_response_completion_is_bounded() {
+            completed_sidecar_responses_evict_oldest_beyond_cap();
+            taking_sidecar_responses_releases_completion_gauge();
         }
 
         #[test]

--- a/crates/v8-runtime/src/isolate.rs
+++ b/crates/v8-runtime/src/isolate.rs
@@ -5,6 +5,7 @@ use std::ffi::c_void;
 use std::sync::Once;
 
 use crate::ipc::ExecutionError;
+use secure_exec_bridge::queue_tracker::{warn_limit_exhausted, TrackedLimit};
 
 static V8_INIT: Once = Once::new();
 const MAX_UNHANDLED_PROMISE_REJECTIONS: usize = 1024;
@@ -135,6 +136,11 @@ extern "C" fn near_heap_limit_callback(
         // guest with an uncatchable exception rather than crashing the process.
         handle.terminate_execution();
     }
+    warn_limit_exhausted(
+        TrackedLimit::V8HeapBytes,
+        current_heap_limit,
+        initial_heap_limit.max(1),
+    );
     // Grant headroom so V8 does not immediately fatal-abort before the termination
     // takes effect. We never shrink below the current limit.
     current_heap_limit

--- a/crates/v8-runtime/src/session.rs
+++ b/crates/v8-runtime/src/session.rs
@@ -6,6 +6,8 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 
 use crossbeam_channel::{Receiver, Sender};
+#[cfg(not(test))]
+use secure_exec_bridge::queue_tracker::{warn_limit_exhausted, TrackedLimit};
 
 use crate::execution;
 #[cfg(not(test))]
@@ -1365,6 +1367,10 @@ fn session_thread(
 
                         // Send ExecutionResult
                         let result_frame = if cpu_budget_exceeded {
+                            if let Some(budget_ms) = cpu_time_limit_ms {
+                                let capacity = budget_ms as usize;
+                                warn_limit_exhausted(TrackedLimit::V8CpuTimeMs, capacity, capacity);
+                            }
                             RuntimeEvent::ExecutionResult {
                                 session_id,
                                 exit_code: 1,
@@ -1379,6 +1385,14 @@ fn session_thread(
                                 }),
                             }
                         } else if wall_clock_timed_out {
+                            if let Some(limit_ms) = wall_clock_limit_ms {
+                                let capacity = limit_ms as usize;
+                                warn_limit_exhausted(
+                                    TrackedLimit::V8WallClockMs,
+                                    capacity,
+                                    capacity,
+                                );
+                            }
                             RuntimeEvent::ExecutionResult {
                                 session_id,
                                 exit_code: 1,

--- a/crates/v8-runtime/src/timeout.rs
+++ b/crates/v8-runtime/src/timeout.rs
@@ -19,6 +19,7 @@
 // The two guards are independent: setting one env knob arms only that guard,
 // and when both are set whichever fires first terminates execution.
 
+use secure_exec_bridge::queue_tracker::{register_limit, TrackedLimit};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
@@ -187,6 +188,12 @@ impl CpuBudgetGuard {
         let baseline_ms = cpu_clock.elapsed_ms().unwrap_or(0);
         let budget_ms = budget_ms as u64;
 
+        // Sample CPU consumption into a registry gauge every poll so the operator
+        // gets an edge-triggered ~80% approach warning BEFORE the budget is
+        // exhausted and the isolate is terminated (the terminal edge is reported
+        // separately by `warn_limit_exhausted`).
+        let cpu_gauge = register_limit(TrackedLimit::V8CpuTimeMs, budget_ms as usize);
+
         let handle = thread::Builder::new()
             .name("cpu-budget".into())
             .spawn(move || {
@@ -202,6 +209,7 @@ impl CpuBudgetGuard {
                                 .elapsed_ms()
                                 .unwrap_or(baseline_ms)
                                 .saturating_sub(baseline_ms);
+                            cpu_gauge.observe_depth(used as usize);
                             if used >= budget_ms {
                                 fired_clone.store(true, Ordering::SeqCst);
                                 isolate_handle.terminate_execution();
@@ -343,20 +351,38 @@ impl TimeoutGuard {
         let fired = Arc::new(AtomicBool::new(false));
         let fired_clone = Arc::clone(&fired);
 
+        // Emit an edge-triggered ~80% approach warning before the wall-clock
+        // budget is exhausted and the isolate is terminated. Observing the gauge
+        // once at the threshold reuses the registry's warn + host-forward path.
+        let wall_gauge = register_limit(TrackedLimit::V8WallClockMs, timeout_ms as usize);
+        let warn_at_ms =
+            timeout_ms as u64 * secure_exec_bridge::queue_tracker::WARN_FILL_PERCENT as u64 / 100;
+
         let handle = thread::Builder::new()
             .name("timeout".into())
             .spawn(move || {
+                let warn_timer = crossbeam_channel::after(Duration::from_millis(warn_at_ms));
                 let timer = crossbeam_channel::after(Duration::from_millis(timeout_ms as u64));
 
-                crossbeam_channel::select! {
-                    recv(timer) -> _ => {
-                        // Timeout elapsed — terminate V8 execution
-                        fired_clone.store(true, Ordering::SeqCst);
-                        isolate_handle.terminate_execution();
-                        on_timeout();
-                    }
-                    recv(cancel_rx) -> _ => {
-                        // Cancelled — execution completed normally
+                loop {
+                    crossbeam_channel::select! {
+                        recv(warn_timer) -> _ => {
+                            // Crossed the approach threshold — warn once. The full
+                            // timer (and cancel) are still pending; `after` fires
+                            // only once, so the next select waits on those.
+                            wall_gauge.observe_depth(warn_at_ms as usize);
+                        }
+                        recv(timer) -> _ => {
+                            // Timeout elapsed — terminate V8 execution
+                            fired_clone.store(true, Ordering::SeqCst);
+                            isolate_handle.terminate_execution();
+                            on_timeout();
+                            return;
+                        }
+                        recv(cancel_rx) -> _ => {
+                            // Cancelled — execution completed normally
+                            return;
+                        }
                     }
                 }
             })

--- a/website/src/content/docs/docs/features/resource-limits.mdx
+++ b/website/src/content/docs/docs/features/resource-limits.mdx
@@ -1,6 +1,6 @@
 ---
 title: Resource Limits
-description: A short overview of Secure Exec resource limits, with a link to the canonical agentOS resource limits docs.
+description: Secure Exec resource limits, defaults, backpressure constants, and warning names.
 ---
 import { LinkCard } from '@astrojs/starlight/components';
 
@@ -11,10 +11,250 @@ Secure Exec bounds each VM with per-VM resource caps so untrusted guest code can
 - **Guest-local failure**: A guest that exceeds a cap fails inside its own VM with a normal POSIX errno, exactly as it would on real Linux.
 - **Host is unaffected**: Hitting a limit terminates or fails the guest operation only; the sidecar and host process stay intact and the VM keeps running.
 - **Operator-raisable**: The caller configures the limits per VM and can raise or lower them to fit the workload.
+- **Observable**: Queue, resource, memory, and CPU limits emit `limit_warning` structured events and `WARN` logs as they approach or hit a cap.
 
-## Full reference
+## Operator constants
 
-The canonical limit names, defaults, and configuration API are owned by agentOS.
+These constants are the default caps behind the `limits.*` VM config fields.
+
+| Config field | Constant | Default |
+| --- | --- | --- |
+| `limits.resources.cpuCount` | `DEFAULT_VIRTUAL_CPU_COUNT` | `1` |
+| `limits.resources.maxProcesses` | `DEFAULT_MAX_PROCESSES` | `256` |
+| `limits.resources.maxOpenFds` | `DEFAULT_MAX_OPEN_FDS` | `256` |
+| `limits.resources.maxPipes` | `DEFAULT_MAX_PIPES` | `128` |
+| `limits.resources.maxPtys` | `DEFAULT_MAX_PTYS` | `128` |
+| `limits.resources.maxSockets` | `DEFAULT_MAX_SOCKETS` | `256` |
+| `limits.resources.maxConnections` | `DEFAULT_MAX_CONNECTIONS` | `256` |
+| `limits.resources.maxSocketBufferedBytes` | `DEFAULT_MAX_SOCKET_BUFFERED_BYTES` | `4 MiB` |
+| `limits.resources.maxSocketDatagramQueueLen` | `DEFAULT_MAX_SOCKET_DATAGRAM_QUEUE_LEN` | `1024` |
+| `limits.resources.maxFilesystemBytes` | `DEFAULT_MAX_FILESYSTEM_BYTES` | `64 MiB` |
+| `limits.resources.maxInodeCount` | `DEFAULT_MAX_INODE_COUNT` | `16384` |
+| `limits.resources.maxBlockingReadMs` | `DEFAULT_BLOCKING_READ_TIMEOUT_MS` | `5000 ms` |
+| `limits.resources.maxPreadBytes` | `DEFAULT_MAX_PREAD_BYTES` | `64 MiB` |
+| `limits.resources.maxFdWriteBytes` | `DEFAULT_MAX_FD_WRITE_BYTES` | `64 MiB` |
+| `limits.resources.maxProcessArgvBytes` | `DEFAULT_MAX_PROCESS_ARGV_BYTES` | `1 MiB` |
+| `limits.resources.maxProcessEnvBytes` | `DEFAULT_MAX_PROCESS_ENV_BYTES` | `1 MiB` |
+| `limits.resources.maxReaddirEntries` | `DEFAULT_MAX_READDIR_ENTRIES` | `4096` |
+| `limits.resources.maxWasmMemoryBytes` | `DEFAULT_MAX_WASM_MEMORY_BYTES` | `128 MiB` |
+| `limits.resources.maxWasmFuel` | none | unset, runtime default applies |
+| `limits.resources.maxWasmStackBytes` | none | unset, engine default applies |
+| `limits.http.maxFetchResponseBytes` | `DEFAULT_MAX_FETCH_RESPONSE_BYTES` | `1 MiB` |
+| `limits.tools.defaultToolTimeoutMs` | `DEFAULT_TOOL_TIMEOUT_MS` | `30000 ms` |
+| `limits.tools.maxToolTimeoutMs` | `MAX_TOOL_TIMEOUT_MS` | `300000 ms` |
+| `limits.tools.maxRegisteredToolkits` | `MAX_REGISTERED_TOOLKITS` | `64` |
+| `limits.tools.maxRegisteredToolsPerVm` | `MAX_REGISTERED_TOOLS_PER_VM` | `256` |
+| `limits.tools.maxToolsPerToolkit` | `MAX_TOOLS_PER_TOOLKIT` | `64` |
+| `limits.tools.maxToolSchemaBytes` | `MAX_TOOL_SCHEMA_BYTES` | `16 KiB` |
+| `limits.tools.maxToolExamplesPerTool` | `MAX_TOOL_EXAMPLES_PER_TOOL` | `16` |
+| `limits.tools.maxToolExampleInputBytes` | `MAX_TOOL_EXAMPLE_INPUT_BYTES` | `4 KiB` |
+| `limits.plugins.maxPersistedManifestBytes` | `MAX_PERSISTED_MANIFEST_BYTES` | `64 MiB` |
+| `limits.plugins.maxPersistedManifestFileBytes` | `MAX_PERSISTED_MANIFEST_FILE_BYTES` | `1 GiB` |
+| `limits.acp.maxReadLineBytes` | `DEFAULT_ACP_MAX_READ_LINE_BYTES` | `16 MiB` |
+| `limits.acp.stdoutBufferByteLimit` | `DEFAULT_ACP_STDOUT_BUFFER_BYTE_LIMIT` | `1 MiB` |
+| `limits.jsRuntime.v8HeapLimitMb` | `DEFAULT_V8_HEAP_LIMIT_MB` | `128 MiB` |
+| `limits.jsRuntime.capturedOutputLimitBytes` | `DEFAULT_JS_CAPTURED_OUTPUT_LIMIT_BYTES` | `16 MiB` |
+| `limits.jsRuntime.stdinBufferLimitBytes` | `DEFAULT_JS_STDIN_BUFFER_LIMIT_BYTES` | `16 MiB` |
+| `limits.jsRuntime.eventPayloadLimitBytes` | `DEFAULT_JS_EVENT_PAYLOAD_LIMIT_BYTES` | `1 MiB` |
+| `limits.jsRuntime.v8IpcMaxFrameBytes` | `DEFAULT_V8_IPC_MAX_FRAME_BYTES` | `64 MiB` |
+| `limits.jsRuntime.syncRpcWaitTimeoutMs` | none | unset, engine default applies |
+| `limits.python.outputBufferMaxBytes` | `DEFAULT_PYTHON_OUTPUT_BUFFER_MAX_BYTES` | `1 MiB` |
+| `limits.python.executionTimeoutMs` | `DEFAULT_PYTHON_EXECUTION_TIMEOUT_MS` | `300000 ms` |
+| `limits.python.maxOldSpaceMb` | `DEFAULT_PYTHON_MAX_OLD_SPACE_MB` | `0`, Pyodide engine default |
+| `limits.python.vfsRpcTimeoutMs` | `DEFAULT_PYTHON_VFS_RPC_TIMEOUT_MS` | `30000 ms` |
+| `limits.wasm.maxModuleFileBytes` | `DEFAULT_WASM_MAX_MODULE_FILE_BYTES` | `256 MiB` |
+| `limits.wasm.capturedOutputLimitBytes` | `DEFAULT_WASM_CAPTURED_OUTPUT_LIMIT_BYTES` | `16 MiB` |
+| `limits.wasm.syncReadLimitBytes` | `DEFAULT_WASM_SYNC_READ_LIMIT_BYTES` | `16 MiB` |
+
+## Backpressure constants
+
+These internal queue caps are not per-VM config fields. They are tracked so slow consumers produce `limit_warning` events instead of silent stalls.
+
+| Warning name | Constant | Default |
+| --- | --- | --- |
+| `javascript_event_channel` | `JAVASCRIPT_EVENT_CHANNEL_CAPACITY` | `512 frames` |
+| `v8_session_frames` | `V8_SESSION_FRAME_CHANNEL_CAPACITY` | `1024 frames` |
+| `sidecar_stdin_frames` | `MAX_STDIN_FRAME_QUEUE` | `128 frames` |
+| `sidecar_stdout_frames` | `MAX_STDOUT_FRAME_QUEUE` | `4096 frames` |
+| `completed_sidecar_responses` | `MAX_COMPLETED_SIDECAR_RESPONSES` | `10000 responses` |
+
+## Audited constants
+
+The limits audit classifies every limit-shaped constant as `policy`, `policy-deferred`, or `invariant`. Keep this table in sync with `crates/sidecar/tests/fixtures/limits-inventory.json`.
+
+| Constant | Class | Source |
+| --- | --- | --- |
+| `MAX_SYMLINK_DEPTH` | `invariant` | `crates/execution/assets/v8-bridge.source.js` |
+| `MAX_BENCHMARK_ITERATIONS` | `invariant` | `crates/execution/src/benchmark.rs` |
+| `MAX_BENCHMARK_WARMUP_ITERATIONS` | `invariant` | `crates/execution/src/benchmark.rs` |
+| `JAVASCRIPT_CAPTURED_OUTPUT_LIMIT_BYTES` | `policy` | `crates/execution/src/javascript.rs` |
+| `JAVASCRIPT_EVENT_CHANNEL_CAPACITY` | `invariant` | `crates/execution/src/javascript.rs` |
+| `JAVASCRIPT_EVENT_PAYLOAD_LIMIT_BYTES` | `policy` | `crates/execution/src/javascript.rs` |
+| `KERNEL_STDIN_BUFFER_LIMIT_BYTES` | `policy` | `crates/execution/src/javascript.rs` |
+| `NODE_SYNC_RPC_RESPONSE_QUEUE_CAPACITY` | `invariant` | `crates/execution/src/javascript.rs` |
+| `DEFAULT_NODE_IMPORT_CACHE_MATERIALIZE_TIMEOUT` | `invariant` | `crates/execution/src/node_import_cache.rs` |
+| `DEFAULT_PYTHON_EXECUTION_TIMEOUT_MS` | `policy` | `crates/execution/src/python.rs` |
+| `DEFAULT_PYTHON_MAX_OLD_SPACE_MB` | `policy` | `crates/execution/src/python.rs` |
+| `DEFAULT_PYTHON_OUTPUT_BUFFER_MAX_BYTES` | `policy` | `crates/execution/src/python.rs` |
+| `DEFAULT_PYTHON_VFS_RPC_TIMEOUT_MS` | `policy` | `crates/execution/src/python.rs` |
+| `V8_SESSION_FRAME_CHANNEL_CAPACITY` | `invariant` | `crates/execution/src/v8_host.rs` |
+| `MAX_FRAME_SIZE` | `policy` | `crates/execution/src/v8_ipc.rs` |
+| `DEFAULT_WASM_EXECUTION_TIMEOUT_MS` | `policy-deferred` | `crates/execution/src/wasm.rs` |
+| `DEFAULT_WASM_PREWARM_TIMEOUT_MS` | `invariant` | `crates/execution/src/wasm.rs` |
+| `MAX_SYNC_WASM_PREWARM_MODULE_BYTES` | `invariant` | `crates/execution/src/wasm.rs` |
+| `MAX_WASM_IMPORT_SECTION_ENTRIES` | `invariant` | `crates/execution/src/wasm.rs` |
+| `MAX_WASM_MEMORY_SECTION_ENTRIES` | `invariant` | `crates/execution/src/wasm.rs` |
+| `MAX_WASM_MODULE_FILE_BYTES` | `policy` | `crates/execution/src/wasm.rs` |
+| `MAX_WASM_VARUINT_BYTES` | `invariant` | `crates/execution/src/wasm.rs` |
+| `WASM_CAPTURED_OUTPUT_LIMIT_BYTES` | `policy` | `crates/execution/src/wasm.rs` |
+| `WASM_SYNC_READ_LIMIT_BYTES` | `policy` | `crates/execution/src/wasm.rs` |
+| `DEFAULT_STREAM_DEVICE_READ_BYTES` | `invariant` | `crates/kernel/src/device_layer.rs` |
+| `MAX_FDS_PER_PROCESS` | `invariant` | `crates/kernel/src/fd_table.rs` |
+| `SHEBANG_LINE_MAX_BYTES` | `invariant` | `crates/kernel/src/kernel.rs` |
+| `MAX_SNAPSHOT_DEPTH` | `invariant` | `crates/vfs/src/posix/overlay_fs.rs` |
+| `MAX_PIPE_BUFFER_BYTES` | `invariant` | `crates/kernel/src/pipe_manager.rs` |
+| `MAX_ALLOCATED_PID` | `invariant` | `crates/kernel/src/process_table.rs` |
+| `MAX_SIGNAL` | `invariant` | `crates/kernel/src/process_table.rs` |
+| `MAX_CANON` | `invariant` | `crates/kernel/src/pty.rs` |
+| `MAX_PTY_BUFFER_BYTES` | `invariant` | `crates/kernel/src/pty.rs` |
+| `DEFAULT_BLOCKING_READ_TIMEOUT_MS` | `policy` | `crates/kernel/src/resource_accounting.rs` |
+| `DEFAULT_MAX_CONNECTIONS` | `policy` | `crates/kernel/src/resource_accounting.rs` |
+| `DEFAULT_MAX_FD_WRITE_BYTES` | `policy` | `crates/kernel/src/resource_accounting.rs` |
+| `DEFAULT_MAX_FILESYSTEM_BYTES` | `policy` | `crates/vfs/src/posix/usage.rs` |
+| `DEFAULT_MAX_INODE_COUNT` | `policy` | `crates/vfs/src/posix/usage.rs` |
+| `DEFAULT_MAX_OPEN_FDS` | `policy` | `crates/kernel/src/resource_accounting.rs` |
+| `DEFAULT_MAX_PIPES` | `policy` | `crates/kernel/src/resource_accounting.rs` |
+| `DEFAULT_MAX_PREAD_BYTES` | `policy` | `crates/kernel/src/resource_accounting.rs` |
+| `DEFAULT_MAX_PROCESS_ARGV_BYTES` | `policy` | `crates/kernel/src/resource_accounting.rs` |
+| `DEFAULT_MAX_PROCESS_ENV_BYTES` | `policy` | `crates/kernel/src/resource_accounting.rs` |
+| `DEFAULT_MAX_PROCESSES` | `policy` | `crates/kernel/src/resource_accounting.rs` |
+| `DEFAULT_MAX_PTYS` | `policy` | `crates/kernel/src/resource_accounting.rs` |
+| `DEFAULT_MAX_READDIR_ENTRIES` | `policy` | `crates/kernel/src/resource_accounting.rs` |
+| `DEFAULT_MAX_WASM_MEMORY_BYTES` | `policy` | `crates/kernel/src/resource_accounting.rs` |
+| `DEFAULT_MAX_SOCKET_BUFFERED_BYTES` | `policy` | `crates/kernel/src/resource_accounting.rs` |
+| `DEFAULT_MAX_SOCKET_DATAGRAM_QUEUE_LEN` | `policy` | `crates/kernel/src/resource_accounting.rs` |
+| `DEFAULT_MAX_SOCKETS` | `policy` | `crates/kernel/src/resource_accounting.rs` |
+| `MAX_PATH_LENGTH` | `invariant` | `crates/vfs/src/posix/vfs.rs` |
+| `MAX_SYMLINK_DEPTH` | `invariant` | `crates/vfs/src/posix/vfs.rs` |
+| `MAX_PATH` | `invariant` | `crates/vfs/src/engine/types.rs` |
+| `MAX_SYMLINK_DEPTH` | `invariant` | `crates/vfs/src/engine/types.rs` |
+| `DEFAULT_METADATA_CACHE_ENTRIES` | `invariant` | `crates/sidecar/src/plugins/chunked_local.rs` |
+| `DEFAULT_METADATA_CACHE_ENTRIES` | `invariant` | `crates/sidecar/src/plugins/chunked_s3.rs` |
+| `CONTROL_FRAME_QUEUE_CAPACITY` | `invariant` | `crates/secure-exec-client/src/transport.rs` |
+| `EVENT_CHANNEL_CAPACITY` | `invariant` | `crates/secure-exec-client/src/transport.rs` |
+| `PENDING_REQUEST_LIMIT` | `invariant` | `crates/secure-exec-client/src/transport.rs` |
+| `REQUEST_FRAME_QUEUE_CAPACITY` | `invariant` | `crates/secure-exec-client/src/transport.rs` |
+| `DEFAULT_KERNEL_STDIN_READ_MAX_BYTES` | `invariant` | `crates/sidecar/src/execution.rs` |
+| `DEFAULT_KERNEL_STDIN_READ_TIMEOUT_MS` | `invariant` | `crates/sidecar/src/execution.rs` |
+| `EXITED_PROCESS_SNAPSHOT_RETENTION` | `invariant` | `crates/sidecar/src/execution.rs` |
+| `JAVASCRIPT_NET_POLL_MAX_WAIT` | `invariant` | `crates/sidecar/src/execution.rs` |
+| `MAX_JAVASCRIPT_COMMAND_REDIRECT_DEPTH` | `invariant` | `crates/sidecar/src/execution.rs` |
+| `MAX_PER_PROCESS_STATE_HANDLES` | `policy-deferred` | `crates/sidecar/src/execution.rs` |
+| `SQLITE_JS_SAFE_INTEGER_MAX` | `invariant` | `crates/sidecar/src/execution.rs` |
+| `VM_FETCH_BUFFER_LIMIT_BYTES` | `policy` | `crates/sidecar/src/execution.rs` |
+| `DEFAULT_ACP_MAX_READ_LINE_BYTES` | `policy` | `crates/sidecar/src/limits.rs` |
+| `DEFAULT_ACP_STDOUT_BUFFER_BYTE_LIMIT` | `policy` | `crates/sidecar/src/limits.rs` |
+| `DEFAULT_JS_CAPTURED_OUTPUT_LIMIT_BYTES` | `policy` | `crates/sidecar/src/limits.rs` |
+| `DEFAULT_JS_EVENT_PAYLOAD_LIMIT_BYTES` | `policy` | `crates/sidecar/src/limits.rs` |
+| `DEFAULT_JS_STDIN_BUFFER_LIMIT_BYTES` | `policy` | `crates/sidecar/src/limits.rs` |
+| `DEFAULT_MAX_FETCH_RESPONSE_BYTES` | `policy` | `crates/sidecar/src/limits.rs` |
+| `DEFAULT_PYTHON_EXECUTION_TIMEOUT_MS` | `policy` | `crates/sidecar/src/limits.rs` |
+| `DEFAULT_PYTHON_MAX_OLD_SPACE_MB` | `policy` | `crates/sidecar/src/limits.rs` |
+| `DEFAULT_PYTHON_OUTPUT_BUFFER_MAX_BYTES` | `policy` | `crates/sidecar/src/limits.rs` |
+| `DEFAULT_PYTHON_VFS_RPC_TIMEOUT_MS` | `policy` | `crates/sidecar/src/limits.rs` |
+| `DEFAULT_TOOL_TIMEOUT_MS` | `policy` | `crates/sidecar/src/limits.rs` |
+| `DEFAULT_V8_IPC_MAX_FRAME_BYTES` | `policy` | `crates/sidecar/src/limits.rs` |
+| `DEFAULT_V8_HEAP_LIMIT_MB` | `policy` | `crates/sidecar/src/limits.rs` |
+| `DEFAULT_WASM_CAPTURED_OUTPUT_LIMIT_BYTES` | `policy` | `crates/sidecar/src/limits.rs` |
+| `DEFAULT_WASM_MAX_MODULE_FILE_BYTES` | `policy` | `crates/sidecar/src/limits.rs` |
+| `DEFAULT_WASM_SYNC_READ_LIMIT_BYTES` | `policy` | `crates/sidecar/src/limits.rs` |
+| `MAX_PERSISTED_MANIFEST_BYTES` | `policy` | `crates/sidecar/src/limits.rs` |
+| `MAX_PERSISTED_MANIFEST_FILE_BYTES` | `policy` | `crates/sidecar/src/limits.rs` |
+| `MAX_REGISTERED_TOOLKITS` | `policy` | `crates/sidecar/src/limits.rs` |
+| `MAX_REGISTERED_TOOLS_PER_VM` | `policy` | `crates/sidecar/src/limits.rs` |
+| `MAX_TOOL_EXAMPLE_INPUT_BYTES` | `policy` | `crates/sidecar/src/limits.rs` |
+| `MAX_TOOL_EXAMPLES_PER_TOOL` | `policy` | `crates/sidecar/src/limits.rs` |
+| `MAX_TOOL_SCHEMA_BYTES` | `policy` | `crates/sidecar/src/limits.rs` |
+| `MAX_TOOL_TIMEOUT_MS` | `policy` | `crates/sidecar/src/limits.rs` |
+| `MAX_TOOLS_PER_TOOLKIT` | `policy` | `crates/sidecar/src/limits.rs` |
+| `MAX_PERSISTED_MANIFEST_BYTES` | `policy` | `crates/sidecar/src/plugins/google_drive.rs` |
+| `MAX_PERSISTED_MANIFEST_FILE_BYTES` | `policy` | `crates/sidecar/src/plugins/google_drive.rs` |
+| `MAX_HOST_DIR_READ_BYTES` | `policy` | `crates/sidecar/src/plugins/host_dir.rs` |
+| `DEFAULT_MAX_FULL_READ_BYTES` | `policy-deferred` | `crates/sidecar/src/plugins/sandbox_agent.rs` |
+| `DEFAULT_PROCESS_TIMEOUT_MS` | `policy-deferred` | `crates/sidecar/src/plugins/sandbox_agent.rs` |
+| `DEFAULT_TIMEOUT_MS` | `policy-deferred` | `crates/sidecar/src/plugins/sandbox_agent.rs` |
+| `DEFAULT_COMPLETED_RESPONSE_CAP` | `invariant` | `crates/sidecar/src/protocol.rs` |
+| `DEFAULT_MAX_FRAME_BYTES` | `policy` | `crates/sidecar/src/protocol.rs` |
+| `DEFAULT_MAX_FRAME_BYTES` | `invariant` | `crates/sidecar/src/wire.rs` |
+| `MAX_COMPLETED_SIDECAR_RESPONSES` | `invariant` | `crates/sidecar/src/service.rs` |
+| `MAX_OUTBOUND_SIDECAR_REQUESTS` | `invariant` | `crates/sidecar/src/service.rs` |
+| `MAX_PENDING_SIDECAR_RESPONSES` | `invariant` | `crates/sidecar/src/service.rs` |
+| `MAX_PROCESS_EVENT_QUEUE` | `invariant` | `crates/sidecar/src/service.rs` |
+| `HOST_REALPATH_MAX_SYMLINK_DEPTH` | `invariant` | `crates/sidecar/src/state.rs` |
+| `VM_LISTEN_PORT_MAX_METADATA_KEY` | `invariant` | `crates/sidecar/src/state.rs` |
+| `MAX_EVENT_READY_QUEUE` | `invariant` | `crates/sidecar/src/stdio.rs` |
+| `MAX_STDIN_FRAME_QUEUE` | `invariant` | `crates/sidecar/src/stdio.rs` |
+| `MAX_STDOUT_FRAME_QUEUE` | `invariant` | `crates/sidecar/src/stdio.rs` |
+| `DEFAULT_TOOL_TIMEOUT_MS` | `policy` | `crates/sidecar/src/tools.rs` |
+| `MAX_REGISTERED_TOOLKITS` | `policy` | `crates/sidecar/src/tools.rs` |
+| `MAX_REGISTERED_TOOLS_PER_VM` | `policy` | `crates/sidecar/src/tools.rs` |
+| `MAX_TOOL_DESCRIPTION_LENGTH` | `policy-deferred` | `crates/sidecar/src/tools.rs` |
+| `MAX_TOOL_EXAMPLE_INPUT_BYTES` | `policy` | `crates/sidecar/src/tools.rs` |
+| `MAX_TOOL_EXAMPLES_PER_TOOL` | `policy` | `crates/sidecar/src/tools.rs` |
+| `MAX_TOOL_NAME_LENGTH` | `policy-deferred` | `crates/sidecar/src/tools.rs` |
+| `MAX_TOOL_SCHEMA_BYTES` | `policy` | `crates/sidecar/src/tools.rs` |
+| `MAX_TOOL_SCHEMA_DEPTH` | `invariant` | `crates/sidecar/src/tools.rs` |
+| `MAX_TOOL_TIMEOUT_MS` | `policy` | `crates/sidecar/src/tools.rs` |
+| `MAX_TOOLKIT_NAME_LENGTH` | `policy-deferred` | `crates/sidecar/src/tools.rs` |
+| `MAX_TOOLS_PER_TOOLKIT` | `policy` | `crates/sidecar/src/tools.rs` |
+| `MAX_VM_LAYERS` | `policy-deferred` | `crates/sidecar/src/vm.rs` |
+| `MAX_CBOR_BRIDGE_CONTAINER_ITEMS` | `invariant` | `crates/v8-runtime/src/bridge.rs` |
+| `MAX_CBOR_BRIDGE_DEPTH` | `invariant` | `crates/v8-runtime/src/bridge.rs` |
+| `MAX_PENDING_PROMISES` | `invariant` | `crates/v8-runtime/src/bridge.rs` |
+| `MAX_VM_CONTEXTS` | `invariant` | `crates/v8-runtime/src/bridge.rs` |
+| `SESSION_OUTPUT_CHANNEL_CAPACITY` | `invariant` | `crates/v8-runtime/src/embedded_runtime.rs` |
+| `MAX_CJS_NAMED_EXPORTS` | `invariant` | `crates/v8-runtime/src/execution.rs` |
+| `MAX_CJS_RUNTIME_EXPORT_NAME_LEN` | `invariant` | `crates/v8-runtime/src/execution.rs` |
+| `MAX_MODULE_BATCH_RESOLVE_RESPONSE_BYTES` | `invariant` | `crates/v8-runtime/src/execution.rs` |
+| `MAX_MODULE_PREFETCH_BATCH_SIZE` | `invariant` | `crates/v8-runtime/src/execution.rs` |
+| `MAX_MODULE_PREFETCH_GRAPH_MODULES` | `invariant` | `crates/v8-runtime/src/execution.rs` |
+| `MAX_MODULE_RESOLVE_CACHE_ENTRIES` | `invariant` | `crates/v8-runtime/src/execution.rs` |
+| `MAX_MODULE_RESOLVE_MODULES` | `invariant` | `crates/v8-runtime/src/execution.rs` |
+| `MAX_FRAME_SIZE` | `policy` | `crates/v8-runtime/src/ipc_binary.rs` |
+| `MAX_UNHANDLED_PROMISE_REJECTIONS` | `invariant` | `crates/v8-runtime/src/isolate.rs` |
+| `NEAR_HEAP_LIMIT_HEADROOM_BYTES` | `invariant` | `crates/v8-runtime/src/isolate.rs` |
+| `MAX_DEFERRED_SESSION_COMMANDS` | `invariant` | `crates/v8-runtime/src/session.rs` |
+| `MAX_DEFERRED_SYNC_MESSAGES` | `invariant` | `crates/v8-runtime/src/session.rs` |
+| `SESSION_COMMAND_CHANNEL_CAPACITY` | `invariant` | `crates/v8-runtime/src/session.rs` |
+| `MAX_SNAPSHOT_BLOB_BYTES` | `invariant` | `crates/v8-runtime/src/snapshot.rs` |
+| `MAX_V8_BRIDGE_CODE_BYTES` | `invariant` | `crates/v8-runtime/src/snapshot.rs` |
+| `TRAILING_OUTPUT_DRAIN_MAX_MS` | `invariant` | `packages/core/src/kernel-proxy.ts` |
+| `DEFAULT_SIDECAR_EVENT_BUFFER_CAPACITY` | `policy-deferred` | `packages/core/src/native-client.ts` |
+| `DEFAULT_SIDECAR_FRAME_TIMEOUT_MS` | `policy-deferred` | `packages/core/src/native-client.ts` |
+| `MAX_SYMLINK_DEPTH` | `invariant` | `packages/core/src/test-runtime.ts` |
+
+## Warning names
+
+The limit registry emits stable names in `limit_warning.detail.limit`.
+`limits.resources.maxWasmStackBytes` is audited as a configured constant above, but it does not emit `limit_warning` until runtime stack enforcement has a reliable exhaustion edge.
+
+When a warning fires depends on whether the limit has a continuously-sampled usage:
+
+- **Queue**, **Resource**, and **CPU** limits emit an **edge-triggered ~80% approach warning** (re-armed once usage drains back below ~50%), so the operator gets a heads-up *before* the cap is reached. The CPU budgets (`v8_cpu_time_ms`, `v8_wall_clock_ms`, `wasm_fuel_ms`) are sampled by the execution watchdogs; the queue/resource gauges are sampled as items flow through them.
+- **Memory** limits (`v8_heap_bytes`, `wasm_memory_bytes`) emit at the **terminal edge** — V8's near-heap-limit callback fires as the isolate is about to exceed its heap cap, and WASM memory is checked at module-instantiation time. There is no separate 80% heap sample because a V8 isolate cannot be safely read from the watchdog thread.
+
+CPU budgets therefore emit both the ~80% approach warning *and* a terminal exhaustion warning when the watchdog finally terminates execution.
+
+| Category | Warning names |
+| --- | --- |
+| Queue | `javascript_event_channel`, `v8_session_frames`, `sidecar_stdin_frames`, `sidecar_stdout_frames`, `completed_sidecar_responses`, `pending_process_events`, `pending_sidecar_responses`, `outbound_sidecar_requests` |
+| Resource | `vm_processes`, `vm_open_fds`, `vm_pipes`, `vm_ptys`, `vm_sockets`, `vm_connections`, `vm_socket_buffered_bytes`, `vm_socket_datagram_queue_len`, `vm_filesystem_bytes`, `vm_inodes` |
+| Memory | `v8_heap_bytes`, `wasm_memory_bytes` |
+| CPU | `v8_cpu_time_ms`, `v8_wall_clock_ms`, `wasm_fuel_ms` |
+
+## Related agentOS docs
+
+agentOS layers its own session and adapter limits on top of Secure Exec.
 
 <LinkCard
   title="agentOS: Resource Limits"


### PR DESCRIPTION
## Problem

Two bounded queues in the guest→host path reacted **catastrophically when full** instead of applying backpressure:

1. **Event channel** (`crates/execution/src/javascript.rs`) — `send_javascript_event` did `try_send`, and on `Full` called `v8_session.destroy()` → `Shutdown` → `Exited(1)`. A transient backlog tore the whole session down with a truncated event stream.
2. **Stdout frame queue** (`crates/sidecar/src/stdio.rs`) — `send_output_frame` did `try_send`, and on `Full` returned a `BrokenPipe` error that propagated up and **exited the entire sidecar process (code 1)**, taking every session with it.

Both only fire when the host consumer is *briefly* slow (e.g. a chatty tool/skill turn outpacing a host that is momentarily not draining stdout) — a transient, recoverable condition that should never be fatal. This is the defense-in-depth half of the Zid adapter-stall investigation (the primary fix is host-side: a non-blocking buffered adapter-stderr WriteStream instead of per-line sync I/O).

## Fix

**Backpressure instead of self-destruct.** Both producers now block until the consumer drains a slot:
- The event channel runs on a dedicated OS thread → `blocking_send`.
- The stdout queue producer is a current-thread runtime whose writer drains on an **independent** thread, so a blocking `SyncSender::send` backpressures without deadlock. A genuinely dead consumer still terminates the producer via `Closed`/`Disconnected` (e.g. the writer thread detecting a real broken pipe) rather than blocking forever.
- The oversized-single-event guard (a frame too large to ever send) still destroys — it's genuinely unsendable, not backpressure.

**Headroom.** Raise `JAVASCRIPT_EVENT_CHANNEL_CAPACITY` 64→512 and `MAX_STDOUT_FRAME_QUEUE` 128→4096 so realistic bursts are absorbed before backpressure engages at all.

**Centralized queue tracker** (`secure_exec_bridge::queue_tracker`) — the explicit ask for observability:
- Every bounded queue registers a `QueueGauge` in a process-global `QueueRegistry`.
- Depth + high-water are tracked; a single **edge-triggered `warn!` fires at ≥80% fill** (re-arming below 50% for hysteresis) so a slow consumer is visible *before* it stalls a session.
- `queue_snapshot()` / `log_queue_snapshot()` expose live usage (name/depth/high-water/capacity/fill%) for debugging.
- Wired: the V8 event channel and the stdin frame queue (depth sampled from the Tokio channel's `max_capacity - capacity`), and the stdout frame queue (via a `TrackedSyncSender`/`TrackedReceiver` wrapper that records enqueue/dequeue).

## Tests

- **bridge**: `queue_tracker` unit tests — depth/high-water tracking, edge-triggered warn with hysteresis, registry snapshot + auto-prune of dropped queues.
- **execution**: `send_javascript_event` now backpressures instead of destroying (unit, with a slow drainer) + an integration test in the `javascript_v8` suite that bursts 1000 guest logs past the channel with a delayed host drain and asserts a **clean exit with every line delivered**. Without the fix the same test reproduces the bug exactly: `lines=64/1000` (the old capacity) and a torn-down session.
- **sidecar**: stdout frame queue accepts > capacity frames under a slow drainer (backpressure) and only errors when the writer is gone (`BrokenPipe`).

All green: `cargo build --workspace` clean (no warnings), bridge / sidecar-lib / execution unit + `javascript_v8` integration / `limits_audit` suites pass.