### PR TITLE
fix: repair main after #124 (rustfmt 1.96.0 + userland_code test ctors + clippy)

### DIFF
--- a/crates/bridge/src/queue_tracker.rs
+++ b/crates/bridge/src/queue_tracker.rs
@@ -199,11 +199,10 @@ fn dispatch_warning(warning: &LimitWarning) {
 /// Use this for runtime caps such as CPU or heap exhaustion where there is no
 /// continuously sampled queue depth to observe before the terminal edge.
 pub fn warn_limit_exhausted(name: TrackedLimit, observed: usize, capacity: usize) {
-    let fill_percent = if capacity == 0 {
-        0
-    } else {
-        observed.saturating_mul(100) / capacity
-    };
+    let fill_percent = observed
+        .saturating_mul(100)
+        .checked_div(capacity)
+        .unwrap_or(0);
     let category = name.category();
     tracing::warn!(
         limit = name.as_str(),
@@ -276,11 +275,10 @@ impl QueueGauge {
     /// Fill fraction (0–100) at the given depth. Saturates rather than dividing
     /// by zero for untracked (capacity 0) queues.
     fn fill_percent(&self, depth: usize) -> usize {
-        if self.capacity == 0 {
-            0
-        } else {
-            depth.saturating_mul(100) / self.capacity
-        }
+        depth
+            .saturating_mul(100)
+            .checked_div(self.capacity)
+            .unwrap_or(0)
     }
 
     /// Record a new depth: refresh the high-water mark and emit an edge-triggered

--- a/crates/execution/tests/javascript_v8.rs
+++ b/crates/execution/tests/javascript_v8.rs
@@ -4045,14 +4045,10 @@ fn javascript_execution_v8_event_channel_backpressures_instead_of_destroying_ses
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
     let mut exit_code = None;
-    loop {
-        // A poll error (e.g. EventChannelClosed) means the session was torn down
-        // out from under us — exactly the destroy-on-full regression — so stop and
-        // let the assertions below report the truncation rather than panicking.
-        let event = match execution.poll_event_blocking(Duration::from_secs(10)) {
-            Ok(event) => event,
-            Err(_session_died) => break,
-        };
+    // A poll error (e.g. EventChannelClosed) means the session was torn down
+    // out from under us — exactly the destroy-on-full regression — so stop and
+    // let the assertions below report the truncation rather than panicking.
+    while let Ok(event) = execution.poll_event_blocking(Duration::from_secs(10)) {
         match event {
             Some(JavascriptExecutionEvent::Stdout(chunk)) => stdout.extend(chunk),
             Some(JavascriptExecutionEvent::Stderr(chunk)) => stderr.extend(chunk),
@@ -4253,7 +4249,10 @@ console.log("ORDER_OK:" + trace);
         stdout.contains("ORDER_OK:data:chunk-1,immediate,data:chunk-2"),
         "expected macrotask to interleave between chunks; stdout: {stdout}\nstderr: {stderr}"
     );
-    assert_eq!(socket_reads, 3, "expected exactly chunk1, chunk2, EOF reads");
+    assert_eq!(
+        socket_reads, 3,
+        "expected exactly chunk1, chunk2, EOF reads"
+    );
 }
 
 fn javascript_execution_v8_dynamic_import_accepts_file_urls() {

--- a/crates/sidecar/src/execution.rs
+++ b/crates/sidecar/src/execution.rs
@@ -3066,14 +3066,12 @@ where
                             compile_cache_root: Some(self.cache_root.join("node-compile-cache")),
                         });
                 let built_reader = build_module_reader(vm, &resolved);
-                let guest_reader = built_reader
-                    .clone()
-                    .map(|reader| {
-                        Box::new(crate::plugins::host_dir::SessionModuleReader::new(reader))
-                            as Box<dyn GuestModuleReader>
-                    });
-                let module_reader = built_reader
-                    .map(|reader| Box::new(reader) as Box<dyn ModuleFsReader + Send>);
+                let guest_reader = built_reader.clone().map(|reader| {
+                    Box::new(crate::plugins::host_dir::SessionModuleReader::new(reader))
+                        as Box<dyn GuestModuleReader>
+                });
+                let module_reader =
+                    built_reader.map(|reader| Box::new(reader) as Box<dyn ModuleFsReader + Send>);
                 let execution = self
                     .javascript_engine
                     .start_execution_with_module_reader(
@@ -5386,9 +5384,7 @@ where
                     prepare_javascript_shadow(vm, &resolved)?;
 
                     let built_reader = build_module_reader(vm, &resolved);
-                    let guest_reader = built_reader
-                        .clone()
-                        .map(|reader| {
+                    let guest_reader = built_reader.clone().map(|reader| {
                         Box::new(crate::plugins::host_dir::SessionModuleReader::new(reader))
                             as Box<dyn GuestModuleReader>
                     });
@@ -5787,9 +5783,7 @@ where
                     prepare_javascript_shadow(vm, &resolved)?;
 
                     let built_reader = build_module_reader(vm, &resolved);
-                    let guest_reader = built_reader
-                        .clone()
-                        .map(|reader| {
+                    let guest_reader = built_reader.clone().map(|reader| {
                         Box::new(crate::plugins::host_dir::SessionModuleReader::new(reader))
                             as Box<dyn GuestModuleReader>
                     });
@@ -13608,7 +13602,7 @@ fn record_sync_rpc(method: &str) {
     };
     *map.entry(method.to_string()).or_insert(0) += 1;
     let total: u64 = map.values().sum();
-    if total == 1 || total % 50 == 0 {
+    if total == 1 || total.is_multiple_of(50) {
         let mut top: Vec<(&String, &u64)> = map.iter().collect();
         top.sort_by(|a, b| b.1.cmp(a.1));
         let breakdown = top

--- a/crates/sidecar/tests/host_dir.rs
+++ b/crates/sidecar/tests/host_dir.rs
@@ -6,6 +6,10 @@
 #[path = "../src/macos_fs.rs"]
 mod macos_fs;
 
+// The source is `include!`d wholesale but this test only exercises the
+// filesystem-plugin subset, so items used elsewhere in the crate (e.g. the
+// session-thread `SessionModuleReader`) are legitimately unused here.
+#[allow(dead_code)]
 mod host_dir {
     include!("../src/plugins/host_dir.rs");
 

--- a/crates/v8-runtime/src/embedded_runtime.rs
+++ b/crates/v8-runtime/src/embedded_runtime.rs
@@ -11,8 +11,7 @@ use crate::host_call::CallIdRouter;
 use crate::ipc_binary::BinaryFrame;
 use crate::runtime_protocol::{
     validate_bridge_response_status, BridgeResponse, ModuleReaderHandle, RuntimeCommand,
-    RuntimeEvent, SessionMessage,
-    StreamEvent,
+    RuntimeEvent, SessionMessage, StreamEvent,
 };
 use crate::session::{RuntimeEventEnvelope, SessionCommand, SessionManager};
 use crate::snapshot::SnapshotCache;
@@ -302,10 +301,11 @@ impl EmbeddedV8SessionHandle {
         &self,
         reader: Box<dyn crate::execution::GuestModuleReader>,
     ) -> io::Result<()> {
-        self.runtime.dispatch(RuntimeCommand::SetSessionModuleReader {
-            session_id: self.session_id.clone(),
-            reader: ModuleReaderHandle::new(reader),
-        })
+        self.runtime
+            .dispatch(RuntimeCommand::SetSessionModuleReader {
+                session_id: self.session_id.clone(),
+                reader: ModuleReaderHandle::new(reader),
+            })
     }
 
     pub fn terminate(&self) -> io::Result<()> {
@@ -601,9 +601,7 @@ fn dispatch_runtime_command(
             match reader.take() {
                 Some(reader) => sender
                     .send(SessionCommand::SetModuleReader(reader))
-                    .map_err(|e| {
-                        other_io_error(format!("session thread disconnected: {}", e))
-                    }),
+                    .map_err(|e| other_io_error(format!("session thread disconnected: {}", e))),
                 None => Ok(()),
             }
         }

--- a/crates/v8-runtime/src/ipc_binary.rs
+++ b/crates/v8-runtime/src/ipc_binary.rs
@@ -759,6 +759,7 @@ mod tests {
             file_path: "".into(),
             bridge_code: "(function(){ /* bridge */ })()".into(),
             post_restore_script: "".into(),
+            userland_code: String::new(),
             user_code: "console.log('hello')".into(),
         });
     }
@@ -771,6 +772,7 @@ mod tests {
             file_path: "/app/index.mjs".into(),
             bridge_code: "(function(){ /* bridge */ })()".into(),
             post_restore_script: "__runtimeApplyConfig({})".into(),
+            userland_code: String::new(),
             user_code: "export default 42".into(),
         });
     }
@@ -922,6 +924,7 @@ mod tests {
     fn roundtrip_warm_snapshot() {
         roundtrip(&BinaryFrame::WarmSnapshot {
             bridge_code: "(function(){ /* bridge IIFE */ })()".into(),
+            userland_code: String::new(),
         });
     }
 
@@ -929,6 +932,7 @@ mod tests {
     fn roundtrip_warm_snapshot_empty_bridge_code() {
         roundtrip(&BinaryFrame::WarmSnapshot {
             bridge_code: "".into(),
+            userland_code: String::new(),
         });
     }
 
@@ -936,6 +940,7 @@ mod tests {
     fn roundtrip_warm_snapshot_large_bridge_code() {
         roundtrip(&BinaryFrame::WarmSnapshot {
             bridge_code: "x".repeat(100_000),
+            userland_code: String::new(),
         });
     }
 
@@ -943,6 +948,7 @@ mod tests {
     fn extract_session_id_warm_snapshot_returns_none() {
         let frame = BinaryFrame::WarmSnapshot {
             bridge_code: "bridge()".into(),
+            userland_code: String::new(),
         };
         let mut buf = Vec::new();
         write_frame(&mut buf, &frame).expect("write");
@@ -1023,6 +1029,7 @@ mod tests {
                 file_path: "".into(),
                 bridge_code: "bridge()".into(),
                 post_restore_script: "".into(),
+                userland_code: String::new(),
                 user_code: "1+1".into(),
             },
             BinaryFrame::DestroySession {
@@ -1093,7 +1100,9 @@ mod tests {
 
         let destroy_session = vec![MSG_DESTROY_SESSION, 1, b's', 0xAA];
         let terminate_execution = vec![MSG_TERMINATE_EXECUTION, 1, b's', 0xAA];
-        let warm_snapshot = vec![MSG_WARM_SNAPSHOT, 0, 0, 0, 0, 0, 0xAA];
+        // WarmSnapshot body: no-session-id flag, bridge_code (u32 len = 0), then
+        // userland_code (u32 len = 0); a single trailing 0xAA must be rejected.
+        let warm_snapshot = vec![MSG_WARM_SNAPSHOT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xAA];
 
         for body in [
             create_session,
@@ -1170,6 +1179,7 @@ mod tests {
                 file_path: "".into(),
                 bridge_code: "".into(),
                 post_restore_script: "".into(),
+                userland_code: String::new(),
                 user_code: "".into(),
             },
             BinaryFrame::BridgeResponse {
@@ -1265,6 +1275,7 @@ mod tests {
                     file_path: "".into(),
                     bridge_code: "".into(),
                     post_restore_script: "".into(),
+                    userland_code: String::new(),
                     user_code: "".into(),
                 },
                 0x05,
@@ -1295,6 +1306,7 @@ mod tests {
             (
                 BinaryFrame::WarmSnapshot {
                     bridge_code: "bridge()".into(),
+                    userland_code: String::new(),
                 },
                 0x09,
             ),
@@ -1542,6 +1554,7 @@ mod tests {
             file_path: long_path,
             bridge_code: "".into(),
             post_restore_script: "".into(),
+            userland_code: String::new(),
             user_code: "".into(),
         };
         let result = frame_to_bytes(&frame);

--- a/crates/v8-runtime/src/session.rs
+++ b/crates/v8-runtime/src/session.rs
@@ -846,6 +846,10 @@ fn session_thread(
                     userland_code,
                     user_code,
                 } => {
+                    // `userland_code` is consumed only by the non-test snapshot
+                    // path below; keep it bound (without a warning) under `test`.
+                    #[cfg(test)]
+                    let _ = &userland_code;
                     #[cfg(not(test))]
                     {
                         let session_id = session_id.clone();

--- a/crates/v8-runtime/src/snapshot.rs
+++ b/crates/v8-runtime/src/snapshot.rs
@@ -102,11 +102,7 @@ const SNAPSHOT_USERLAND_PREP: &str = r#"
 /// Compile and run a Script in the snapshot-creation context, returning a
 /// descriptive error (with the V8 exception message) on failure. `label`
 /// identifies the phase (e.g. "bridge code" / "userland code") in error text.
-fn run_snapshot_script(
-    scope: &mut v8::HandleScope,
-    code: &str,
-    label: &str,
-) -> Result<(), String> {
+fn run_snapshot_script(scope: &mut v8::HandleScope, code: &str, label: &str) -> Result<(), String> {
     let try_catch = &mut v8::TryCatch::new(scope);
     let source = match v8::String::new(try_catch, code) {
         Some(source) => source,
@@ -447,8 +443,7 @@ fn snapshot_cache_key(bridge_code: &str, userland_code: Option<&str>) -> Snapsho
     match userland_code {
         None => sha256(bridge_code.as_bytes()),
         Some(userland_code) => {
-            let mut buf =
-                Vec::with_capacity(bridge_code.len() + 1 + userland_code.len());
+            let mut buf = Vec::with_capacity(bridge_code.len() + 1 + userland_code.len());
             buf.extend_from_slice(bridge_code.as_bytes());
             buf.push(0);
             buf.extend_from_slice(userland_code.as_bytes());
@@ -1520,10 +1515,12 @@ pub fn run_snapshot_consolidated_checks() {
             let b = cache
                 .get_or_create_with_userland(bridge_code, Some(userland))
                 .expect("userland cache hit");
-            assert!(Arc::ptr_eq(&a, &b), "identical userland should hit the cache");
+            assert!(
+                Arc::ptr_eq(&a, &b),
+                "identical userland should hit the cache"
+            );
 
-            let userland2 =
-                "(function(){ globalThis.__x = { f: function(){ return 7; } }; })();";
+            let userland2 = "(function(){ globalThis.__x = { f: function(){ return 7; } }; })();";
             let c = cache
                 .get_or_create_with_userland(bridge_code, Some(userland2))
                 .expect("changed userland create");

--- a/crates/v8-runtime/tests/embedded_runtime_session.rs
+++ b/crates/v8-runtime/tests/embedded_runtime_session.rs
@@ -59,6 +59,7 @@ fn dispatch_execute(
             file_path: String::new(),
             bridge_code: bridge_code.to_owned(),
             post_restore_script: String::new(),
+            userland_code: String::new(),
             user_code: user_code.to_owned(),
         },
     })
@@ -186,6 +187,7 @@ fn assert_warmed_snapshot_bridge_state() -> io::Result<()> {
 
     runtime.dispatch(RuntimeCommand::WarmSnapshot {
         bridge_code: bridge_code.to_owned(),
+        userland_code: String::new(),
     })?;
     dispatch_execute(
         runtime.as_ref(),


### PR DESCRIPTION
## Why

PR #124 (`perf: cut create-session latency via agent-SDK heap snapshot`, merged in `2e95d518`) landed while its CI was **red**, leaving `main` failing on three gates:

- **rustfmt 1.96.0** — `embedded_runtime.rs`, `snapshot.rs`, `sidecar/execution.rs` unformatted under the pinned toolchain.
- **clippy `-D warnings`** — `manual_div`, `is_multiple_of`, `while let`, and a source-included dead-code false positive.
- **test-compile** — 13 `BinaryFrame`/`SessionMessage`/`RuntimeCommand` constructors missing the new `userland_code` field; one hand-built `WarmSnapshot` byte test still on the old 1-field wire layout.

Every open PR's CI inherits this via the merge commit, so `main` was blocking the whole repo.

## What

- Reformat the 3 files with the pinned rustfmt 1.96.0.
- Add `userland_code` (empty = bridge-only, the documented default) to the 11 `ipc_binary` test frames + 2 `embedded_runtime_session` frames; update the `WarmSnapshot` trailing-byte test for the 2-field (`bridge_code` + `userland_code`) wire layout.
- clippy: `checked_div` (queue_tracker), `is_multiple_of` (sidecar/execution), `while let` (js backpressure test), `#[allow(dead_code)]` on the `host_dir` test's `include!`d module (`SessionModuleReader` is used elsewhere in the crate).

## Verification (local)

`cargo fmt --check` (rustfmt 1.96.0) clean · `cargo clippy --workspace --all-targets -- -D warnings` clean · ipc_binary (51), embedded_runtime_session, javascript_v8_suite (incl. the #122/#123 regression tests), queue_tracker, kernel gauges, sidecar completion all pass.