### PR TITLE
[codex] test custom JS VFS mounts

### DIFF
--- a/packages/build-tools/scripts/build-v8-bridge.mjs
+++ b/packages/build-tools/scripts/build-v8-bridge.mjs
@@ -468,7 +468,7 @@ function createUndiciBuildPlugins() {
 					},
 					(args) => {
 						const resolvedPath = require.resolve(args.path, {
-							paths: [args.resolveDir, packageRoot, workspaceRoot],
+							paths: [packageRoot, workspaceRoot, args.resolveDir],
 						});
 						return { path: resolvedPath };
 					},

--- a/packages/core/tests/mount-fs-custom-vfs.test.ts
+++ b/packages/core/tests/mount-fs-custom-vfs.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+	createInMemoryFileSystem,
+	createKernel,
+	type Kernel,
+	type VirtualFileSystem,
+} from "../src/test-runtime.js";
+
+const VFS_METHODS = [
+	"readFile",
+	"readTextFile",
+	"readDir",
+	"readDirWithTypes",
+	"writeFile",
+	"createDir",
+	"mkdir",
+	"exists",
+	"stat",
+	"removeFile",
+	"removeDir",
+	"rename",
+	"realpath",
+	"symlink",
+	"readlink",
+	"lstat",
+	"link",
+	"chmod",
+	"chown",
+	"utimes",
+	"truncate",
+	"pread",
+	"pwrite",
+] as const;
+
+function createRecordingFilesystem(): {
+	fs: VirtualFileSystem;
+	calls: string[];
+} {
+	const base = createInMemoryFileSystem();
+	const calls: string[] = [];
+	const delegates = base as unknown as Record<
+		(typeof VFS_METHODS)[number],
+		(...args: unknown[]) => unknown
+	>;
+	const fs = Object.fromEntries(
+		VFS_METHODS.map((method) => [
+			method,
+			(...args: unknown[]) => {
+				calls.push(`${method}:${String(args[0])}`);
+				return delegates[method].apply(base, args);
+			},
+		]),
+	) as unknown as VirtualFileSystem;
+
+	return { fs, calls };
+}
+
+describe("Kernel.mountFs custom JS VFS", () => {
+	let kernel: Kernel | undefined;
+
+	afterEach(async () => {
+		await kernel?.dispose();
+		kernel = undefined;
+	});
+
+	test(
+		"routes runtime reads and writes through a plain JS VFS object",
+		async () => {
+			const mounted = createRecordingFilesystem();
+			kernel = createKernel({ filesystem: createInMemoryFileSystem() });
+
+			kernel.mountFs("/mnt/custom", mounted.fs);
+			await kernel.writeFile("/mnt/custom/note.txt", "from custom vfs");
+
+			expect(
+				new TextDecoder().decode(await kernel.readFile("/mnt/custom/note.txt")),
+			).toBe("from custom vfs");
+			expect(mounted.calls).toContain("writeFile:/note.txt");
+			expect(mounted.calls).toContain("readFile:/note.txt");
+
+			kernel.unmountFs("/mnt/custom");
+			await expect(kernel.readFile("/mnt/custom/note.txt")).rejects.toThrow();
+		},
+		120_000,
+	);
+});


### PR DESCRIPTION
## What

- Add a focused regression test proving Kernel.mountFs routes reads and writes through a plain JavaScript VFS object.
- Make the V8 bridge build resolve pinned shim dependencies from secure-exec before a caller workspace.

## Why

When secure-exec is consumed from a sibling workspace, the V8 bridge build could resolve web-streams-polyfill from the caller workspace instead of secure-exec's pinned dependency. That broke Agent OS local secure-exec builds when the caller had web-streams-polyfill v4 installed.

## Validation

- pnpm --dir packages/core exec vitest run tests/mount-fs-custom-vfs.test.ts --reporter=verbose
