### PR TITLE
feat(sidecar): stream extension events live during dispatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,8 @@ Every bound that protects a shared resource — memory/heap, CPU/wall-clock, fd/
 
 ## Project Boundaries
 
-- Keep this repo Agent OS-agnostic: no ACP, agents, sessions, `agentos-protocol`, `agentos-client`, or `agentos-sidecar` dependencies in secure-exec code.
+- Keep the secure-exec runtime Agent OS-agnostic: no ACP, sessions, `agentos-protocol`, `agentos-client`, or `agentos-sidecar` dependencies in runtime code.
+- Packaged agent definitions/adapters live in `registry/agent/*`; generic VM software lives in `registry/software/*`.
 - `crates/bridge/` is the browser/native portability seam. Shared contracts belong there.
 - `crates/vfs/` is generic filesystem infrastructure: POSIX-style in-memory/overlay/mount/root engines plus generic chunked/object engines and in-memory stores. It must stay free of secure-exec sidecar, bridge, S3, SQLite, and host-disk coupling.
 - `crates/secure-exec-vfs/` contains concrete secure-exec filesystem backends: S3 adapters, host-disk SQLite/file stores, and bridge/callback-backed metadata stores. Policy decisions, config validation, and mount descriptor parsing stay in sidecar plugins.
@@ -80,6 +81,12 @@ Every bound that protects a shared resource — memory/heap, CPU/wall-clock, fd/
 
 ## Development
 
+### Release Tracks
+
+- **secure-exec runtime** — `@secure-exec/*` npm packages and `secure-exec-*` crates; releases keep npm/crates in sync, previews are npm-only. See "Preview-publishing" and "Publishing" for details.
+- **`@agentos-software/*` registry packages** — generic VM software from secure-exec `registry/software/*` plus agent adapters from secure-exec `registry/agent/*`; versioned independently of secure-exec runtime packages.
+- **agent-os product/API** — `@rivet-dev/agentos*`, AgentOs APIs, sidecar wrapper, docs, quickstarts, and examples; see agent-os `CLAUDE.md` for its pinning workflow.
+
 ### Preview-publishing
 
 Dispatch `.github/workflows/publish.yaml` (workflow_dispatch) with no version input to cut a **preview** (debug sidecar build, npm-only, dist-tag = sanitized branch name) — for handing a build to a downstream (agent-os) or external project. **Preview-publish is for previews ONLY; never cut a release with it.** Caveats: WASM-bearing packages (`@secure-exec/core`, `@agentos-software/*`) publish MANUALLY (see Publishing), and the crates.io job is skipped on preview — a *crate* change only reaches consumers locally (path dep / `[patch]`) or via a real release.
@@ -91,7 +98,7 @@ Dispatch `.github/workflows/publish.yaml` (workflow_dispatch) with no version in
 
 ## Publishing
 
-- **The `@secure-exec/*` npm packages and the `secure-exec-*` Cargo crates are always published at the same version** (npm and crates stay in sync), so a downstream pins both to one `<v>`. The `@agentos-software/*` registry software packages are on a **separate** version track.
+- **The `@secure-exec/*` npm packages and the `secure-exec-*` Cargo crates are always published at the same version** (npm and crates stay in sync), so a downstream pins both to one `<v>`. See "Release Tracks" for how this differs from `@agentos-software/*` and agent-os releases.
 - CI (`.github/workflows/publish.yaml`) does NOT build or publish the WASM command binaries. There is no `build-commands` job and nothing restores a `wasm-commands` artifact — the workflow only builds/publishes the sidecar binary and the pure-TS packages.
 - WASM-bearing packages are ALWAYS published MANUALLY: `@secure-exec/core` (which vendors `registry/native` commands into `packages/core/commands` via `copy-wasm-commands.mjs`, guarded by its `prepack --require`) and the `@agentos-software/*` registry software. `@secure-exec/core` is in `EXCLUDED` in `scripts/publish/src/lib/packages.ts`, so CI never publishes it.
 - Manual core flow: build the commands locally (`make -C registry/native wasm`), then `npm publish` (not `pnpm publish`) `@secure-exec/core` at the **same version** CI used for that release so dependents resolving `@secure-exec/core@<version>` succeed. `prepack` vendors the commands and fails loud if they are absent.

--- a/crates/sidecar/src/extension.rs
+++ b/crates/sidecar/src/extension.rs
@@ -8,7 +8,7 @@ use crate::protocol::{
     ProcessKilledResponse, ProcessStartedResponse, SidecarRequestPayload, SidecarResponsePayload,
     StdinClosedResponse, StdinWrittenResponse, WriteStdinRequest,
 };
-use crate::state::{SharedSidecarRequestClient, SidecarError};
+use crate::state::{SharedEventSink, SharedSidecarRequestClient, SidecarError};
 
 pub type ExtensionFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, SidecarError>> + 'a>>;
 
@@ -151,6 +151,7 @@ pub struct ExtensionSnapshot {
     namespace: String,
     ownership: OwnershipScope,
     sidecar_requests: SharedSidecarRequestClient,
+    event_sink: SharedEventSink,
 }
 
 pub struct ExtensionContext<'a> {
@@ -163,11 +164,13 @@ impl ExtensionSnapshot {
         namespace: String,
         ownership: OwnershipScope,
         sidecar_requests: SharedSidecarRequestClient,
+        event_sink: SharedEventSink,
     ) -> Self {
         Self {
             namespace,
             ownership,
             sidecar_requests,
+            event_sink,
         }
     }
 
@@ -194,6 +197,28 @@ impl ExtensionSnapshot {
         payload: Vec<u8>,
     ) -> Result<crate::wire::EventFrame, SidecarError> {
         crate::wire::event_frame_from_compat(self.ext_event(payload)).map_err(wire_protocol_error)
+    }
+
+    /// Emit a wire event frame to the host the instant it is produced, rather
+    /// than collecting it into the dispatch result and waiting for the whole
+    /// request to resolve. Returns `Ok(None)` when delivered live, or
+    /// `Ok(Some(event))` when no live sink is configured (in-process sidecar) so
+    /// the caller can fall back to returning it in the dispatch's batch.
+    pub fn emit_event_wire(
+        &self,
+        event: crate::wire::EventFrame,
+    ) -> Result<Option<crate::wire::EventFrame>, SidecarError> {
+        self.event_sink.try_emit(event)
+    }
+
+    /// Build a namespaced ext-event from `payload` and emit it live (see
+    /// [`Self::emit_event_wire`]).
+    pub fn emit_ext_event(
+        &self,
+        payload: Vec<u8>,
+    ) -> Result<Option<crate::wire::EventFrame>, SidecarError> {
+        let event = self.ext_event_wire(payload)?;
+        self.emit_event_wire(event)
     }
 
     pub fn invoke_callback(
@@ -239,6 +264,24 @@ impl<'a> ExtensionContext<'a> {
         payload: Vec<u8>,
     ) -> Result<crate::wire::EventFrame, SidecarError> {
         self.snapshot.ext_event_wire(payload)
+    }
+
+    /// Emit a wire event frame to the host live (see
+    /// [`ExtensionSnapshot::emit_event_wire`]).
+    pub fn emit_event_wire(
+        &self,
+        event: crate::wire::EventFrame,
+    ) -> Result<Option<crate::wire::EventFrame>, SidecarError> {
+        self.snapshot.emit_event_wire(event)
+    }
+
+    /// Build a namespaced ext-event from `payload` and emit it live (see
+    /// [`ExtensionSnapshot::emit_ext_event`]).
+    pub fn emit_ext_event(
+        &self,
+        payload: Vec<u8>,
+    ) -> Result<Option<crate::wire::EventFrame>, SidecarError> {
+        self.snapshot.emit_ext_event(payload)
     }
 
     pub fn invoke_callback(
@@ -599,5 +642,86 @@ pub trait Extension: Send + Sync {
 
     fn on_dispose<'a>(&'a self) -> ExtensionFuture<'a, ()> {
         Box::pin(async { Ok(()) })
+    }
+}
+
+#[cfg(test)]
+mod live_event_tests {
+    use super::*;
+    use crate::state::EventSinkTransport;
+    use std::sync::{Arc, Mutex};
+
+    /// Records every event handed to the live sink, standing in for the stdio
+    /// `FrameEventTransport` that writes `ProtocolFrame::EventFrame`s to stdout.
+    #[derive(Default)]
+    struct RecordingEventSink {
+        events: Arc<Mutex<Vec<crate::wire::EventFrame>>>,
+    }
+
+    impl EventSinkTransport for RecordingEventSink {
+        fn emit_event(&self, event: crate::wire::EventFrame) -> Result<(), SidecarError> {
+            self.events.lock().unwrap().push(event);
+            Ok(())
+        }
+    }
+
+    fn snapshot_with_sink(event_sink: SharedEventSink) -> ExtensionSnapshot {
+        ExtensionSnapshot::new(
+            String::from("dev.rivet.test.live-event"),
+            OwnershipScope::session("conn-live", "sess-live"),
+            SharedSidecarRequestClient::default(),
+            event_sink,
+        )
+    }
+
+    // With a transport configured (the stdio path), an ext event is emitted live
+    // and `emit_ext_event` reports nothing left to batch.
+    #[test]
+    fn emit_ext_event_streams_live_when_sink_configured() {
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let mut sink = SharedEventSink::default();
+        sink.set_transport(Arc::new(RecordingEventSink {
+            events: recorded.clone(),
+        }));
+
+        let snapshot = snapshot_with_sink(sink);
+        let leftover = snapshot
+            .emit_ext_event(b"live-update".to_vec())
+            .expect("emit must succeed");
+
+        assert!(
+            leftover.is_none(),
+            "a configured sink consumes the event live, leaving nothing to batch"
+        );
+        let recorded = recorded.lock().unwrap();
+        assert_eq!(recorded.len(), 1, "the event must reach the live transport");
+        // The live frame round-trips back to the namespaced ext payload.
+        let compat = crate::wire::event_frame_to_compat(recorded[0].clone())
+            .expect("recorded frame converts back to compat");
+        match compat.payload {
+            EventPayload::Ext(envelope) => {
+                assert_eq!(envelope.namespace, "dev.rivet.test.live-event");
+                assert_eq!(envelope.payload, b"live-update");
+            }
+            other => panic!("unexpected live event payload: {other:?}"),
+        }
+    }
+
+    // With no transport (an in-process sidecar), the event is handed back so the
+    // caller can fall back to the dispatch-result batch — preserving delivery.
+    #[test]
+    fn emit_ext_event_falls_back_to_batch_without_sink() {
+        let snapshot = snapshot_with_sink(SharedEventSink::default());
+        let leftover = snapshot
+            .emit_ext_event(b"batched-update".to_vec())
+            .expect("emit must succeed");
+
+        let frame = leftover.expect("without a sink the event is returned for batching");
+        let compat = crate::wire::event_frame_to_compat(frame)
+            .expect("returned frame converts back to compat");
+        match compat.payload {
+            EventPayload::Ext(envelope) => assert_eq!(envelope.payload, b"batched-update"),
+            other => panic!("unexpected batched event payload: {other:?}"),
+        }
     }
 }

--- a/crates/sidecar/src/lib.rs
+++ b/crates/sidecar/src/lib.rs
@@ -28,6 +28,7 @@ pub use extension::{
     ExtensionInterruptResponse, ExtensionResponse,
 };
 pub use service::{DispatchResult, NativeSidecar, NativeSidecarConfig, SidecarError};
+pub use state::EventSinkTransport;
 pub use state::SidecarRequestTransport;
 
 use wire::{DEFAULT_MAX_FRAME_BYTES, PROTOCOL_NAME, PROTOCOL_VERSION};

--- a/crates/sidecar/src/service.rs
+++ b/crates/sidecar/src/service.rs
@@ -30,8 +30,8 @@ use crate::protocol::{
     VmLifecycleState, WriteStdinRequest,
 };
 use crate::state::{
-    ActiveExecutionEvent, BridgeError, ConnectionState, JavascriptSocketFamily,
-    JavascriptSocketPathContext, ProcessEventEnvelope, SessionState, SharedBridge,
+    ActiveExecutionEvent, BridgeError, ConnectionState, EventSinkTransport, JavascriptSocketFamily,
+    JavascriptSocketPathContext, ProcessEventEnvelope, SessionState, SharedBridge, SharedEventSink,
     SharedSidecarRequestClient, SidecarRequestTransport, VmState, EXECUTION_DRIVER_NAME,
 };
 use crate::tools::register_host_callbacks;
@@ -870,6 +870,7 @@ pub struct NativeSidecar<B> {
     pub(crate) pending_sidecar_responses_gauge: Arc<QueueGauge>,
     pub(crate) outbound_sidecar_requests_gauge: Arc<QueueGauge>,
     pub(crate) sidecar_requests: SharedSidecarRequestClient,
+    pub(crate) event_sink: SharedEventSink,
     pub(crate) extensions: BTreeMap<String, Arc<dyn Extension>>,
     pub(crate) extension_sessions: BTreeMap<(String, String), ExtensionSessionResources>,
     pub(crate) extension_process_output_buffers:
@@ -980,6 +981,7 @@ where
                 MAX_OUTBOUND_SIDECAR_REQUESTS,
             ),
             sidecar_requests: SharedSidecarRequestClient::default(),
+            event_sink: SharedEventSink::default(),
             extensions: BTreeMap::new(),
             extension_sessions: BTreeMap::new(),
             extension_process_output_buffers: BTreeMap::new(),
@@ -1160,6 +1162,10 @@ where
 
     pub fn set_sidecar_request_transport(&mut self, transport: Arc<dyn SidecarRequestTransport>) {
         self.sidecar_requests.set_transport(transport);
+    }
+
+    pub fn set_event_transport(&mut self, transport: Arc<dyn EventSinkTransport>) {
+        self.event_sink.set_transport(transport);
     }
 
     pub fn register_extension(
@@ -1488,6 +1494,7 @@ where
             namespace.clone(),
             request.ownership.clone(),
             self.sidecar_requests.clone(),
+            self.event_sink.clone(),
         );
         let ctx = ExtensionContext::new(snapshot, self);
         let response = extension.handle_request(ctx, envelope.payload).await?;
@@ -1898,6 +1905,7 @@ where
                 extension.namespace().to_owned(),
                 ownership.clone(),
                 self.sidecar_requests.clone(),
+                self.event_sink.clone(),
             );
             if let Err(error) = extension.on_session_disposed(snapshot).await {
                 if first_error.is_none() {

--- a/crates/sidecar/src/state.rs
+++ b/crates/sidecar/src/state.rs
@@ -198,6 +198,45 @@ impl SharedSidecarRequestClient {
     }
 }
 
+/// Fire-and-forget live event sink. Lets an extension emit a `session/update`
+/// (or any other) event frame to the host *mid-dispatch*, instead of having to
+/// return it from the dispatch and wait for the whole request to resolve before
+/// the stdio loop flushes it. Mirrors `SidecarRequestTransport`, but events have
+/// no response, no request id, and no timeout — they are written to the same
+/// outbound stdout channel the batch path uses.
+pub trait EventSinkTransport: Send + Sync {
+    fn emit_event(&self, event: crate::wire::EventFrame) -> Result<(), SidecarError>;
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct SharedEventSink {
+    transport: Option<Arc<dyn EventSinkTransport>>,
+}
+
+impl SharedEventSink {
+    pub(crate) fn set_transport(&mut self, transport: Arc<dyn EventSinkTransport>) {
+        self.transport = Some(transport);
+    }
+
+    /// Emit `event` live if a transport is configured (the stdio path). Returns
+    /// `Ok(None)` when the event was handed to the live transport, or
+    /// `Ok(Some(event))` when no transport is configured (e.g. an in-process
+    /// `NativeSidecar` with no stdout loop) so the caller can fall back to the
+    /// batch path and still deliver the event when the dispatch resolves.
+    pub(crate) fn try_emit(
+        &self,
+        event: crate::wire::EventFrame,
+    ) -> Result<Option<crate::wire::EventFrame>, SidecarError> {
+        match self.transport.as_ref() {
+            Some(transport) => {
+                transport.emit_event(event)?;
+                Ok(None)
+            }
+            None => Ok(Some(event)),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Bridge wrapper
 // ---------------------------------------------------------------------------

--- a/crates/sidecar/src/stdio.rs
+++ b/crates/sidecar/src/stdio.rs
@@ -4,8 +4,8 @@ use crate::wire::{
     SidecarResponseFrame, WireDispatchResult, WireFrameCodec,
 };
 use crate::{
-    Extension, ExtensionInterruptRequest, NativeSidecar, NativeSidecarConfig, SidecarError,
-    SidecarRequestTransport,
+    EventSinkTransport, Extension, ExtensionInterruptRequest, NativeSidecar, NativeSidecarConfig,
+    SidecarError, SidecarRequestTransport,
 };
 use secure_exec_bridge::queue_tracker::{tracked_sync_channel, TrackedLimit, TrackedSyncSender};
 use secure_exec_bridge::{
@@ -155,6 +155,12 @@ async fn run_async(extensions: Vec<Box<dyn Extension>>) -> Result<(), Box<dyn Er
     }));
     let callback_transport = Arc::new(FrameSidecarRequestTransport::new(write_tx.clone()));
     sidecar.set_sidecar_request_transport(callback_transport.clone());
+    // Live event sink: lets an extension stream `session/update` (and other)
+    // events to stdout mid-dispatch instead of batching them until the request
+    // resolves. Shares the same outbound `write_tx` channel as the batch path, so
+    // ordering and backpressure are identical.
+    let event_transport = Arc::new(FrameEventTransport::new(write_tx.clone()));
+    sidecar.set_event_transport(event_transport);
     let mut event_pump = time::interval(EVENT_PUMP_INTERVAL);
     let writer_codec = codec.clone();
     let reader_codec = codec.clone();
@@ -1378,6 +1384,28 @@ impl SessionScope {
 
     fn compat_ownership_scope(&self) -> crate::protocol::OwnershipScope {
         wire::ownership_scope_to_compat(self.ownership_scope())
+    }
+}
+
+/// Live event sink backed by the outbound stdout channel. Writes each event as a
+/// `ProtocolFrame::EventFrame` immediately, using the same blocking
+/// backpressure semantics as the batch event path (`send_output_frame`): a full
+/// queue parks the producer until the writer thread drains stdout rather than
+/// tearing down the process.
+struct FrameEventTransport {
+    writer: TrackedSyncSender<ProtocolFrame>,
+}
+
+impl FrameEventTransport {
+    fn new(writer: TrackedSyncSender<ProtocolFrame>) -> Self {
+        Self { writer }
+    }
+}
+
+impl EventSinkTransport for FrameEventTransport {
+    fn emit_event(&self, event: crate::wire::EventFrame) -> Result<(), SidecarError> {
+        send_output_frame(&self.writer, ProtocolFrame::EventFrame(event))
+            .map_err(|error| SidecarError::Bridge(error.to_string()))
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -19,5 +19,11 @@
 		"turbo": "^2.5.6",
 		"typescript": "^5.9.2",
 		"vitest": "^2.1.8"
+	},
+	"pnpm": {
+		"overrides": {
+			"@mariozechner/pi-tui": "0.60.0",
+			"@mariozechner/pi-agent-core": "0.60.0"
+		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@mariozechner/pi-tui': 0.60.0
+  '@mariozechner/pi-agent-core': 0.60.0
+
 importers:
 
   .:
@@ -442,6 +446,85 @@ importers:
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.15
+
+  registry/agent/claude:
+    dependencies:
+      '@agentclientprotocol/sdk':
+        specifier: ^0.16.1
+        version: 0.16.1(zod@4.3.6)
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: 0.2.87
+        version: 0.2.87(zod@4.3.6)
+      zod:
+        specifier: ^4.1.11
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.15
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
+  registry/agent/codex:
+    dependencies:
+      '@agentos-software/codex-cli':
+        specifier: workspace:*
+        version: link:../../software/codex
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.15
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
+  registry/agent/opencode:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.15
+      bun:
+        specifier: 1.3.11
+        version: 1.3.11
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
+  registry/agent/pi:
+    dependencies:
+      '@agentclientprotocol/sdk':
+        specifier: ^0.16.1
+        version: 0.16.1(zod@4.3.6)
+      '@mariozechner/pi-ai':
+        specifier: 0.60.0
+        version: 0.60.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent':
+        specifier: 0.60.0
+        version: 0.60.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.15
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
+  registry/agent/pi-cli:
+    dependencies:
+      '@mariozechner/pi-coding-agent':
+        specifier: ^0.60.0
+        version: 0.60.0(zod@3.25.76)
+      pi-acp:
+        specifier: ^0.0.23
+        version: 0.0.23
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.15
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
 
   registry/file-system/google-drive:
     dependencies:
@@ -1005,6 +1088,11 @@ importers:
 
 packages:
 
+  '@agentclientprotocol/sdk@0.12.0':
+    resolution: {integrity: sha512-V8uH/KK1t7utqyJmTA7y7DzKu6+jKFIXM+ZVouz8E55j8Ej2RV42rEvPKn3/PpBJlliI5crcGk1qQhZ7VwaepA==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
   '@agentclientprotocol/sdk@0.16.1':
     resolution: {integrity: sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw==}
     peerDependencies:
@@ -1013,6 +1101,30 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/claude-agent-sdk@0.2.87':
+    resolution: {integrity: sha512-WWmgBPxPhBOvNT0ujI8vPTI2lK+w5YEkEZ/y1mH0EDkK/0kBnxVJNhCtG5vnueiAViwLoUOFn66pbkDiivijdA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.73.0':
+    resolution: {integrity: sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@anthropic-ai/sdk@0.74.0':
+    resolution: {integrity: sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@astrojs/compiler@2.13.1':
     resolution: {integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==}
@@ -1059,6 +1171,107 @@ packages:
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1075.0':
+    resolution: {integrity: sha512-LDGtNMOxnMz0dw9q+8z0f/X+Soj8OyiYg5zPcqToLh6H9/HHlazogFj7PXqFLOhnvhCqyAvKVAC1ZrL0RX418g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.23':
+    resolution: {integrity: sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.49':
+    resolution: {integrity: sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.51':
+    resolution: {integrity: sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.56':
+    resolution: {integrity: sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.55':
+    resolution: {integrity: sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.58':
+    resolution: {integrity: sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.49':
+    resolution: {integrity: sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.55':
+    resolution: {integrity: sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.55':
+    resolution: {integrity: sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.22':
+    resolution: {integrity: sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.18':
+    resolution: {integrity: sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.31':
+    resolution: {integrity: sha512-ps1rumU1LybSFHaW9dTDgkhCMJLVaedEY78kKSzUDDY+b9974/g6aiaYYA0U9WV0oL4CJCJrVWG+EZ/qr4or7g==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.23':
+    resolution: {integrity: sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1074.0':
+    resolution: {integrity: sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1075.0':
+    resolution: {integrity: sha512-SsunyegDXq68TaN5Iut8ElErGIAA6DeuKPKd5/v0lpSmZBI7ZKOC5OALyi1MRHsl/cuO/zHkJL3vKnNHdGaI+Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.13':
+    resolution: {integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.31':
+    resolution: {integrity: sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1213,6 +1426,9 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
   '@capsizecss/unpack@4.0.1':
     resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
@@ -1690,6 +1906,15 @@ packages:
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
     engines: {node: '>=12.10.0'}
@@ -1703,6 +1928,12 @@ packages:
     resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1969,8 +2200,110 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    resolution: {integrity: sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    resolution: {integrity: sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    resolution: {integrity: sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@mariozechner/clipboard@0.3.9':
+    resolution: {integrity: sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==}
+    engines: {node: '>= 10'}
+
+  '@mariozechner/jiti@2.6.5':
+    resolution: {integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==}
+    hasBin: true
+
+  '@mariozechner/pi-agent-core@0.60.0':
+    resolution: {integrity: sha512-1zQcfFp8r0iwZCxCBQ9/ccFJoagns68cndLPTJJXl1ZqkYirzSld1zBOPxLAgeAKWIz3OX8dB2WQwTJFhmEojQ==}
+    engines: {node: '>=20.0.0'}
+    deprecated: please use @earendil-works/pi-agent-core instead going forward
+
+  '@mariozechner/pi-ai@0.60.0':
+    resolution: {integrity: sha512-OiMuXQturnEDPmA+ho7eLe4G8plO2z21yjNMs9niQREauoblWOz7Glv58I66KPzczLED4aZTlQLTRdU6t1rz8A==}
+    engines: {node: '>=20.0.0'}
+    deprecated: please use @earendil-works/pi-ai instead going forward
+    hasBin: true
+
+  '@mariozechner/pi-coding-agent@0.60.0':
+    resolution: {integrity: sha512-IOv7cTU4nbznFNUE5ofi13k2dmSG39coBoGWIBQTVw3iVyl0HxuHbg0NiTx3ktrPIDNtkii+y7tWXzWqwoo4lw==}
+    engines: {node: '>=20.6.0'}
+    deprecated: please use @earendil-works/pi-coding-agent instead going forward
+    hasBin: true
+
+  '@mariozechner/pi-tui@0.60.0':
+    resolution: {integrity: sha512-ZAK5gxYhGmfJqMjfWcRBjB8glITltDbTrYJXvcDtfengbKTZN0p39p5uO5pvUB8/PiAWKTRS06yaNMhf/LG26g==}
+    engines: {node: '>=20.0.0'}
+    deprecated: please use @earendil-works/pi-tui instead going forward
+
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@mistralai/mistralai@1.14.1':
+    resolution: {integrity: sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1986,6 +2319,66 @@ packages:
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
+
+  '@oven/bun-darwin-aarch64@1.3.11':
+    resolution: {integrity: sha512-/8IzqSu4/OWGRs7Fs2ROzGVwJMFTBQkgAp6sAthkBYoN7OiM4rY/CpPVs2X9w9N1W61CHSkEdNKi8HrLZKfK3g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oven/bun-darwin-x64-baseline@1.3.11':
+    resolution: {integrity: sha512-CYjIHWaQG7T4phfjErHr6BiXRs0K/9DqMeiohJmuYSBF+H2m56vFslOenLCguGYQL9jeiiCZBeoVCpwjxZrMgQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oven/bun-darwin-x64@1.3.11':
+    resolution: {integrity: sha512-TT7eUihnAzxM2tlZesusuC75PAOYKvUBgVU/Nm/lakZ/DpyuqhNkzUfcxSgmmK9IjVWzMmezLIGZl16XGCGJng==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oven/bun-linux-aarch64-musl@1.3.11':
+    resolution: {integrity: sha512-jBwYCLG5Eb+PqtFrc3Wp2WMYlw1Id75gUcsdP+ApCOpf5oQhHxkFWCjZmcDoioDmEhMWAiM3wtwSrTlPg+sI6Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oven/bun-linux-aarch64@1.3.11':
+    resolution: {integrity: sha512-8XMLyRNxHF4jfLajkWt+F8UDxsWbzysyxQVMZKUXwoeGvaxB0rVd07r3YbgDtG8U6khhRFM3oaGp+CQ0whwmdA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oven/bun-linux-x64-baseline@1.3.11':
+    resolution: {integrity: sha512-KZlf1jKtf4jai8xiQv/0XRjxVVhHnw/HtUKtLdOeQpTOQ1fQFhLoz2FGGtVRd0LVa/yiRbSz9HlWIzWlmJClng==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-linux-x64-musl-baseline@1.3.11':
+    resolution: {integrity: sha512-J+qz4Al05PrNIOdj7xsWVTyx0c/gjUauG5nKV3Rrx0Q+5JO+1pPVlnfNmWbOF9pKG4f3IGad8KXJUfGMORld+Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-linux-x64-musl@1.3.11':
+    resolution: {integrity: sha512-ADImD4yCHNpqZu718E2chWcCaAHvua90yhmpzzV6fF4zOhwkGGbPCgUWmKyJ83uz+DXaPdYxX0ttDvtolrzx3Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-linux-x64@1.3.11':
+    resolution: {integrity: sha512-z3GFCk1UBzDOOiEBHL32lVP7Edi26BhOjKb6bIc0nRyabbRiyON4++GR0zmd/H5zM5S0+UcXFgCGnD+b8avTLw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oven/bun-windows-aarch64@1.3.11':
+    resolution: {integrity: sha512-UOdkwScHRkGPz+n9ZJU7sTkTvqV7rD1SLCLaru1xH8WRsV7tDorPqNCzEN1msOIiPRK825nvAtEm9UsomO1GsA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oven/bun-windows-x64-baseline@1.3.11':
+    resolution: {integrity: sha512-cCsXK9AQ9Zf18QlVnbrFu2IKfr4sf2sfbErkF2jfCzyCO9Bnhl0KRx63zlN+Ni1xU7gcBLAssgcui5R400N2eA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oven/bun-windows-x64@1.3.11':
+    resolution: {integrity: sha512-E51tyWDP1l0CbjZYhiUxhDGPaY8Hf5YBREx0PHBff1LM1/q3qsJ6ZvRUa8YbbOO0Ax9QP6GHjD9vf3n6bXZ7QA==}
+    cpu: [x64]
+    os: [win32]
 
   '@pagefind/darwin-arm64@1.5.2':
     resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
@@ -2265,6 +2658,58 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@silvia-odwyer/photon-node@0.3.4':
+    resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
+
+  '@sinclair/typebox@0.34.49':
+    resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
+
+  '@smithy/core@3.26.0':
+    resolution: {integrity: sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.2':
+    resolution: {integrity: sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.5.2':
+    resolution: {integrity: sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.8.2':
+    resolution: {integrity: sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.5.2':
+    resolution: {integrity: sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.15.0':
+    resolution: {integrity: sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
   '@turbo/darwin-64@2.9.1':
     resolution: {integrity: sha512-d1zTcIf6VWT7cdfjhi0X36C2PRsUi2HdEwYzVgkLHmuuYtL+1Y1Zu3JdlouoB/NjG2vX3q4NnKLMNhDOEweoIg==}
     cpu: [x64]
@@ -2328,6 +2773,9 @@ packages:
   '@types/mdx@2.0.14':
     resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
 
+  '@types/mime-types@2.1.4':
+    resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
+
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -2348,6 +2796,9 @@ packages:
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
@@ -2359,6 +2810,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -2398,6 +2852,10 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2410,6 +2868,21 @@ packages:
 
   acp-http-client@0.4.2:
     resolution: {integrity: sha512-3wtPieF08YIU4vNXaoL5up/1D0if4i9IX3Ye5q/bwbcwg1BKsazIK/VNNfvN4ldbPjWul69IqIOpGRS3I0qo3Q==}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -2463,6 +2936,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
@@ -2513,6 +2990,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
+    engines: {node: '>=10.0.0'}
+
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
 
@@ -2521,6 +3002,9 @@ packages:
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -2535,8 +3019,15 @@ packages:
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
@@ -2584,6 +3075,12 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   buffer-xor@1.0.3:
     resolution: {integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==}
 
@@ -2596,6 +3093,16 @@ packages:
 
   builtin-status-codes@3.0.0:
     resolution: {integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==}
+
+  bun@1.3.11:
+    resolution: {integrity: sha512-AvXWYFO6j/ZQ7bhGm4X6eilq2JHsDVC90ZM32k2B7/srhC2gs3Sdki1QTbwrdRCo8o7eT+167vcB1yzOvPdbjA==}
+    cpu: [arm64, x64]
+    os: [darwin, linux, win32]
+    hasBin: true
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -2630,6 +3137,10 @@ packages:
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -2673,6 +3184,14 @@ packages:
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
+
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -2723,11 +3242,31 @@ packages:
   constants-browserify@1.0.0:
     resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -2735,6 +3274,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cpu-features@0.0.10:
     resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
@@ -2793,6 +3336,14 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -2819,6 +3370,14 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2897,6 +3456,12 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.375:
     resolution: {integrity: sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==}
 
@@ -2911,6 +3476,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -2963,9 +3532,26 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
 
   estree-util-attach-comments@3.0.0:
     resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
@@ -2991,12 +3577,28 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
@@ -3009,18 +3611,42 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
   expressive-code@0.41.7:
     resolution: {integrity: sha512-2wZjC8OQ3TaVEMcBtYY4Va3lo6J+Ai9jf3d4dbhURMJcU4Pbqe6EcHe424MIZI0VHUA1bR6xdpoHYi3yxokWqA==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3031,9 +3657,21 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -3058,6 +3696,14 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -3075,6 +3721,10 @@ packages:
       react-dom:
         optional: true
 
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -3090,6 +3740,14 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@7.1.5:
+    resolution: {integrity: sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -3119,12 +3777,20 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -3142,12 +3808,31 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
+  google-auth-library@10.9.0:
+    resolution: {integrity: sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
@@ -3235,8 +3920,19 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
+
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
+
+  hosted-git-info@9.0.3:
+    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
@@ -3250,8 +3946,20 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-browserify@1.0.0:
     resolution: {integrity: sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
@@ -3260,8 +3968,16 @@ packages:
   i18next@23.16.8:
     resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
 
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
@@ -3271,6 +3987,14 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -3344,6 +4068,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -3380,6 +4107,9 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3392,10 +4122,29 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -3404,6 +4153,9 @@ packages:
   klona@2.0.6:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
+
+  koffi@2.16.2:
+    resolution: {integrity: sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -3441,6 +4193,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
   lucide-react@0.469.0:
     resolution: {integrity: sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==}
     peerDependencies:
@@ -3465,6 +4221,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -3535,6 +4296,14 @@ packages:
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -3659,6 +4428,14 @@ packages:
     resolution: {integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==}
     hasBin: true
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
@@ -3708,15 +4485,32 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
 
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
+
   nlcst-to-string@4.0.0:
     resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
@@ -3770,6 +4564,10 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -3782,6 +4580,18 @@ packages:
 
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
+  openai@6.26.0:
+    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   os-browserify@0.3.0:
     resolution: {integrity: sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==}
@@ -3802,9 +4612,21 @@ packages:
     resolution: {integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==}
     engines: {node: '>=18'}
 
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
   p-timeout@6.1.4:
     resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
     engines: {node: '>=14.16'}
+
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -3829,8 +4651,24 @@ packages:
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
 
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -3854,6 +4692,13 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
@@ -3864,6 +4709,14 @@ packages:
   pbkdf2@3.1.5:
     resolution: {integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==}
     engines: {node: '>= 0.10'}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  pi-acp@0.0.23:
+    resolution: {integrity: sha512-neOq/zgZoViyaDN/KsoAMJ1ToE63kqvzm5fdoQkDzQ2+UezO3vwdVY1WjyEfDHaLQiOKgQQjXVqFUZ9fn3LZvQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
@@ -3890,6 +4743,10 @@ packages:
   pixelmatch@7.2.0:
     resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-dir@5.0.0:
     resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
@@ -3987,12 +4844,26 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   public-encrypt@4.0.3:
     resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
@@ -4011,6 +4882,10 @@ packages:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   querystring-es3@0.2.1:
     resolution: {integrity: sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==}
     engines: {node: '>=0.4.x'}
@@ -4026,6 +4901,14 @@ packages:
 
   randomfill@1.0.4:
     resolution: {integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
@@ -4128,6 +5011,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -4148,6 +5035,14 @@ packages:
   retext@9.0.0:
     resolution: {integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==}
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -4160,6 +5055,10 @@ packages:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -4225,12 +5124,23 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
 
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sha.js@2.4.12:
     resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
@@ -4260,6 +5170,10 @@ packages:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
   side-channel-map@1.0.1:
     resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
     engines: {node: '>= 0.4'}
@@ -4272,8 +5186,15 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -4290,12 +5211,28 @@ packages:
     engines: {node: '>=20.19.5', npm: '>=10.8.2'}
     hasBin: true
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   source-map@0.7.6:
@@ -4314,6 +5251,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -4360,6 +5301,10 @@ packages:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
 
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -4370,6 +5315,10 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -4440,11 +5389,22 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -4482,6 +5442,10 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -4509,6 +5473,10 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
@@ -4561,6 +5529,10 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   unstorage@1.17.5:
     resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
@@ -4644,6 +5616,10 @@ packages:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -4810,6 +5786,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -4829,13 +5817,24 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs@16.2.2:
+    resolution: {integrity: sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==}
+    engines: {node: '>=10'}
+
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4875,11 +5874,52 @@ packages:
 
 snapshots:
 
+  '@agentclientprotocol/sdk@0.12.0(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
+
   '@agentclientprotocol/sdk@0.16.1(zod@4.3.6)':
     dependencies:
       zod: 4.3.6
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/claude-agent-sdk@0.2.87(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.74.0(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+      zod: 4.3.6
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
+  '@anthropic-ai/sdk@0.73.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
+
+  '@anthropic-ai/sdk@0.73.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
+  '@anthropic-ai/sdk@0.74.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
 
   '@astrojs/compiler@2.13.1': {}
 
@@ -5017,6 +6057,228 @@ snapshots:
       which-pm-runs: 1.1.0
     transitivePeerDependencies:
       - supports-color
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.13
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1075.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-node': 3.972.58
+      '@aws-sdk/eventstream-handler-node': 3.972.22
+      '@aws-sdk/middleware-eventstream': 3.972.18
+      '@aws-sdk/middleware-websocket': 3.972.31
+      '@aws-sdk/token-providers': 3.1075.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.23':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/xml-builder': 3.972.31
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.26.0
+      '@smithy/signature-v4': 5.5.2
+      '@smithy/types': 4.15.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.56':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-env': 3.972.49
+      '@aws-sdk/credential-provider-http': 3.972.51
+      '@aws-sdk/credential-provider-login': 3.972.55
+      '@aws-sdk/credential-provider-process': 3.972.49
+      '@aws-sdk/credential-provider-sso': 3.972.55
+      '@aws-sdk/credential-provider-web-identity': 3.972.55
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/credential-provider-imds': 4.4.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.58':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.49
+      '@aws-sdk/credential-provider-http': 3.972.51
+      '@aws-sdk/credential-provider-ini': 3.972.56
+      '@aws-sdk/credential-provider-process': 3.972.49
+      '@aws-sdk/credential-provider-sso': 3.972.55
+      '@aws-sdk/credential-provider-web-identity': 3.972.55
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/credential-provider-imds': 4.4.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/token-providers': 3.1074.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.22':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.18':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.31':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/signature-v4': 5.5.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.23':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/signature-v4': 5.5.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1074.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1075.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.13':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.31':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -5176,6 +6438,8 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.4.10':
     optional: true
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@capsizecss/unpack@4.0.1':
     dependencies:
@@ -5446,6 +6710,19 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))':
+    dependencies:
+      google-auth-library: 10.9.0
+      p-retry: 4.6.2
+      protobufjs: 7.5.4
+      ws: 8.21.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@grpc/grpc-js@1.14.3':
     dependencies:
       '@grpc/proto-loader': 0.8.0
@@ -5467,6 +6744,10 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
     optional: true
+
+  '@hono/node-server@1.19.14(hono@4.12.27)':
+    dependencies:
+      hono: 4.12.27
 
   '@img/colour@1.1.0':
     optional: true
@@ -5671,6 +6952,195 @@ snapshots:
   '@js-sdsl/ordered-map@4.4.2':
     optional: true
 
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard@0.3.9':
+    optionalDependencies:
+      '@mariozechner/clipboard-darwin-arm64': 0.3.9
+      '@mariozechner/clipboard-darwin-universal': 0.3.9
+      '@mariozechner/clipboard-darwin-x64': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.9
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.9
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.9
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.9
+    optional: true
+
+  '@mariozechner/jiti@2.6.5':
+    dependencies:
+      std-env: 3.10.0
+      yoctocolors: 2.1.2
+
+  '@mariozechner/pi-agent-core@0.60.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+    dependencies:
+      '@mariozechner/pi-ai': 0.60.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-agent-core@0.60.0(zod@3.25.76)':
+    dependencies:
+      '@mariozechner/pi-ai': 0.60.0(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-ai@0.60.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime': 3.1075.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
+      '@mistralai/mistralai': 1.14.1
+      '@sinclair/typebox': 0.34.49
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      chalk: 5.6.2
+      openai: 6.26.0(ws@8.21.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      proxy-agent: 6.5.0
+      undici: 7.24.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-ai@0.60.0(zod@3.25.76)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.73.0(zod@3.25.76)
+      '@aws-sdk/client-bedrock-runtime': 3.1075.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
+      '@mistralai/mistralai': 1.14.1
+      '@sinclair/typebox': 0.34.49
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      chalk: 5.6.2
+      openai: 6.26.0(zod@3.25.76)
+      partial-json: 0.1.7
+      proxy-agent: 6.5.0
+      undici: 7.24.6
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-coding-agent@0.60.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+    dependencies:
+      '@mariozechner/jiti': 2.6.5
+      '@mariozechner/pi-agent-core': 0.60.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.60.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.60.0
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      diff: 8.0.4
+      extract-zip: 2.0.1
+      file-type: 21.3.4
+      glob: 13.0.6
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      marked: 15.0.12
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      strip-ansi: 7.2.0
+      undici: 7.24.6
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-coding-agent@0.60.0(zod@3.25.76)':
+    dependencies:
+      '@mariozechner/jiti': 2.6.5
+      '@mariozechner/pi-agent-core': 0.60.0(zod@3.25.76)
+      '@mariozechner/pi-ai': 0.60.0(zod@3.25.76)
+      '@mariozechner/pi-tui': 0.60.0
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      diff: 8.0.4
+      extract-zip: 2.0.1
+      file-type: 21.3.4
+      glob: 13.0.6
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      marked: 15.0.12
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      strip-ansi: 7.2.0
+      undici: 7.24.6
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-tui@0.60.0':
+    dependencies:
+      '@types/mime-types': 2.1.4
+      chalk: 5.6.2
+      get-east-asian-width: 1.6.0
+      marked: 15.0.12
+      mime-types: 3.0.2
+    optionalDependencies:
+      koffi: 2.16.2
+
   '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.8
@@ -5701,6 +7171,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@mistralai/mistralai@1.14.1':
+    dependencies:
+      ws: 8.21.0
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -5714,6 +7215,42 @@ snapshots:
       fastq: 1.20.1
 
   '@oslojs/encoding@1.1.0': {}
+
+  '@oven/bun-darwin-aarch64@1.3.11':
+    optional: true
+
+  '@oven/bun-darwin-x64-baseline@1.3.11':
+    optional: true
+
+  '@oven/bun-darwin-x64@1.3.11':
+    optional: true
+
+  '@oven/bun-linux-aarch64-musl@1.3.11':
+    optional: true
+
+  '@oven/bun-linux-aarch64@1.3.11':
+    optional: true
+
+  '@oven/bun-linux-x64-baseline@1.3.11':
+    optional: true
+
+  '@oven/bun-linux-x64-musl-baseline@1.3.11':
+    optional: true
+
+  '@oven/bun-linux-x64-musl@1.3.11':
+    optional: true
+
+  '@oven/bun-linux-x64@1.3.11':
+    optional: true
+
+  '@oven/bun-windows-aarch64@1.3.11':
+    optional: true
+
+  '@oven/bun-windows-x64-baseline@1.3.11':
+    optional: true
+
+  '@oven/bun-windows-x64@1.3.11':
+    optional: true
 
   '@pagefind/darwin-arm64@1.5.2':
     optional: true
@@ -5745,38 +7282,28 @@ snapshots:
     dependencies:
       playwright: 1.59.1
 
-  '@protobufjs/aspromise@1.1.2':
-    optional: true
+  '@protobufjs/aspromise@1.1.2': {}
 
-  '@protobufjs/base64@1.1.2':
-    optional: true
+  '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4':
-    optional: true
+  '@protobufjs/codegen@2.0.4': {}
 
-  '@protobufjs/eventemitter@1.1.0':
-    optional: true
+  '@protobufjs/eventemitter@1.1.0': {}
 
   '@protobufjs/fetch@1.1.0':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/inquire': 1.1.0
-    optional: true
 
-  '@protobufjs/float@1.0.2':
-    optional: true
+  '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.0':
-    optional: true
+  '@protobufjs/inquire@1.1.0': {}
 
-  '@protobufjs/path@1.1.2':
-    optional: true
+  '@protobufjs/path@1.1.2': {}
 
-  '@protobufjs/pool@1.1.0':
-    optional: true
+  '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.0':
-    optional: true
+  '@protobufjs/utf8@1.1.0': {}
 
   '@rivet-dev/docs-theme@https://codeload.github.com/rivet-dev/docs-theme/tar.gz/ed588a45112cfe70c9abe6e8f52e8fe47a1d6162(@astrojs/starlight@0.36.3(astro@5.18.2(@types/node@24.13.2)(jiti@1.21.7)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)))(astro@5.18.2(@types/node@24.13.2)(jiti@1.21.7)(rollup@4.60.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))':
     dependencies:
@@ -5931,6 +7458,69 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@silvia-odwyer/photon-node@0.3.4': {}
+
+  '@sinclair/typebox@0.34.49': {}
+
+  '@smithy/core@3.26.0':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.5.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.8.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.5.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.15.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
+
   '@turbo/darwin-64@2.9.1':
     optional: true
 
@@ -5992,6 +7582,8 @@ snapshots:
 
   '@types/mdx@2.0.14': {}
 
+  '@types/mime-types@2.1.4': {}
+
   '@types/ms@2.1.0': {}
 
   '@types/nlcst@2.0.3':
@@ -6014,6 +7606,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/retry@0.12.0': {}
+
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 22.19.15
@@ -6023,6 +7617,11 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 22.19.15
+    optional: true
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -6078,6 +7677,11 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -6089,6 +7693,19 @@ snapshots:
       '@agentclientprotocol/sdk': 0.16.1(zod@4.3.6)
     transitivePeerDependencies:
       - zod
+
+  agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-align@3.0.1:
     dependencies:
@@ -6139,6 +7756,10 @@ snapshots:
       util: 0.12.5
 
   assertion-error@2.0.1: {}
+
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
 
   astring@1.9.0: {}
 
@@ -6276,6 +7897,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.38: {}
 
+  basic-ftp@5.3.1: {}
+
   bcp-47-match@2.0.3: {}
 
   bcp-47@2.1.0:
@@ -6288,6 +7911,8 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
     optional: true
+
+  bignumber.js@9.3.1: {}
 
   binary-extensions@2.3.0: {}
 
@@ -6302,7 +7927,23 @@ snapshots:
 
   bn.js@5.2.3: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolbase@1.0.0: {}
+
+  bowser@2.14.1: {}
 
   boxen@8.0.1:
     dependencies:
@@ -6385,6 +8026,10 @@ snapshots:
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  buffer-crc32@0.2.13: {}
+
+  buffer-equal-constant-time@1.0.1: {}
+
   buffer-xor@1.0.3: {}
 
   buffer@5.7.1:
@@ -6396,6 +8041,23 @@ snapshots:
     optional: true
 
   builtin-status-codes@3.0.0: {}
+
+  bun@1.3.11:
+    optionalDependencies:
+      '@oven/bun-darwin-aarch64': 1.3.11
+      '@oven/bun-darwin-x64': 1.3.11
+      '@oven/bun-darwin-x64-baseline': 1.3.11
+      '@oven/bun-linux-aarch64': 1.3.11
+      '@oven/bun-linux-aarch64-musl': 1.3.11
+      '@oven/bun-linux-x64': 1.3.11
+      '@oven/bun-linux-x64-baseline': 1.3.11
+      '@oven/bun-linux-x64-musl': 1.3.11
+      '@oven/bun-linux-x64-musl-baseline': 1.3.11
+      '@oven/bun-windows-aarch64': 1.3.11
+      '@oven/bun-windows-x64': 1.3.11
+      '@oven/bun-windows-x64-baseline': 1.3.11
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -6431,6 +8093,11 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   chalk@5.6.2: {}
 
@@ -6473,6 +8140,21 @@ snapshots:
 
   cli-boxes@3.0.0: {}
 
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.2
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -6514,13 +8196,28 @@ snapshots:
 
   constants-browserify@1.0.0: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
 
   cookie-es@1.2.3: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   cookie@1.1.1: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cpu-features@0.0.10:
     dependencies:
@@ -6607,6 +8304,10 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
+  data-uri-to-buffer@6.0.2: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -6630,6 +8331,14 @@ snapshots:
       object-keys: 1.1.1
 
   defu@6.1.7: {}
+
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+
+  depd@2.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -6719,6 +8428,12 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.375: {}
 
   elliptic@6.6.1:
@@ -6737,10 +8452,11 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  encodeurl@2.0.0: {}
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
-    optional: true
 
   entities@4.5.0: {}
 
@@ -6856,7 +8572,21 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@5.0.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+
+  esprima@4.0.1: {}
+
+  estraverse@5.3.0: {}
 
   estree-util-attach-comments@3.0.0:
     dependencies:
@@ -6893,9 +8623,19 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  esutils@2.0.3: {}
+
+  etag@1.8.1: {}
+
   eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
 
   evp_bytestokey@1.0.3:
     dependencies:
@@ -6916,6 +8656,44 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   expressive-code@0.41.7:
     dependencies:
       '@expressive-code/core': 0.41.7
@@ -6925,6 +8703,18 @@ snapshots:
 
   extend@3.0.2: {}
 
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -6933,17 +8723,48 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-uri@3.1.2: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@5.0.0:
     dependencies:
@@ -6969,6 +8790,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
+  forwarded@0.2.0: {}
+
   fraction.js@5.3.4: {}
 
   framer-motion@12.40.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
@@ -6979,6 +8806,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0:
     optional: true
@@ -6991,12 +8820,27 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gaxios@7.1.5:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.5
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
 
-  get-caller-file@2.0.5:
-    optional: true
+  get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
 
@@ -7021,11 +8865,23 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-stream@8.0.1: {}
 
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.3.1
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   github-slugger@2.0.0: {}
 
@@ -7046,7 +8902,28 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  google-auth-library@10.9.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.5
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
 
   h3@1.15.11:
     dependencies:
@@ -7059,6 +8936,8 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.4
       uncrypto: 0.1.3
+
+  has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
     dependencies:
@@ -7280,11 +9159,19 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
+  highlight.js@10.7.3: {}
+
   hmac-drbg@1.0.1:
     dependencies:
       hash.js: 1.1.7
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+
+  hono@4.12.27: {}
+
+  hosted-git-info@9.0.3:
+    dependencies:
+      lru-cache: 11.5.1
 
   html-escaper@3.0.3: {}
 
@@ -7294,7 +9181,29 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-browserify@1.0.0: {}
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-signals@5.0.0: {}
 
@@ -7302,13 +9211,23 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
+
+  ignore@7.0.5: {}
 
   import-meta-resolve@4.2.0: {}
 
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -7371,6 +9290,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-promise@4.0.0: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -7404,6 +9325,8 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  jose@6.2.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.2.0:
@@ -7412,11 +9335,38 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
   json5@2.2.3: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   kleur@3.0.3: {}
 
   klona@2.0.6: {}
+
+  koffi@2.16.2:
+    optional: true
 
   lilconfig@3.1.3: {}
 
@@ -7433,8 +9383,7 @@ snapshots:
   lodash.camelcase@4.3.0:
     optional: true
 
-  long@5.3.2:
-    optional: true
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -7447,6 +9396,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@7.18.3: {}
 
   lucide-react@0.469.0(react@19.2.7):
     dependencies:
@@ -7476,6 +9427,8 @@ snapshots:
       uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
+
+  marked@15.0.12: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -7673,6 +9626,10 @@ snapshots:
   mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -7962,6 +9919,12 @@ snapshots:
       bn.js: 4.12.3
       brorand: 1.1.0
 
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mimic-fn@4.0.0: {}
 
   minimalistic-assert@1.0.1: {}
@@ -8002,13 +9965,25 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  negotiator@1.0.0: {}
+
   neotraverse@0.6.18: {}
+
+  netmask@2.1.1: {}
 
   nlcst-to-string@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
 
+  node-domexception@1.0.0: {}
+
   node-fetch-native@1.6.7: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-mock-http@1.0.4: {}
 
@@ -8084,10 +10059,13 @@ snapshots:
 
   ohash@2.0.11: {}
 
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-    optional: true
 
   onetime@6.0.0:
     dependencies:
@@ -8100,6 +10078,15 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  openai@6.26.0(ws@8.21.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 4.3.6
+
+  openai@6.26.0(zod@3.25.76):
+    optionalDependencies:
+      zod: 3.25.76
 
   os-browserify@0.3.0: {}
 
@@ -8120,7 +10107,30 @@ snapshots:
       eventemitter3: 5.0.4
       p-timeout: 6.1.4
 
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
   p-timeout@6.1.4: {}
+
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
 
   package-json-from-dist@1.0.1: {}
 
@@ -8165,9 +10175,21 @@ snapshots:
       unist-util-visit-children: 3.0.0
       vfile: 6.0.3
 
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
+
+  parseurl@1.3.3: {}
+
+  partial-json@0.1.7: {}
 
   path-browserify@1.0.1: {}
 
@@ -8184,6 +10206,13 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
+      minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
+
   pathe@1.1.2: {}
 
   pathval@2.0.1: {}
@@ -8196,6 +10225,13 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
       to-buffer: 1.2.2
+
+  pend@1.2.0: {}
+
+  pi-acp@0.0.23:
+    dependencies:
+      '@agentclientprotocol/sdk': 0.12.0(zod@3.25.76)
+      zod: 3.25.76
 
   piccolore@0.1.3: {}
 
@@ -8212,6 +10248,8 @@ snapshots:
   pixelmatch@7.2.0:
     dependencies:
       pngjs: 7.0.0
+
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@5.0.0:
     dependencies:
@@ -8286,6 +10324,12 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   property-information@7.2.0: {}
 
   protobufjs@7.5.4:
@@ -8302,7 +10346,26 @@ snapshots:
       '@protobufjs/utf8': 1.1.0
       '@types/node': 22.19.15
       long: 5.3.2
-    optional: true
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
 
   public-encrypt@4.0.3:
     dependencies:
@@ -8317,7 +10380,6 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
-    optional: true
 
   punycode.js@2.3.1: {}
 
@@ -8326,6 +10388,11 @@ snapshots:
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   querystring-es3@0.2.1: {}
 
@@ -8341,6 +10408,15 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
       safe-buffer: 5.2.1
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
@@ -8515,8 +10591,9 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  require-directory@2.1.1:
-    optional: true
+  require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -8550,6 +10627,10 @@ snapshots:
       retext-latin: 4.0.0
       retext-stringify: 4.0.0
       unified: 11.0.5
+
+  retry@0.12.0: {}
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -8589,6 +10670,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -8603,8 +10694,7 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
-  safer-buffer@2.1.2:
-    optional: true
+  safer-buffer@2.1.2: {}
 
   sandbox-agent@0.4.2(dockerode@4.0.10)(get-port@7.2.0)(zod@4.3.6):
     dependencies:
@@ -8625,6 +10715,31 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -8635,6 +10750,8 @@ snapshots:
       has-property-descriptors: 1.0.2
 
   setimmediate@1.0.5: {}
+
+  setprototypeof@1.2.0: {}
 
   sha.js@2.4.12:
     dependencies:
@@ -8722,6 +10839,11 @@ snapshots:
       es-errors: 1.3.0
       object-inspect: 1.13.4
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
   side-channel-map@1.0.1:
     dependencies:
       call-bound: 1.0.4
@@ -8745,7 +10867,17 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
@@ -8762,9 +10894,27 @@ snapshots:
       arg: 5.0.2
       sax: 1.6.0
 
+  smart-buffer@4.2.0: {}
+
   smol-toml@1.6.1: {}
 
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
+
   source-map-js@1.2.1: {}
+
+  source-map@0.6.1:
+    optional: true
 
   source-map@0.7.6: {}
 
@@ -8783,6 +10933,8 @@ snapshots:
     optional: true
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -8841,6 +10993,10 @@ snapshots:
 
   strip-final-newline@3.0.0: {}
 
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -8858,6 +11014,10 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -8957,9 +11117,19 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-interface-checker@0.1.13: {}
 
@@ -8992,6 +11162,12 @@ snapshots:
 
   type-fest@4.41.0: {}
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -9016,6 +11192,8 @@ snapshots:
   uc.micro@2.1.0: {}
 
   ufo@1.6.4: {}
+
+  uint8array-extras@1.5.0: {}
 
   ultrahtml@1.6.0: {}
 
@@ -9089,6 +11267,8 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  unpipe@1.0.0: {}
+
   unstorage@1.17.5:
     dependencies:
       anymatch: 3.1.3
@@ -9123,6 +11303,8 @@ snapshots:
 
   uuid@10.0.0:
     optional: true
+
+  vary@1.1.2: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -9269,21 +11451,33 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  wrappy@1.0.2:
-    optional: true
+  wrappy@1.0.2: {}
+
+  ws@8.21.0: {}
 
   xtend@4.0.2: {}
 
   xxhash-wasm@1.1.0: {}
 
-  y18n@5.0.8:
-    optional: true
+  y18n@5.0.8: {}
 
   yallist@3.1.1: {}
 
   yaml@2.9.0: {}
 
+  yargs-parser@20.2.9: {}
+
   yargs-parser@21.1.1: {}
+
+  yargs@16.2.2:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yargs@17.7.2:
     dependencies:
@@ -9295,6 +11489,11 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
     optional: true
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 
@@ -9309,6 +11508,10 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - packages/*
   - examples/*
   - examples/docs/*
+  - registry/agent/*
   - registry/software/*
   - registry/file-system/*
   - registry/tool/*

--- a/registry/agent/claude/package.json
+++ b/registry/agent/claude/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@agentos-software/claude-code",
+	"version": "0.2.0-rc.3",
+	"type": "module",
+	"license": "Apache-2.0",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"bin": {
+		"claude-sdk-acp": "./dist/adapter.js"
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc && node ./scripts/build-patched-cli.mjs",
+		"check-types": "tsc --noEmit",
+		"test": "pnpm build && node --test tests/*.test.mjs"
+	},
+	"dependencies": {
+		"@agentclientprotocol/sdk": "^0.16.1",
+		"@anthropic-ai/claude-agent-sdk": "0.2.87",
+		"zod": "^4.1.11"
+	},
+	"devDependencies": {
+		"@types/node": "^22.10.2",
+		"typescript": "^5.7.2"
+	}
+}

--- a/registry/agent/claude/scripts/build-patched-cli.mjs
+++ b/registry/agent/claude/scripts/build-patched-cli.mjs
@@ -1,0 +1,342 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, resolve as resolvePath } from "node:path";
+
+const require = createRequire(import.meta.url);
+const sdkPath = require.resolve("@anthropic-ai/claude-agent-sdk");
+const cliPath = resolvePath(dirname(sdkPath), "cli.js");
+const distDir = resolvePath(import.meta.dirname, "..", "dist");
+const manifestPath = resolvePath(distDir, "claude-cli-patched.json");
+const sdkManifestPath = resolvePath(distDir, "claude-sdk-patched.json");
+
+const source = readFileSync(cliPath, "utf-8");
+const sdkSource = readFileSync(sdkPath, "utf-8");
+const patches = [
+	{
+		name: "inject stdout normalization helpers",
+		needle: 'import{createRequire as H15}from"node:module";',
+		replacement:
+			'import{createRequire as H15}from"node:module";if(process.env.CLAUDE_CODE_TRACE_STARTUP==="1")process.stderr.write("[agentos-claude] bootstrap_loaded\\n");function __agentOsTrimOutput(q){if(typeof q==="string")return q.trim();if(q==null)return"";if(typeof q.trim==="function")return q.trim();if(typeof Buffer!=="undefined"&&Buffer.isBuffer(q))return q.toString("utf8").trim();if(q instanceof Uint8Array)return Buffer.from(q).toString("utf8").trim();return String(q).trim()}function __agentOsTrimStdout(q){return __agentOsTrimOutput(q?.stdout)}function __agentOsTrimStderr(q){return __agentOsTrimOutput(q?.stderr)}const __agentOsOriginalRealpath=globalThis["Nkq"];async function __agentOsRealpath(q){return typeof __agentOsOriginalRealpath==="function"?__agentOsOriginalRealpath(q):q}function __agentOsEnsureAsyncIterable(q){if(q&&typeof q[Symbol.asyncIterator]==="function")return q;if(q&&typeof q[Symbol.iterator]==="function")return(async function*(){for(let K of q)yield K})();if(q&&typeof q.on==="function"){return{[Symbol.asyncIterator](){let K=[],_=[],Y=!1,z=null;let A=(X)=>{K.push(X);O()};let O=()=>{for(;_.length>0;){if(z){_.shift().reject(z);continue}if(K.length>0){_.shift().resolve({done:!1,value:K.shift()});continue}if(Y){_.shift().resolve({done:!0,value:void 0});continue}break}};let $=()=>{Y=!0;w()};let w=()=>{q.off?.("data",A);q.off?.("end",$);q.off?.("close",$);q.off?.("error",j)};let j=(X)=>{z=X,Y=!0,w(),O()};q.on("data",A);q.on("end",$);q.on("close",$);q.on("error",j);q.resume?.();return{next(){if(z)return Promise.reject(z);if(K.length>0)return Promise.resolve({done:!1,value:K.shift()});if(Y)return Promise.resolve({done:!0,value:void 0});return new Promise((X,M)=>{_.push({resolve:X,reject:M})})},return(){Y=!0,w(),O();return Promise.resolve({done:!0,value:void 0})},[Symbol.asyncIterator](){return this}}}}}throw new TypeError("expected input to be async iterable")}',
+	},
+	{
+		name: "ignore startup exit code in headless mode",
+		needle:
+			'if(process.exitCode!==void 0){k("Graceful shutdown initiated, skipping further initialization");return}',
+		replacement:
+			'if(process.exitCode!==void 0){if(process.env.CLAUDE_CODE_IGNORE_STARTUP_EXIT_CODE!=="1"){k("Graceful shutdown initiated, skipping further initialization");return}process.stderr.write("[agentos-claude] ignoring_startup_exit_code "+String(process.exitCode)+"\\n");process.exitCode=void 0}',
+	},
+	{
+		name: "guard EPIPE destroy calls for Agent OS stdio",
+		needle:
+			'function ow7(q){return(K)=>{if(K.code==="EPIPE")q.destroy()}}',
+		replacement:
+			'function ow7(q){return(K)=>{if(K.code==="EPIPE")typeof q.destroy=="function"?q.destroy():typeof q.end=="function"&&q.end()}}',
+	},
+	{
+		name: "guard buffered stream destroy helper",
+		needle:
+			'Mr8=async(q,K)=>{if(!q||K===void 0)return;await Kz5(0),q.destroy();try{return await K}catch(_){return _.bufferedData}}',
+		replacement:
+			'Mr8=async(q,K)=>{if(!q||K===void 0)return;await Kz5(0),typeof q.destroy=="function"&&q.destroy();try{return await K}catch(_){return _.bufferedData}}',
+	},
+	{
+		name: "force Agent OS ripgrep when requested",
+		needle:
+			'KG8=Y1(()=>{if(V_(process.env.USE_BUILTIN_RIPGREP)){let{cmd:Y}=x_8("rg",[]);if(Y!=="rg")return{mode:"system",command:"rg",args:[]}}if(lw())return{mode:"embedded",command:process.execPath,args:["--no-config"],argv0:"rg"};let K=Z16.resolve(dy_,"vendor","ripgrep");return{mode:"builtin",command:process.platform==="win32"?Z16.resolve(K,`${process.arch}-win32`,"rg.exe"):Z16.resolve(K,`${process.arch}-${process.platform}`,"rg"),args:[]}});',
+		replacement:
+			'KG8=Y1(()=>{if(process.env.CLAUDE_CODE_FORCE_AGENT_OS_RIPGREP==="1")return{mode:"system",command:"rg",args:[]};if(V_(process.env.USE_BUILTIN_RIPGREP)){let{cmd:Y}=x_8("rg",[]);if(Y!=="rg")return{mode:"system",command:"rg",args:[]}}if(lw())return{mode:"embedded",command:process.execPath,args:["--no-config"],argv0:"rg"};let K=Z16.resolve(dy_,"vendor","ripgrep");return{mode:"builtin",command:process.platform==="win32"?Z16.resolve(K,`${process.arch}-win32`,"rg.exe"):Z16.resolve(K,`${process.arch}-${process.platform}`,"rg"),args:[]}});',
+	},
+	{
+		name: "guard missing events.setMaxListeners export",
+		needle:
+			'function C3(q=Xi_){let K=new AbortController;return Ji_(q,K.signal),K}',
+		replacement:
+			'function C3(q=Xi_){let K=new AbortController;return typeof Ji_=="function"&&Ji_(q,K.signal),K}',
+	},
+	{
+		name: "fix shell snapshot login shell argument ordering",
+		needle: 'O9Y(q,["-c","-l",j],{env:{',
+		replacement: 'O9Y(q,["-l","-c",j],{env:{',
+	},
+	{
+		name: "fix bash provider spawn argument ordering",
+		needle:
+			'return["-c",...O?[]:["-l"],A]},async getEnvironmentOverrides(A){',
+		replacement:
+			'return O?["-c",A]:["-l","-c",A]},async getEnvironmentOverrides(A){',
+	},
+	{
+		name: "force pipe-mode bash output under Agent OS",
+		needle:
+			'L=await J.getEnvironmentOverrides(q),S=!!j,h=JL("local_bash"),x=new iA(h,A??null,!S);',
+		replacement:
+			'L=await J.getEnvironmentOverrides(q),S=!!j||process.env.CLAUDE_CODE_USE_PIPE_OUTPUT==="1",h=JL("local_bash"),x=new iA(h,A??null,!S);',
+	},
+	{
+		name: "disable /dev/null shell redirection under Agent OS",
+		needle: 'if(K)return Gq([q,"<","/dev/null"]);return Gq([q])',
+		replacement:
+			'if(process.env.CLAUDE_CODE_DISABLE_DEV_NULL_REDIRECT==="1")return Gq([q]);if(K)return Gq([q,"<","/dev/null"]);return Gq([q])',
+	},
+	{
+		name: "disable cwd persistence checkpoint under Agent OS",
+		needle: 'let Z=await lNq();if(Z)W.push(Z);let f=v9Y(q);if(f)W.push(f);W.push(`eval ${P}`),W.push(`pwd -P >| ${Gq([J])}`);let G=W.join(" && ");',
+		replacement:
+			'let Z=await lNq();if(Z)W.push(Z);let f=v9Y(q);if(f)W.push(f);W.push(`eval ${P}`),process.env.CLAUDE_CODE_DISABLE_CWD_PERSIST!=="1"&&W.push(`pwd -P >| ${Gq([J])}`);let G=W.join(" && ");',
+	},
+	{
+		name: "use direct shell command execution under Agent OS",
+		needle:
+			'let G=W.join(" && ");if(process.env.CLAUDE_CODE_SHELL_PREFIX)G=rN8(process.env.CLAUDE_CODE_SHELL_PREFIX,G);',
+		replacement:
+			'let G=W.join(" && ");if(process.env.CLAUDE_CODE_SIMPLE_SHELL_EXEC==="1")G=A;if(process.env.CLAUDE_CODE_SHELL_PREFIX)G=rN8(process.env.CLAUDE_CODE_SHELL_PREFIX,G);',
+	},
+	{
+		name: "trace bash shell spawn configuration",
+		needle:
+			'let V=G?"/bin/sh":f,N=G?["-c",W]:J.getSpawnArgs(W),L=await J.getEnvironmentOverrides(q),S=!!j||process.env.CLAUDE_CODE_USE_PIPE_OUTPUT==="1",h=JL("local_bash"),x=new iA(h,A??null,!S);',
+		replacement:
+			'let V=G?"/bin/sh":f,N=G?["-c",W]:J.getSpawnArgs(W),L=await J.getEnvironmentOverrides(q),S=!!j||process.env.CLAUDE_CODE_USE_PIPE_OUTPUT==="1";if(!G&&process.env.CLAUDE_CODE_FORCE_SH_FOR_BASH==="1")V="/bin/sh",N=["-c",W];if(process.env.CLAUDE_CODE_TRACE_BASH_SHELL==="1")process.stderr.write("[agentos-claude] bash_spawn_config "+JSON.stringify({shell:V,args:N,cwd:Z,command:W,envOverrides:L,pipeOutput:S})+"\\n");let h=JL("local_bash"),x=new iA(h,A??null,!S);',
+	},
+	{
+		name: "trace bash shell child process output",
+		needle:
+			'try{let p=h9Y(V,N,{env:{...Vu(),SHELL:_==="bash"?f:void 0,GIT_EDITOR:"true",CLAUDECODE:"1",...L,...{}},cwd:Z,stdio:S?["pipe","pipe","pipe"]:["pipe",I?.fd,I?.fd],detached:J.detached,windowsHide:!0}),B=aN8(p,K,H,x,w);',
+		replacement:
+			'try{let BA=Vu(),BB=Object.entries(BA).filter(([Q,i])=>typeof i!=="string"&&i!==void 0),BC=Object.fromEntries(Object.entries(BA).filter(([Q,i])=>typeof i==="string")),BD={...BC,SHELL:_==="bash"?f:void 0,GIT_EDITOR:"true",CLAUDECODE:"1",...L,...{}};if(process.env.CLAUDE_CODE_TRACE_DIRECT_XU==="1"){let Q=h9Y("xu",["hello-agent-os"],{env:BD,cwd:Z,stdio:["pipe","pipe","pipe"],detached:!1,windowsHide:!0}),i="",R="";Q.stdout?.on("data",(k)=>i+=String(k)),Q.stderr?.on("data",(k)=>R+=String(k));let se=await new Promise((k)=>Q.on("close",(ve,ye)=>k({code:ve,signal:ye})));process.stderr.write("[agentos-claude] direct_xu "+JSON.stringify({stdout:i,stderr:R,...se})+"\\n")}let BE=V,BF=N,BG=BD;if(process.env.CLAUDE_CODE_NODE_SHELL_WRAPPER==="1"){let Q=\'const{spawn}=require("child_process");const cmd=process.env.CLAUDE_CODE_NODE_SHELL_COMMAND||"";const child=spawn(cmd,[],{cwd:process.env.CLAUDE_CODE_NODE_SHELL_CWD||process.cwd(),env:process.env,shell:true,stdio:["ignore","pipe","pipe"],windowsHide:true});child.stdout?.on("data",(c)=>process.stdout.write(c));child.stderr?.on("data",(c)=>process.stderr.write(c));child.on("close",(code)=>process.exit(typeof code==="number"?code:1));child.on("error",(error)=>{process.stderr.write(String(error?.stack??error)+"\\\\n");process.exit(126)});\';BE=process.execPath||"node",BF=["-e",Q],BG={...BD,CLAUDE_CODE_NODE_SHELL_COMMAND:W,CLAUDE_CODE_NODE_SHELL_CWD:Z};if(process.env.CLAUDE_CODE_TRACE_BASH_SHELL==="1")process.stderr.write("[agentos-claude] bash_node_wrapper "+JSON.stringify({command:W,cwd:Z,exec:BE})+"\\n")}let p=h9Y(BE,BF,{env:BG,cwd:Z,stdio:S?["pipe","pipe","pipe"]:["pipe",I?.fd,I?.fd],detached:J.detached,windowsHide:!0});if(process.env.CLAUDE_CODE_TRACE_BASH_SHELL==="1")(BB.length>0&&process.stderr.write("[agentos-claude] bash_non_string_env "+JSON.stringify(BB.map(([Q,i])=>[Q,typeof i]))+"\\n"),process.stderr.write("[agentos-claude] bash_spawned "+JSON.stringify({pid:p.pid,shell:BE,args:BF})+"\\n"),p.stdout?.on("data",(Q)=>process.stderr.write("[agentos-claude] bash_stdout "+JSON.stringify(String(Q))+"\\n")),p.stderr?.on("data",(Q)=>process.stderr.write("[agentos-claude] bash_stderr "+JSON.stringify(String(Q))+"\\n")),p.on("exit",(Q,i)=>process.stderr.write("[agentos-claude] bash_exit "+JSON.stringify({code:Q,signal:i})+"\\n")));let B=aN8(p,K,H,x,w);',
+	},
+	{
+		name: "skip special CLI entrypoints under Agent OS",
+		needle:
+			'if(K("cli_entry"),process.argv[2]==="--claude-in-chrome-mcp"){',
+		replacement:
+			'let __agentOsArg2=process.argv[2];if(process.env.CLAUDE_CODE_TRACE_STARTUP==="1")process.stderr.write("[agentos-claude] cli_argv "+JSON.stringify(process.argv)+"\\n");if(K("cli_entry"),process.env.CLAUDE_CODE_SKIP_SPECIAL_ENTRYPOINTS==="1"&&(__agentOsArg2==="--claude-in-chrome-mcp"||__agentOsArg2==="--chrome-native-host"||__agentOsArg2==="--computer-use-mcp"))process.stderr.write("[agentos-claude] skip_special_entrypoint "+String(__agentOsArg2)+"\\n");else if(process.argv[2]==="--claude-in-chrome-mcp"){',
+	},
+	{
+		name: "trace message loop startup",
+		needle: 'n8("info","cli_message_loop_started");',
+		replacement:
+			'process.stderr.write("[agentos-claude] cli_message_loop_started\\n"),n8("info","cli_message_loop_started");',
+	},
+	{
+		name: "trace stdin message parsing",
+		needle: 'if(z)n8("info","cli_stdin_message_parsed",{type:z.type}),yield z',
+		replacement:
+			'if(z)(process.stderr.write("[agentos-claude] cli_stdin_message_parsed "+z.type+"\\n"),n8("info","cli_stdin_message_parsed",{type:z.type}),yield z)',
+	},
+	{
+		name: "coerce structured IO input streams into async iterables",
+		needle: "yield*K();for await(let _ of this.input)q+=_,yield*K();if(q){",
+		replacement:
+			"yield*K();for await(let _ of __agentOsEnsureAsyncIterable(this.input))q+=_,yield*K();if(q){",
+	},
+	{
+		name: "trace initialize request handling",
+		needle:
+			'if(await Xcz(h6.request,h6.request_id,L6,f,_,I,q,!!H.enableAuthStatus,H,j,$),h6.request.promptSuggestions)',
+		replacement:
+			'if(process.stderr.write("[agentos-claude] initialize_request_start\\n"),await Xcz(h6.request,h6.request_id,L6,f,_,I,q,!!H.enableAuthStatus,H,j,$),process.stderr.write("[agentos-claude] initialize_request_done\\n"),h6.request.promptSuggestions)',
+	},
+	{
+		name: "trace pre-runHeadlessStreaming bootstrap",
+		needle:
+			'aw7(),oJ("after_loadInitialMessages"),await jw8(),oJ("after_modelStrings");',
+		replacement:
+			'aw7(),oJ("after_loadInitialMessages"),process.stderr.write("[agentos-claude] before_ensureModelStrings\\n"),await jw8(),process.stderr.write("[agentos-claude] after_ensureModelStrings\\n"),oJ("after_modelStrings");',
+	},
+	{
+		name: "trace before runHeadlessStreaming consumption",
+		needle: 'oJ("before_runHeadlessStreaming");',
+		replacement:
+			'process.stderr.write("[agentos-claude] before_runHeadlessStreaming\\n"),oJ("before_runHeadlessStreaming");',
+	},
+	{
+		name: "trace runHeadless entry",
+		needle: 'oJ("runHeadless_entry"),',
+		replacement:
+			'process.stderr.write("[agentos-claude] runHeadless_entry\\n"),oJ("runHeadless_entry"),',
+	},
+	{
+		name: "trace after grove check",
+		needle: 'oJ("after_grove_check"),',
+		replacement:
+			'process.stderr.write("[agentos-claude] after_grove_check\\n"),oJ("after_grove_check"),',
+	},
+	{
+		name: "defer growthbook init when requested",
+		needle:
+			'process.stderr.write("[agentos-claude] after_grove_check\\n"),oJ("after_grove_check"),Zi(),$.resumeSessionAt&&!$.resume){',
+		replacement:
+			'process.stderr.write("[agentos-claude] after_grove_check\\n"),oJ("after_grove_check"),process.env.CLAUDE_CODE_DEFER_GROWTHBOOK_INIT==="1"?queueMicrotask(()=>{void Zi()}):Zi(),$.resumeSessionAt&&!$.resume){',
+	},
+	{
+		name: "trace structured IO and stream-json guard setup",
+		needle:
+			'let w=Wcz(q,$);if($.outputFormat==="stream-json")VeK();let j=w7.getSandboxUnavailableReason();',
+		replacement:
+			'let w=Wcz(q,$);process.stderr.write("[agentos-claude] after_structured_io\\n");if($.outputFormat==="stream-json")(process.stderr.write("[agentos-claude] before_stream_json_guard\\n"),VeK(),process.stderr.write("[agentos-claude] after_stream_json_guard\\n"));let j=w7.getSandboxUnavailableReason();process.stderr.write("[agentos-claude] after_sandbox_reason\\n");',
+	},
+	{
+		name: "allow skipping Claude sandbox initialization",
+		needle:
+			'else if(w7.isSandboxingEnabled())try{await w7.initialize(w.createSandboxAskCallback())}catch(x){process.stderr.write(`\n❌ Sandbox Error: ${i6(x)}\n`),iK(1,"other");return}',
+		replacement:
+			'else if(w7.isSandboxingEnabled())if(process.env.CLAUDE_CODE_SKIP_SANDBOX_INIT==="1")process.stderr.write("[agentos-claude] sandbox_init_skipped\\n");else try{process.stderr.write("[agentos-claude] before_sandbox_init\\n");await w7.initialize(w.createSandboxAskCallback());process.stderr.write("[agentos-claude] after_sandbox_init\\n")}catch(x){process.stderr.write(`\n❌ Sandbox Error: ${i6(x)}\n`),iK(1,"other");return}',
+	},
+	{
+		name: "gate stream-json hook event forwarding behind opt-out env var",
+		needle: 'if($.outputFormat==="stream-json"&&$.verbose)JMK((x)=>{',
+		replacement:
+			'if($.outputFormat==="stream-json"&&$.verbose&&process.env.AGENT_OS_CLAUDE_DISABLE_HOOK_EVENTS!=="1")JMK((x)=>{',
+	},
+	{
+		name: "trace before loadInitialMessages",
+		needle: 'if($.setupTrigger)await cI8($.setupTrigger);oJ("before_loadInitialMessages");',
+		replacement:
+			'process.stderr.write("[agentos-claude] after_hook_event_registration\\n");if($.setupTrigger)(process.stderr.write("[agentos-claude] before_setup_hooks\\n"),await cI8($.setupTrigger),process.stderr.write("[agentos-claude] after_setup_hooks\\n"));process.stderr.write("[agentos-claude] before_loadInitialMessages\\n"),oJ("before_loadInitialMessages");',
+	},
+	{
+		name: "trace after loadInitialMessages returns",
+		needle:
+			'let H=K(),{messages:J,turnInterruptionState:X,agentSetting:M}=await Pcz(_,{continue:$.continue,teleport:$.teleport,resume:$.resume,resumeSessionAt:$.resumeSessionAt,forkSession:$.forkSession,outputFormat:$.outputFormat,sessionStartHooksPromise:$.sessionStartHooksPromise,restoredWorkerState:w.restoredWorkerState}),D=cYK();',
+		replacement:
+			'let H=K(),{messages:J,turnInterruptionState:X,agentSetting:M}=process.env.CLAUDE_CODE_SKIP_INITIAL_MESSAGES==="1"?(process.stderr.write("[agentos-claude] skip_initial_messages\\n"),{messages:[],turnInterruptionState:void 0,agentSetting:void 0}):await Pcz(_,{continue:$.continue,teleport:$.teleport,resume:$.resume,resumeSessionAt:$.resumeSessionAt,forkSession:$.forkSession,outputFormat:$.outputFormat,sessionStartHooksPromise:$.sessionStartHooksPromise,restoredWorkerState:w.restoredWorkerState}),D=(process.stderr.write("[agentos-claude] after_loadInitialMessages_return messages="+J.length+" exit="+String(process.exitCode)+" agent="+String(M)+"\\n"),cYK());',
+	},
+	{
+		name: "trace prepend initial user message",
+		needle: "if(D)w.prependUserMessage(D);",
+		replacement:
+			'if(D)(process.stderr.write("[agentos-claude] prepend_initial_user_message\\n"),w.prependUserMessage(D));',
+	},
+	{
+		name: "trace after agent restore block",
+		needle:
+			'if(!$.agent&&!NB()&&M){let{agentDefinition:x}=KJ6(M,void 0,{activeAgents:O,allAgents:O});if(x){if(_((I)=>({...I,agent:x.agentType})),!$.systemPrompt&&!Pw(x)){let I=x.getSystemPrompt();if(I)$.systemPrompt=I}$78(x.agentType)}}if(J.length===0&&process.exitCode!==void 0)return;',
+		replacement:
+			'if(!$.agent&&!NB()&&M){let{agentDefinition:x}=KJ6(M,void 0,{activeAgents:O,allAgents:O});if(x){if(_((I)=>({...I,agent:x.agentType})),!$.systemPrompt&&!Pw(x)){let I=x.getSystemPrompt();if(I)$.systemPrompt=I}$78(x.agentType)}}process.stderr.write("[agentos-claude] after_agent_restore_block\\n");if(J.length===0&&process.exitCode!==void 0){if(process.env.CLAUDE_CODE_IGNORE_STARTUP_EXIT_CODE==="1"){process.stderr.write("[agentos-claude] ignoring_post_initial_exit_code "+String(process.exitCode)+"\\n");process.exitCode=void 0}else return;}',
+	},
+	{
+		name: "trace before tool filtering",
+		needle: 'let Z=L68(H.mcp.tools,H.toolPermissionContext),',
+		replacement:
+			'process.stderr.write("[agentos-claude] before_tool_filtering\\n");let Z=L68(H.mcp.tools,H.toolPermissionContext),',
+	},
+	{
+		name: "trace after permission handler setup",
+		needle:
+			'if($.permissionPromptToolName)f=f.filter((x)=>!L_(x,$.permissionPromptToolName));aw7(),',
+		replacement:
+			'if($.permissionPromptToolName)f=f.filter((x)=>!L_(x,$.permissionPromptToolName));process.stderr.write("[agentos-claude] after_permission_handler_setup\\n"),aw7(),',
+	},
+	{
+		name: "trace after registerProcessOutputErrorHandlers",
+		needle: 'aw7(),oJ("after_loadInitialMessages"),',
+		replacement:
+			'aw7(),process.stderr.write("[agentos-claude] after_registerProcessOutputErrorHandlers\\n"),oJ("after_loadInitialMessages"),',
+	},
+	{
+		name: "trace before connectMcp",
+		needle: 'xq("before_connectMcp"),await z5(H3,"regular"),',
+		replacement:
+			'process.stderr.write("[agentos-claude] before_connectMcp\\n"),xq("before_connectMcp"),await z5(H3,"regular"),',
+	},
+	{
+		name: "trace after connectMcp",
+		needle: 'xq("after_connectMcp"),await j6.then(',
+		replacement:
+			'process.stderr.write("[agentos-claude] after_connectMcp\\n"),xq("after_connectMcp"),await j6.then(',
+	},
+	{
+		name: "trace after claudeai MCP connect",
+		needle: 'xq("after_connectMcp_claudeai"),',
+		replacement:
+			'process.stderr.write("[agentos-claude] after_connectMcp_claudeai\\n"),xq("after_connectMcp_claudeai"),',
+	},
+	{
+		name: "trace before print import",
+		needle: 'S65(),xq("before_print_import");',
+		replacement:
+			'S65(),process.stderr.write("[agentos-claude] before_print_import\\n"),xq("before_print_import");',
+	},
+	{
+		name: "trace after print import",
+		needle: 'xq("after_print_import"),OK(',
+		replacement:
+			'process.stderr.write("[agentos-claude] after_print_import\\n"),xq("after_print_import"),OK(',
+	},
+	{
+		name: "trace early input capture and main import",
+		needle:
+			'if(q.includes("--bare"))process.env.CLAUDE_CODE_SIMPLE="1";let{startCapturingEarlyInput:Y}=await Promise.resolve().then(() => (Jd6(),Dn4));Y(),K("cli_before_main_import");let{main:z}=await Promise.resolve().then(() => (eY7(),C65));K("cli_after_main_import"),await z(),K("cli_after_main_complete")',
+		replacement:
+			'if(q.includes("--bare"))process.env.CLAUDE_CODE_SIMPLE="1";process.stderr.write("[agentos-claude] before_early_input_import\\n");let{startCapturingEarlyInput:Y}=await Promise.resolve().then(() => (Jd6(),Dn4));process.stderr.write("[agentos-claude] after_early_input_import\\n");if(process.env.CLAUDE_CODE_SKIP_EARLY_INPUT_CAPTURE==="1")process.stderr.write("[agentos-claude] skip_early_input_capture\\n");else{process.stderr.write("[agentos-claude] before_early_input_start\\n");Y();process.stderr.write("[agentos-claude] after_early_input_start\\n")}K("cli_before_main_import");process.stderr.write("[agentos-claude] before_main_import\\n");let{main:z}=await Promise.resolve().then(() => (eY7(),C65));process.stderr.write("[agentos-claude] after_main_import\\n");K("cli_after_main_import"),await z(),K("cli_after_main_complete")',
+	},
+];
+
+let patched = source;
+for (const patch of patches) {
+	if (!patched.includes(patch.needle)) {
+		throw new Error(`Could not find Claude CLI patch target: ${patch.name}`);
+	}
+	patched = patched.replace(patch.needle, patch.replacement);
+}
+
+patched = patched.replace(
+	/\b([A-Za-z_$][\w$]*)\.stdout\.trim\(\)/g,
+	"__agentOsTrimStdout($1)",
+);
+patched = patched.replace(
+	/\b([A-Za-z_$][\w$]*)\.stderr\.trim\(\)/g,
+	"__agentOsTrimStderr($1)",
+);
+patched = patched.replace(/\bNkq\(/g, "__agentOsRealpath(");
+
+const streamJsonHookGuard =
+	'if($.outputFormat==="stream-json"&&$.verbose&&process.env.AGENT_OS_CLAUDE_DISABLE_HOOK_EVENTS!=="1")JMK((x)=>{';
+if (!patched.includes(streamJsonHookGuard)) {
+	throw new Error(
+		"Patched Claude CLI is missing the AGENT_OS_CLAUDE_DISABLE_HOOK_EVENTS guard",
+	);
+}
+if (patched.includes('if($.outputFormat==="stream-json"&&$.verbose&&false)JMK((x)=>{')) {
+	throw new Error(
+		"Patched Claude CLI still contains the disabled stream-json hook-event kill-switch",
+	);
+}
+
+const sdkNeedle =
+	'function y1($=AL){let X=new AbortController;return ML($,X.signal),X}';
+const sdkReplacement =
+	'function y1($=AL){let X=new AbortController;return typeof ML==="function"&&ML($,X.signal),X}';
+const patchedSdk = sdkSource.includes(sdkNeedle)
+	? sdkSource.replace(sdkNeedle, sdkReplacement)
+	: sdkSource;
+
+mkdirSync(distDir, { recursive: true });
+const hash = createHash("sha256").update(patched).digest("hex").slice(0, 16);
+const fileName = `claude-cli-patched-${hash}.mjs`;
+const outputPath = resolvePath(distDir, fileName);
+writeFileSync(outputPath, patched, "utf-8");
+
+const sdkHash = createHash("sha256")
+	.update(patchedSdk)
+	.digest("hex")
+	.slice(0, 16);
+const sdkFileName = `claude-sdk-patched-${sdkHash}.mjs`;
+const sdkOutputPath = resolvePath(distDir, sdkFileName);
+writeFileSync(sdkOutputPath, patchedSdk, "utf-8");
+
+writeFileSync(
+	manifestPath,
+	JSON.stringify({ entry: `./${fileName}` }, null, 2) + "\n",
+	"utf-8",
+);
+writeFileSync(
+	sdkManifestPath,
+	JSON.stringify({ entry: `./${sdkFileName}` }, null, 2) + "\n",
+	"utf-8",
+);
+process.stdout.write(`Wrote ${outputPath}\n`);

--- a/registry/agent/claude/src/adapter.ts
+++ b/registry/agent/claude/src/adapter.ts
@@ -1,0 +1,1300 @@
+#!/usr/bin/env node
+
+import {
+	type Agent,
+	AgentSideConnection,
+	type AuthenticateRequest,
+	type AuthenticateResponse,
+	type CancelNotification,
+	type InitializeRequest,
+	type InitializeResponse,
+	type NewSessionRequest,
+	type NewSessionResponse,
+	type PromptRequest,
+	type PromptResponse,
+	type RequestPermissionResponse,
+	type SessionUpdate,
+	type SetSessionModeRequest,
+	type SetSessionModeResponse,
+	ndJsonStream,
+} from "@agentclientprotocol/sdk";
+import {
+	type CanUseTool,
+	type McpServerConfig,
+	type PermissionMode,
+	type PermissionResult,
+	type PermissionUpdate,
+	type Query,
+	type SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import { createHash, randomUUID } from "node:crypto";
+import {
+	appendFileSync,
+	existsSync,
+	mkdirSync,
+	writeFileSync,
+} from "node:fs";
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, resolve as resolvePath } from "node:path";
+import { PassThrough } from "node:stream";
+import { fileURLToPath } from "node:url";
+import { resolveClaudeCliPath, resolveClaudeSdkPath } from "./patched-cli.js";
+
+type PromptPart = { type?: string; text?: string };
+type ClaudeSdkRuntime = Awaited<typeof claudeSdkRuntimePromise>;
+type QueryFactory = ClaudeSdkRuntime["query"];
+
+const ACP_MODES: PermissionMode[] = [
+	"default",
+	"acceptEdits",
+	"bypassPermissions",
+	"plan",
+	"dontAsk",
+];
+
+let appendSystemPrompt: string | undefined;
+const argv = process.argv.slice(2);
+for (let i = 0; i < argv.length; i++) {
+	if (argv[i] === "--append-system-prompt" && i + 1 < argv.length) {
+		appendSystemPrompt = argv[i + 1];
+		i++;
+	}
+}
+
+const claudeSdkRuntimePromise = loadPatchedClaudeSdkRuntime();
+const traceAdapterMessages =
+	process.env.CLAUDE_CODE_TRACE_ADAPTER_MESSAGES === "1";
+const traceFile = process.env.CLAUDE_CODE_TRACE_FILE;
+
+function traceAdapter(message: string): void {
+	if (!traceAdapterMessages) return;
+	process.stderr.write(`[agentos-claude] ${message}\n`);
+	if (traceFile) {
+		appendFileSync(traceFile, `[agentos-claude] ${message}\n`);
+	}
+}
+
+async function loadPatchedClaudeSdkRuntime(): Promise<
+	{
+		cliPath: string;
+		query: typeof import("@anthropic-ai/claude-agent-sdk").query;
+	}
+> {
+	const require = createRequire(import.meta.url);
+	const sdkPath = require.resolve("@anthropic-ai/claude-agent-sdk");
+	const packageDir = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
+	const cliPath = resolveClaudeCliPath({ packageDir, sdkPath });
+	const runtime = await import(resolveClaudeSdkPath({ packageDir, sdkPath }));
+	return {
+		cliPath,
+		query: runtime.query,
+	};
+}
+
+function ensureClaudeCliWrapper(originalCliPath: string): string {
+	const cacheDir = resolvePath(tmpdir(), "agentos-claude-sdk");
+	mkdirSync(cacheDir, { recursive: true });
+
+const wrapperSource = `#!/usr/bin/env node
+import { appendFileSync as __agentOsAppendFileSync } from "node:fs";
+import { inspect } from "node:util";
+import { PassThrough } from "node:stream";
+
+const originalCliPath = ${JSON.stringify(originalCliPath)};
+const swapStdio = process.env.CLAUDE_CODE_SWAP_STDIO === "1";
+const traceExit = process.env.CLAUDE_CODE_TRACE_EXIT === "1";
+const traceStdio = process.env.CLAUDE_CODE_TRACE_STDIO === "1";
+const traceFile = process.env.CLAUDE_CODE_TRACE_FILE;
+const realStdout = process.stdout;
+const realStderr = process.stderr;
+
+function wrapperTrace(message) {
+	if (traceFile) {
+		try {
+			__agentOsAppendFileSync(traceFile, message + "\\n");
+		} catch {}
+	}
+}
+
+if (swapStdio) {
+	Object.defineProperty(process, "stdout", {
+		configurable: true,
+		enumerable: true,
+		value: realStderr,
+	});
+	Object.defineProperty(process, "stderr", {
+		configurable: true,
+		enumerable: true,
+		value: realStdout,
+	});
+}
+
+process.stderr.write(
+	"[agentos-claude] wrapper_start cli=" + originalCliPath + "\\n",
+);
+wrapperTrace(
+	"[agentos-claude] wrapper_start cli=" + originalCliPath,
+);
+process.stderr.write(
+	"[agentos-claude] wrapper_argv " +
+		JSON.stringify(process.argv) +
+		"\\n",
+);
+wrapperTrace(
+	"[agentos-claude] wrapper_argv " + JSON.stringify(process.argv),
+);
+
+process.on("unhandledRejection", (error) => {
+	process.stderr.write(
+		"[agentos-claude] unhandledRejection " + inspect(error, { depth: 6 }) + "\\n",
+	);
+});
+
+process.on("uncaughtException", (error) => {
+	process.stderr.write(
+		"[agentos-claude] uncaughtException " + inspect(error, { depth: 6 }) + "\\n",
+	);
+});
+
+function writeTrace(label, value) {
+	if (!traceExit) return;
+	const stack = new Error().stack ?? "";
+	process.stderr.write(
+		"[agentos-claude] " +
+			label +
+			" " +
+			inspect(value, { depth: 4, breakLength: Infinity }) +
+			"\\n" +
+			stack +
+			"\\n",
+	);
+}
+
+let exitCodeValue = process.exitCode;
+if (
+	process.env.CLAUDE_CODE_IGNORE_STARTUP_EXIT_CODE === "1" &&
+	exitCodeValue === 0
+) {
+	exitCodeValue = undefined;
+}
+Object.defineProperty(process, "exitCode", {
+	configurable: true,
+	enumerable: true,
+	get() {
+		return exitCodeValue;
+	},
+	set(value) {
+		writeTrace("process.exitCode =", value);
+		exitCodeValue = value;
+	},
+});
+
+const originalExit = process.exit.bind(process);
+process.exit = (code) => {
+	writeTrace("process.exit()", code);
+	return originalExit(code);
+};
+
+const realStdin = process.stdin;
+const bufferedStdin = new PassThrough();
+bufferedStdin.isTTY = realStdin.isTTY;
+bufferedStdin.fd = realStdin.fd;
+if (typeof realStdin.setRawMode === "function") {
+	bufferedStdin.setRawMode = realStdin.setRawMode.bind(realStdin);
+}
+realStdin.on("data", (chunk) => {
+	bufferedStdin.write(chunk);
+});
+realStdin.on("end", () => {
+	bufferedStdin.end();
+});
+realStdin.on("error", (error) => {
+	bufferedStdin.destroy(error);
+});
+realStdin.resume();
+Object.defineProperty(process, "stdin", {
+	configurable: true,
+	enumerable: true,
+	value: bufferedStdin,
+});
+
+for (const stream of [process.stdout, process.stderr]) {
+	if (typeof stream.destroy !== "function") {
+		stream.destroy = (error) => {
+			if (error) {
+				stream.emit("error", error);
+				return stream;
+			}
+			if (typeof stream.end === "function") {
+				stream.end();
+			}
+			return stream;
+		};
+	}
+}
+
+if (traceStdio) {
+	realStdin.on("data", (chunk) => {
+		process.stderr.write(
+			"[agentos-claude] stdin_chunk " +
+				JSON.stringify(String(chunk)).slice(0, 4000) +
+				"\\n",
+		);
+	});
+
+	const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+	process.stdout.write = function (chunk, encoding, callback) {
+		process.stderr.write(
+			"[agentos-claude] stdout_chunk " +
+				JSON.stringify(
+					typeof chunk === "string"
+						? chunk
+						: Buffer.from(chunk).toString(
+								typeof encoding === "string" ? encoding : undefined,
+							),
+				).slice(0, 4000) +
+				"\\n",
+		);
+		return originalStdoutWrite(chunk, encoding, callback);
+	};
+}
+
+await import(originalCliPath);
+`;
+
+	const wrapperHash = createHash("sha256")
+		.update(originalCliPath)
+		.update(wrapperSource)
+		.digest("hex")
+		.slice(0, 16);
+	const wrapperPath = resolvePath(cacheDir, `cli-wrapper-${wrapperHash}.mjs`);
+	if (!existsSync(wrapperPath)) {
+		writeFileSync(wrapperPath, wrapperSource, "utf-8");
+	}
+	return wrapperPath;
+}
+
+class AsyncQueue<T> implements AsyncIterable<T> {
+	private items: T[] = [];
+	private waiters: Array<(result: IteratorResult<T>) => void> = [];
+	private closed = false;
+
+	push(item: T): void {
+		if (this.closed) {
+			throw new Error("Queue is closed");
+		}
+		const waiter = this.waiters.shift();
+		if (waiter) {
+			waiter({ value: item, done: false });
+			return;
+		}
+		this.items.push(item);
+	}
+
+	end(): void {
+		if (this.closed) return;
+		this.closed = true;
+		for (const waiter of this.waiters.splice(0)) {
+			waiter({ value: undefined, done: true });
+		}
+	}
+
+	[Symbol.asyncIterator](): AsyncIterator<T> {
+		return {
+			next: () => {
+				const item = this.items.shift();
+				if (item !== undefined) {
+					return Promise.resolve({ value: item, done: false });
+				}
+				if (this.closed) {
+					return Promise.resolve({ value: undefined, done: true });
+				}
+				return new Promise<IteratorResult<T>>((resolve) => {
+					this.waiters.push(resolve);
+				});
+			},
+		};
+	}
+}
+
+type PendingTurn = {
+	resolve: (response: PromptResponse) => void;
+	reject: (error: Error) => void;
+	sawAssistantText: boolean;
+	sawToolCall: boolean;
+};
+
+class ClaudeQuerySession {
+	private promptQueue = new AsyncQueue<SDKUserMessage>();
+	private query: Query;
+	private readyPromise: Promise<void>;
+	private pendingTurn: PendingTurn | null = null;
+	private lastEmit: Promise<void> = Promise.resolve();
+	private pendingMcpServers: Record<string, McpServerConfig> | undefined;
+	private mcpServersApplied = false;
+	private activeToolCalls = new Map<
+		string,
+		{ toolName: string; rawInput?: Record<string, unknown> }
+	>();
+	private reader: Promise<void>;
+	private closed = false;
+	private cancelled = false;
+
+	constructor(
+		private readonly conn: AgentSideConnection,
+		readonly sessionId: string,
+		private readonly cwd: string,
+		private mode: PermissionMode,
+		params: NewSessionRequest,
+		private readonly pathToClaudeCodeExecutable: string,
+		queryFactory: QueryFactory,
+	) {
+		traceAdapter(
+			`session_ctor id=${sessionId} cwd=${cwd} mode=${mode} cli=${pathToClaudeCodeExecutable}`,
+		);
+		this.query = queryFactory({
+			prompt: this.promptQueue,
+			options: {
+				canUseTool: this.createPermissionHandler(),
+				cwd,
+				env: {
+					...process.env,
+					CLAUDE_CODE_SHELL:
+						process.env.CLAUDE_CODE_SHELL ?? "/bin/sh",
+					CLAUDE_CODE_IGNORE_STARTUP_EXIT_CODE:
+						process.env.CLAUDE_CODE_IGNORE_STARTUP_EXIT_CODE ?? "1",
+					CLAUDE_CODE_DISABLE_DEV_NULL_REDIRECT:
+						process.env.CLAUDE_CODE_DISABLE_DEV_NULL_REDIRECT ?? "1",
+					CLAUDE_CODE_DISABLE_CWD_PERSIST:
+						process.env.CLAUDE_CODE_DISABLE_CWD_PERSIST ?? "1",
+					CLAUDE_CODE_SIMPLE_SHELL_EXEC:
+						process.env.CLAUDE_CODE_SIMPLE_SHELL_EXEC ?? "1",
+					CLAUDE_CODE_SIMPLE: process.env.CLAUDE_CODE_SIMPLE ?? "1",
+					CLAUDE_CODE_NODE_SHELL_WRAPPER:
+						process.env.CLAUDE_CODE_NODE_SHELL_WRAPPER ?? "1",
+					CLAUDE_CODE_SKIP_INITIAL_MESSAGES:
+						process.env.CLAUDE_CODE_SKIP_INITIAL_MESSAGES ?? "1",
+					CLAUDE_CODE_SKIP_SPECIAL_ENTRYPOINTS:
+						process.env.CLAUDE_CODE_SKIP_SPECIAL_ENTRYPOINTS ?? "1",
+					CLAUDE_CODE_USE_PIPE_OUTPUT:
+						process.env.CLAUDE_CODE_USE_PIPE_OUTPUT ?? "1",
+					CLAUDE_CODE_TRACE_EXIT:
+						process.env.CLAUDE_CODE_TRACE_EXIT ?? "0",
+					CLAUDE_CODE_TRACE_STARTUP:
+						process.env.CLAUDE_CODE_TRACE_STARTUP ?? "0",
+					SHELL: process.env.SHELL ?? "/bin/sh",
+				},
+				extraArgs: {
+					bare: null,
+				},
+				includePartialMessages: true,
+				pathToClaudeCodeExecutable,
+				permissionMode: normalizeClaudePermissionMode(mode),
+				persistSession: false,
+				sandbox: { enabled: false },
+				settingSources: ["project"],
+				spawnClaudeCodeProcess: ({ command, args, cwd, env }) => {
+					traceAdapter(
+						`spawn_child command=${command} args=${JSON.stringify(args)} cwd=${cwd}`,
+					);
+					const childEnv: NodeJS.ProcessEnv = {
+						...env,
+						CLAUDE_CODE_SWAP_STDIO:
+							env.CLAUDE_CODE_SWAP_STDIO ?? "0",
+					};
+					const traceChildIo =
+						childEnv.CLAUDE_CODE_TRACE_CHILD_IO === "1" ||
+						(traceAdapterMessages && Boolean(traceFile));
+					const child = spawn(command, args, {
+						cwd,
+						env: childEnv,
+						stdio: ["pipe", "pipe", "pipe"],
+					});
+					const stdout = new PassThrough();
+					const lineBuffers: Record<"stdout" | "stderr", string> = {
+						stdout: "",
+						stderr: "",
+					};
+					let openStreams = 2;
+
+					const looksLikeProtocolLine = (line: string): boolean => {
+						const trimmed = line.trim();
+						if (!trimmed.startsWith("{")) {
+							return false;
+						}
+						try {
+							const parsed = JSON.parse(trimmed) as {
+								type?: unknown;
+								subtype?: unknown;
+								response?: { request_id?: unknown } | unknown;
+								message?: unknown;
+							};
+							return (
+								typeof parsed.type === "string" ||
+								typeof parsed.subtype === "string" ||
+								(typeof parsed.response === "object" &&
+									parsed.response !== null &&
+									"request_id" in parsed.response) ||
+								typeof parsed.message === "string"
+							);
+						} catch {
+							return false;
+						}
+					};
+
+					const writeSideLog = (source: "stdout" | "stderr", text: string) => {
+						if (!text) return;
+						if (traceChildIo) {
+							traceAdapter(
+								`child_side_${source} ${JSON.stringify(text).slice(0, 4000)}`,
+							);
+						}
+						process.stderr.write(text);
+					};
+
+					const flushBuffer = (
+						source: "stdout" | "stderr",
+						final = false,
+					): void => {
+						const buffer = lineBuffers[source];
+						const lines = buffer.split("\n");
+						if (!final) {
+							lineBuffers[source] = lines.pop() ?? "";
+						} else {
+							lineBuffers[source] = "";
+						}
+						for (const line of lines) {
+							const text = `${line}\n`;
+							if (looksLikeProtocolLine(line)) {
+								if (traceChildIo) {
+									traceAdapter(
+										`child_protocol_${source} ${JSON.stringify(text).slice(0, 4000)}`,
+									);
+								}
+								stdout.write(text);
+							} else {
+								writeSideLog(source, text);
+							}
+						}
+						if (final && lineBuffers[source]) {
+							const text = lineBuffers[source];
+							if (looksLikeProtocolLine(text)) {
+								if (traceChildIo) {
+									traceAdapter(
+										`child_protocol_${source} ${JSON.stringify(text).slice(0, 4000)}`,
+									);
+								}
+								stdout.write(text);
+							} else {
+								writeSideLog(source, text);
+							}
+							lineBuffers[source] = "";
+						}
+					};
+
+					const attachStream = (
+						source: "stdout" | "stderr",
+						stream: NodeJS.ReadableStream | null,
+					): void => {
+						if (!stream) {
+							openStreams -= 1;
+							if (openStreams <= 0) {
+								stdout.end();
+							}
+							return;
+						}
+						stream.on("data", (chunk) => {
+							lineBuffers[source] += String(chunk);
+							flushBuffer(source);
+						});
+						stream.on("end", () => {
+							flushBuffer(source, true);
+							openStreams -= 1;
+							if (openStreams <= 0) {
+								stdout.end();
+							}
+						});
+						stream.on("close", () => {
+							flushBuffer(source, true);
+						});
+						stream.on("error", (error) => {
+							stdout.destroy(error);
+						});
+					};
+
+					attachStream("stdout", child.stdout);
+					attachStream("stderr", child.stderr);
+
+					return {
+						stdin: child.stdin,
+						stdout,
+						get killed() {
+							return child.killed;
+						},
+						get exitCode() {
+							return child.exitCode;
+						},
+						kill: child.kill.bind(child),
+						on: child.on.bind(child),
+						once: child.once.bind(child),
+						off: child.off.bind(child),
+					};
+				},
+				stderr: (data) => process.stderr.write(data),
+				systemPrompt: appendSystemPrompt
+					? {
+							type: "preset",
+							preset: "claude_code",
+							append: appendSystemPrompt,
+						}
+					: {
+							type: "preset",
+							preset: "claude_code",
+						},
+				tools: { type: "preset", preset: "claude_code" },
+			},
+		});
+		this.readyPromise = this.initialize(params);
+		this.reader = this.consume();
+	}
+
+	get currentMode(): PermissionMode {
+		return this.mode;
+	}
+
+	async ready(): Promise<void> {
+		await this.readyPromise;
+	}
+
+	async prompt(params: PromptRequest): Promise<PromptResponse> {
+		if (this.closed) {
+			throw new Error("Session is closed");
+		}
+		if (this.pendingTurn) {
+			throw new Error("A Claude prompt is already running");
+		}
+		await this.readyPromise;
+
+		const text = joinPromptText(params.prompt as PromptPart[] | undefined);
+		traceAdapter(
+			`prompt_start session=${this.sessionId} textLength=${text.length}`,
+		);
+		return new Promise<PromptResponse>((resolve, reject) => {
+			this.cancelled = false;
+			this.pendingTurn = {
+				resolve,
+				reject,
+				sawAssistantText: false,
+				sawToolCall: false,
+			};
+			void this.applyPendingMcpServers()
+				.then(() => {
+					traceAdapter(`prompt_queue_push session=${this.sessionId}`);
+					this.promptQueue.push({
+						type: "user",
+						session_id: "",
+						message: {
+							role: "user",
+							content: [{ type: "text", text }],
+						},
+						parent_tool_use_id: null,
+					});
+					traceAdapter(`prompt_queue_pushed session=${this.sessionId}`);
+				})
+				.catch((error) => {
+					traceAdapter(
+						`prompt_setup_error session=${this.sessionId} error=${formatError(error)}`,
+					);
+					if (this.pendingTurn) {
+						this.pendingTurn.reject(asError(error));
+						this.pendingTurn = null;
+					}
+				});
+		});
+	}
+
+	async cancel(): Promise<void> {
+		if (this.closed) return;
+		this.cancelled = true;
+		await this.readyPromise.catch(() => {});
+		await this.query.interrupt();
+	}
+
+	async setMode(mode: PermissionMode): Promise<void> {
+		await this.readyPromise;
+		this.mode = mode;
+		await this.query.setPermissionMode(mode);
+		await this.emit({
+			sessionUpdate: "current_mode_update" as const,
+			currentModeId: mode,
+		});
+	}
+
+	close(): void {
+		if (this.closed) return;
+		this.closed = true;
+		this.promptQueue.end();
+		this.query.close();
+		if (this.pendingTurn) {
+			this.pendingTurn.reject(new Error("Claude session closed"));
+			this.pendingTurn = null;
+		}
+	}
+
+	private async initialize(params: NewSessionRequest): Promise<void> {
+		this.pendingMcpServers = toSdkMcpServers(params.mcpServers);
+		traceAdapter(
+			`session_initialize id=${this.sessionId} mcpServers=${Object.keys(
+				this.pendingMcpServers ?? {},
+			).length}`,
+		);
+	}
+
+	private async applyPendingMcpServers(): Promise<void> {
+		if (this.mcpServersApplied || !this.pendingMcpServers) {
+			traceAdapter(
+				`apply_mcp_skip session=${this.sessionId} applied=${String(this.mcpServersApplied)} pending=${String(Boolean(this.pendingMcpServers))}`,
+			);
+			return;
+		}
+		traceAdapter(`apply_mcp_start session=${this.sessionId}`);
+		await this.query.setMcpServers(this.pendingMcpServers);
+		this.mcpServersApplied = true;
+		traceAdapter(`apply_mcp_done session=${this.sessionId}`);
+	}
+
+	private async consume(): Promise<void> {
+		traceAdapter(`consume_start session=${this.sessionId}`);
+		try {
+			for await (const message of this.query) {
+				traceAdapter(
+					`consume_message session=${this.sessionId} type=${String(message.type ?? "")}`,
+				);
+				await this.handleMessage(message);
+			}
+			traceAdapter(`consume_done session=${this.sessionId}`);
+		} catch (error) {
+			traceAdapter(
+				`consume_error session=${this.sessionId} error=${formatError(error)}`,
+			);
+			if (this.pendingTurn) {
+				this.pendingTurn.reject(asError(error));
+				this.pendingTurn = null;
+			}
+			if (!this.closed) {
+				process.stderr.write(`${formatError(error)}\n`);
+			}
+		} finally {
+			traceAdapter(`consume_finally session=${this.sessionId}`);
+			if (this.pendingTurn) {
+				this.pendingTurn.reject(
+					new Error("Claude query ended before producing a result"),
+				);
+				this.pendingTurn = null;
+			}
+		}
+	}
+
+	private async handleMessage(message: Record<string, unknown>): Promise<void> {
+		if (traceAdapterMessages) {
+			const details =
+				message.type === "result"
+					? ` result=${JSON.stringify({
+							subtype: message.subtype,
+							result: message.result,
+							error: message.error,
+							errors: message.errors,
+						})}`
+					: "";
+			traceAdapter(
+				`adapter_message type=${String(message.type ?? "")} subtype=${String(
+					message.subtype ?? "",
+				)} pendingTurn=${String(Boolean(this.pendingTurn))}${details}`,
+			);
+		}
+		switch (message.type) {
+			case "stream_event":
+				await this.handleStreamEvent(message);
+				return;
+			case "assistant":
+				await this.handleAssistantMessage(message);
+				return;
+			case "tool_progress":
+				await this.handleToolProgress(message);
+				return;
+			case "system":
+				await this.handleSystemMessage(message);
+				return;
+			case "result":
+				await this.handleResult(message);
+				return;
+			case "tool_use_summary":
+				await this.emitText(String(message.summary ?? ""));
+				return;
+			default:
+				return;
+		}
+	}
+
+	private async handleStreamEvent(message: Record<string, unknown>): Promise<void> {
+		if (!this.pendingTurn) return;
+
+		const event = (message.event ?? {}) as Record<string, unknown>;
+		const type = String(event.type ?? "");
+
+		if (type === "content_block_delta") {
+			const delta = (event.delta ?? {}) as Record<string, unknown>;
+			if (delta.type === "text_delta" && typeof delta.text === "string") {
+				if (this.pendingTurn) this.pendingTurn.sawAssistantText = true;
+				await this.emit({
+					sessionUpdate: "agent_message_chunk" as const,
+					content: { type: "text" as const, text: delta.text },
+				});
+				return;
+			}
+			if (
+				delta.type === "thinking_delta" &&
+				typeof delta.thinking === "string"
+			) {
+				await this.emit({
+					sessionUpdate: "agent_thought_chunk" as const,
+					content: { type: "text" as const, text: delta.thinking },
+				});
+				return;
+			}
+			if (
+				delta.type === "input_json_delta" &&
+				typeof event.index === "number"
+			) {
+				const toolCall = this.findToolCallByIndex(Number(event.index));
+				if (!toolCall) return;
+				const rawInput = {
+					...(toolCall.rawInput ?? {}),
+					partial_json: String(delta.partial_json ?? ""),
+				};
+				toolCall.rawInput = rawInput;
+				await this.emitToolCallUpdate(toolCall.toolName, toolCall.toolUseId, {
+					rawInput,
+					status: "pending",
+				});
+			}
+			return;
+		}
+
+		if (type === "content_block_start") {
+			const block = (event.content_block ?? {}) as Record<string, unknown>;
+			if (block.type !== "tool_use") return;
+
+			const toolUseId = String(block.id ?? "");
+			if (!toolUseId) return;
+
+			const toolName = String(block.name ?? "tool");
+			const rawInput = isRecord(block.input) ? block.input : undefined;
+			this.activeToolCalls.set(toolUseId, { toolName, rawInput });
+			if (this.pendingTurn) this.pendingTurn.sawToolCall = true;
+
+			await this.emit({
+				sessionUpdate: "tool_call" as const,
+				toolCallId: toolUseId,
+				kind: toToolKind(toolName),
+				locations: toToolCallLocations(rawInput, this.cwd),
+				rawInput,
+				status: "pending" as const,
+				title: toolName,
+			});
+		}
+	}
+
+	private async handleAssistantMessage(
+		message: Record<string, unknown>,
+	): Promise<void> {
+		if (!this.pendingTurn) return;
+
+		const content = Array.isArray((message.message as Record<string, unknown>)?.content)
+			? (((message.message as Record<string, unknown>).content ??
+					[]) as Array<Record<string, unknown>>)
+			: [];
+
+		for (const block of content) {
+			if (block.type === "tool_use") {
+				const toolUseId = String(block.id ?? "");
+				if (!toolUseId) continue;
+				const toolName = String(block.name ?? "tool");
+				const rawInput = isRecord(block.input) ? block.input : undefined;
+				this.activeToolCalls.set(toolUseId, { toolName, rawInput });
+				if (this.pendingTurn) this.pendingTurn.sawToolCall = true;
+
+				await this.emit({
+					sessionUpdate: "tool_call" as const,
+					toolCallId: toolUseId,
+					kind: toToolKind(toolName),
+					locations: toToolCallLocations(rawInput, this.cwd),
+					rawInput,
+					status: "pending" as const,
+					title: toolName,
+				});
+			}
+		}
+
+		const text = extractTextContent(content);
+		if (text && this.pendingTurn && !this.pendingTurn.sawAssistantText) {
+			this.pendingTurn.sawAssistantText = true;
+			await this.emitText(text);
+		}
+	}
+
+	private async handleToolProgress(
+		message: Record<string, unknown>,
+	): Promise<void> {
+		if (!this.pendingTurn) return;
+
+		const toolUseId = String(message.tool_use_id ?? "");
+		const toolName = String(message.tool_name ?? "tool");
+		if (!toolUseId) return;
+
+		const existing = this.activeToolCalls.get(toolUseId);
+		this.activeToolCalls.set(toolUseId, {
+			toolName,
+			rawInput: existing?.rawInput,
+		});
+
+		await this.emitToolCallUpdate(toolName, toolUseId, {
+			status: "in_progress",
+		});
+	}
+
+	private async handleSystemMessage(
+		message: Record<string, unknown>,
+	): Promise<void> {
+		if (!this.pendingTurn) return;
+
+		if (message.subtype === "local_command_output") {
+			await this.emitText(String(message.content ?? ""));
+		}
+	}
+
+	private async handleResult(message: Record<string, unknown>): Promise<void> {
+		const turn = this.pendingTurn;
+		if (!turn) return;
+
+		const subtype = String(message.subtype ?? "success");
+		const resultText =
+			typeof message.result === "string" ? message.result : undefined;
+		if (resultText && !turn.sawAssistantText) {
+			await this.emitText(resultText);
+		}
+
+		for (const [toolUseId, info] of this.activeToolCalls) {
+			await this.emitToolCallUpdate(info.toolName, toolUseId, {
+				status: subtype === "success" ? "completed" : "failed",
+			});
+		}
+		this.activeToolCalls.clear();
+
+		await this.lastEmit;
+
+		this.pendingTurn = null;
+		turn.resolve({
+			stopReason: this.cancelled ? "cancelled" : "end_turn",
+		});
+		this.cancelled = false;
+	}
+
+	private async emitText(text: string): Promise<void> {
+		if (!text) return;
+		await this.emit({
+			sessionUpdate: "agent_message_chunk" as const,
+			content: {
+				type: "text" as const,
+				text,
+			},
+		});
+	}
+
+	private emit(update: SessionUpdate): Promise<void> {
+		this.lastEmit = this.lastEmit
+			.then(() =>
+				this.conn.sessionUpdate({
+					sessionId: this.sessionId,
+					update,
+				}),
+			)
+			.catch(() => {});
+		return this.lastEmit;
+	}
+
+	private async emitToolCallUpdate(
+		toolName: string,
+		toolUseId: string,
+		update: {
+			status: "pending" | "in_progress" | "completed" | "failed";
+			rawInput?: Record<string, unknown>;
+		},
+	): Promise<void> {
+		await this.emit({
+			sessionUpdate: "tool_call_update" as const,
+			toolCallId: toolUseId,
+			kind: toToolKind(toolName),
+			locations: toToolCallLocations(update.rawInput, this.cwd),
+			rawInput: update.rawInput,
+			status: update.status,
+		});
+	}
+
+	private createPermissionHandler(): CanUseTool {
+		return async (toolName, input, options) => {
+			traceAdapter(
+				`permission_request_start session=${this.sessionId} tool=${toolName} toolUseId=${options.toolUseID}`,
+			);
+			const request = {
+				options: buildPermissionOptions(),
+				sessionId: this.sessionId,
+				toolCall: {
+					kind: toToolKind(toolName),
+					locations: toToolCallLocations(input, this.cwd),
+					rawInput: input,
+					status: "pending" as const,
+					title: options.title ?? toolName,
+					toolCallId: options.toolUseID,
+				},
+			};
+			const permissionFallbackMs = Number.parseInt(
+				process.env.CLAUDE_CODE_PERMISSION_FALLBACK_MS ?? "2000",
+				10,
+			);
+			const response = await Promise.race([
+				this.conn.requestPermission(request),
+				new Promise<RequestPermissionResponse>((resolve) => {
+					setTimeout(() => {
+						traceAdapter(
+							`permission_request_fallback session=${this.sessionId} tool=${toolName} toolUseId=${options.toolUseID}`,
+						);
+						resolve({
+							outcome: {
+								outcome: "selected",
+								optionId: "allow_once",
+							},
+						});
+					}, Number.isFinite(permissionFallbackMs) ? permissionFallbackMs : 2000);
+				}),
+			]);
+			traceAdapter(
+				`permission_request_done session=${this.sessionId} tool=${toolName} toolUseId=${options.toolUseID}`,
+			);
+			return toPermissionResult(
+				response,
+				options.suggestions,
+				options.toolUseID,
+				input,
+			);
+		};
+	}
+
+	private findToolCallByIndex(index: number): {
+		toolUseId: string;
+		toolName: string;
+		rawInput?: Record<string, unknown>;
+	} | null {
+		const entry = [...this.activeToolCalls.entries()][index];
+		if (!entry) return null;
+		const [toolUseId, value] = entry;
+		return { toolUseId, toolName: value.toolName, rawInput: value.rawInput };
+	}
+}
+
+class ClaudeSdkAgent implements Agent {
+	private sessions = new Map<string, ClaudeQuerySession>();
+
+	constructor(private readonly conn: AgentSideConnection) {
+		setTimeout(() => {
+			void this.conn.closed.then(() => {
+				for (const session of this.sessions.values()) {
+					session.close();
+				}
+				this.sessions.clear();
+			});
+		}, 0);
+	}
+
+	async initialize(
+		_params: InitializeRequest,
+	): Promise<InitializeResponse> {
+		return {
+			protocolVersion: 1,
+			agentInfo: {
+				name: "claude-sdk-acp",
+				title: "Claude Agent SDK ACP adapter",
+				version: "0.1.0",
+			},
+			agentCapabilities: {
+				promptCapabilities: {
+					audio: false,
+					embeddedContext: false,
+					image: true,
+				},
+			},
+		};
+	}
+
+	async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
+		const sessionId = randomUUID();
+		const sdk = await claudeSdkRuntimePromise;
+		const session = new ClaudeQuerySession(
+			this.conn,
+			sessionId,
+			params.cwd,
+			"default",
+			params,
+			sdk.cliPath,
+			sdk.query,
+		);
+		await session.ready();
+		this.sessions.set(sessionId, session);
+		return {
+			sessionId,
+			modes: {
+				currentModeId: "default",
+				availableModes: ACP_MODES.map((id) => ({
+					id,
+					name: id,
+				})),
+			},
+		};
+	}
+
+	async prompt(params: PromptRequest): Promise<PromptResponse> {
+		const session = this.requireSession(params.sessionId);
+		return session.prompt(params);
+	}
+
+	async cancel(params: CancelNotification): Promise<void> {
+		const session = this.requireSession(params.sessionId);
+		await session.cancel();
+	}
+
+	async setSessionMode(
+		params: SetSessionModeRequest,
+	): Promise<SetSessionModeResponse | void> {
+		const session = this.requireSession(params.sessionId);
+		await session.setMode(params.modeId as PermissionMode);
+		return {};
+	}
+
+	async authenticate(
+		_params: AuthenticateRequest,
+	): Promise<AuthenticateResponse | void> {
+	}
+
+	private requireSession(sessionId: string): ClaudeQuerySession {
+		const session = this.sessions.get(sessionId);
+		if (!session) {
+			throw new Error(`Unknown Claude session: ${sessionId}`);
+		}
+		return session;
+	}
+}
+
+function joinPromptText(prompt: PromptPart[] | undefined): string {
+	return (prompt ?? [])
+		.map((part) => (part.type === "text" ? (part.text ?? "") : ""))
+		.join("");
+}
+
+function extractTextContent(content: Array<Record<string, unknown>>): string {
+	return content
+		.filter((block) => block.type === "text" && typeof block.text === "string")
+		.map((block) => String(block.text))
+		.join("");
+}
+
+function toSdkMcpServers(
+	servers: NewSessionRequest["mcpServers"],
+): Record<string, McpServerConfig> | undefined {
+	if (!Array.isArray(servers) || servers.length === 0) {
+		return undefined;
+	}
+
+	return Object.fromEntries(
+		servers.map((server, index) => {
+			const name = `mcp-${index + 1}`;
+			const record = server as Record<string, unknown>;
+			if (record.type === "local") {
+				return [
+					name,
+					{
+						args: Array.isArray(record.args)
+							? (record.args as string[])
+							: undefined,
+						command: String(record.command ?? ""),
+						env: isRecord(record.env)
+							? (record.env as Record<string, string>)
+							: undefined,
+						type: "stdio",
+					} satisfies McpServerConfig,
+				];
+			}
+
+			return [
+				name,
+				{
+					headers: isRecord(record.headers)
+						? (record.headers as Record<string, string>)
+						: undefined,
+					type: "http",
+					url: String(record.url ?? ""),
+				} satisfies McpServerConfig,
+			];
+		}),
+	);
+}
+
+function toToolKind(
+	toolName: string,
+): "read" | "edit" | "execute" | "search" | "fetch" | "think" | "other" {
+	switch (toolName) {
+		case "Read":
+			return "read";
+		case "Edit":
+		case "Write":
+		case "MultiEdit":
+		case "NotebookEdit":
+			return "edit";
+		case "Bash":
+		case "Monitor":
+			return "execute";
+		case "Grep":
+		case "Glob":
+		case "LS":
+			return "search";
+		case "WebFetch":
+		case "WebSearch":
+			return "fetch";
+		case "Think":
+			return "think";
+		default:
+			return "other";
+	}
+}
+
+function toToolCallLocations(
+	rawInput: Record<string, unknown> | undefined,
+	cwd: string,
+): Array<{ path: string; line?: number }> | undefined {
+	const path =
+		typeof rawInput?.file_path === "string"
+			? rawInput.file_path
+			: typeof rawInput?.path === "string"
+				? rawInput.path
+				: undefined;
+	if (!path) return undefined;
+
+	return [
+		{
+			path: isAbsolute(path) ? path : resolvePath(cwd, path),
+		},
+	];
+}
+
+function buildPermissionOptions(): Array<{
+	kind: "allow_once" | "allow_always" | "reject_once" | "reject_always";
+	name: string;
+	optionId: string;
+}> {
+	return [
+		{ kind: "allow_once", name: "Allow once", optionId: "allow_once" },
+		{ kind: "allow_always", name: "Always allow", optionId: "allow_always" },
+		{ kind: "reject_once", name: "Reject", optionId: "reject_once" },
+	];
+}
+
+function toPermissionResult(
+	response: RequestPermissionResponse,
+	suggestions: PermissionUpdate[] | undefined,
+	toolUseID: string,
+	input: Record<string, unknown>,
+): PermissionResult {
+	if (response.outcome.outcome === "cancelled") {
+		return {
+			behavior: "deny",
+			decisionClassification: "user_reject",
+			interrupt: true,
+			message: "Permission request cancelled",
+			toolUseID,
+		};
+	}
+
+	switch (response.outcome.optionId) {
+		case "allow_always":
+			return {
+				behavior: "allow",
+				decisionClassification: "user_permanent",
+				toolUseID,
+				updatedInput: input,
+				updatedPermissions: suggestions,
+			};
+		case "allow_once":
+			return {
+				behavior: "allow",
+				decisionClassification: "user_temporary",
+				toolUseID,
+				updatedInput: input,
+			};
+		default:
+			return {
+				behavior: "deny",
+				decisionClassification: "user_reject",
+				message: "Permission denied",
+				toolUseID,
+			};
+	}
+}
+
+function normalizeClaudePermissionMode(mode: PermissionMode): PermissionMode {
+	// Claude Code refuses bypassPermissions when running as root, which is the
+	// normal VM user in this workspace. Fall back to the standard interactive
+	// mode instead of letting startup abort.
+	return mode === "bypassPermissions" ? "default" : mode;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function asError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+function formatError(error: unknown): string {
+	return asError(error).stack ?? asError(error).message;
+}
+
+const input = new WritableStream<Uint8Array>({
+	write(chunk) {
+		return new Promise<void>((resolve) => {
+			process.stdout.write(chunk, () => resolve());
+		});
+	},
+});
+
+const output = new ReadableStream<Uint8Array>({
+	start(controller) {
+		process.stdin.on("data", (chunk: Buffer) => {
+			controller.enqueue(new Uint8Array(chunk));
+		});
+		process.stdin.on("end", () => controller.close());
+		process.stdin.on("error", (error: Error) => controller.error(error));
+	},
+});
+
+const stream = ndJsonStream(input, output);
+const _connection = new AgentSideConnection(
+	(conn) => new ClaudeSdkAgent(conn),
+	stream,
+);
+
+process.stdin.resume();
+process.stdin.on("end", () => {
+	process.exit(0);
+});

--- a/registry/agent/claude/src/index.ts
+++ b/registry/agent/claude/src/index.ts
@@ -1,0 +1,38 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageDir = resolve(__dirname, "..");
+
+const claude = {
+	name: "claude",
+	type: "agent" as const,
+	packageDir,
+	requires: ["@anthropic-ai/claude-agent-sdk"],
+	agent: {
+		id: "claude",
+		acpAdapter: "@agentos-software/claude-code",
+		agentPackage: "@anthropic-ai/claude-agent-sdk",
+		staticEnv: {
+			CLAUDE_AGENT_SDK_CLIENT_APP: "@rivet-dev/agentos",
+			CLAUDE_CODE_SIMPLE: "1",
+			CLAUDE_CODE_FORCE_AGENT_OS_RIPGREP: "1",
+			CLAUDE_CODE_DEFER_GROWTHBOOK_INIT: "1",
+			CLAUDE_CODE_DISABLE_CWD_PERSIST: "1",
+			CLAUDE_CODE_DISABLE_DEV_NULL_REDIRECT: "1",
+			CLAUDE_CODE_NODE_SHELL_WRAPPER: "1",
+			CLAUDE_CODE_DISABLE_STREAM_JSON_HOOK_EVENTS: "1",
+			CLAUDE_CODE_SHELL: "/bin/sh",
+			CLAUDE_CODE_SKIP_INITIAL_MESSAGES: "1",
+			CLAUDE_CODE_SKIP_SANDBOX_INIT: "1",
+			CLAUDE_CODE_SIMPLE_SHELL_EXEC: "1",
+			CLAUDE_CODE_SWAP_STDIO: "0",
+			CLAUDE_CODE_USE_PIPE_OUTPUT: "1",
+			DISABLE_TELEMETRY: "1",
+			SHELL: "/bin/sh",
+			USE_BUILTIN_RIPGREP: "0",
+		},
+	},
+};
+
+export default claude;

--- a/registry/agent/claude/src/patched-cli.ts
+++ b/registry/agent/claude/src/patched-cli.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve as resolvePath } from "node:path";
+
+type PatchedArtifactOptions = {
+	packageDir: string;
+	sdkPath: string;
+};
+
+type PatchedManifest = {
+	entry?: string;
+};
+
+function resolveManifestEntry(
+	packageDir: string,
+	manifestName: string,
+): string | undefined {
+	const manifestPath = resolvePath(packageDir, "dist", manifestName);
+	try {
+		const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as PatchedManifest;
+		if (typeof manifest.entry === "string" && manifest.entry.length > 0) {
+			return resolvePath(packageDir, "dist", manifest.entry.replace(/^\.\//, ""));
+		}
+	} catch {
+	}
+	return undefined;
+}
+
+export function resolveClaudeCliPath({
+	packageDir,
+	sdkPath,
+}: PatchedArtifactOptions): string {
+	return (
+		resolveManifestEntry(packageDir, "claude-cli-patched.json") ??
+		resolvePath(dirname(sdkPath), "cli.js")
+	);
+}
+
+export function resolveClaudeSdkPath({
+	packageDir,
+	sdkPath,
+}: PatchedArtifactOptions): string {
+	return (
+		resolveManifestEntry(packageDir, "claude-sdk-patched.json") ?? sdkPath
+	);
+}

--- a/registry/agent/claude/tests/patched-cli.test.mjs
+++ b/registry/agent/claude/tests/patched-cli.test.mjs
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, resolve as resolvePath } from "node:path";
+import { tmpdir } from "node:os";
+
+const require = createRequire(import.meta.url);
+const sdkPath = require.resolve("@anthropic-ai/claude-agent-sdk");
+const packageDir = resolvePath(import.meta.dirname, "..");
+const cliManifestPath = resolvePath(packageDir, "dist", "claude-cli-patched.json");
+const sdkManifestPath = resolvePath(packageDir, "dist", "claude-sdk-patched.json");
+const { resolveClaudeCliPath, resolveClaudeSdkPath } = await import(
+	resolvePath(packageDir, "dist", "patched-cli.js")
+);
+
+function readManifest(manifestPath) {
+	return JSON.parse(readFileSync(manifestPath, "utf-8"));
+}
+
+test("build writes patched Claude CLI and SDK manifests to dist", () => {
+	const cliManifest = readManifest(cliManifestPath);
+	const sdkManifest = readManifest(sdkManifestPath);
+
+	assert.equal(typeof cliManifest.entry, "string");
+	assert.equal(typeof sdkManifest.entry, "string");
+	assert.equal(
+		resolveClaudeCliPath({ packageDir, sdkPath }),
+		resolvePath(packageDir, "dist", cliManifest.entry.replace(/^\.\//, "")),
+	);
+	assert.equal(
+		resolveClaudeSdkPath({ packageDir, sdkPath }),
+		resolvePath(packageDir, "dist", sdkManifest.entry.replace(/^\.\//, "")),
+	);
+});
+
+test("patched-path helpers fall back to the upstream SDK when manifests are missing", () => {
+	const tempDir = mkdtempSync(resolvePath(tmpdir(), "agentos-claude-test-"));
+	try {
+		assert.equal(
+			resolveClaudeCliPath({ packageDir: tempDir, sdkPath }),
+			resolvePath(dirname(sdkPath), "cli.js"),
+		);
+		assert.equal(resolveClaudeSdkPath({ packageDir: tempDir, sdkPath }), sdkPath);
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+test("patched-path helpers resolve custom manifest entries from dist", () => {
+	const tempDir = mkdtempSync(resolvePath(tmpdir(), "agentos-claude-test-"));
+	try {
+		const distDir = resolvePath(tempDir, "dist");
+		mkdirSync(distDir, { recursive: true });
+		writeFileSync(
+			resolvePath(distDir, "claude-cli-patched.json"),
+			JSON.stringify({ entry: "./custom-cli.mjs" }),
+			"utf-8",
+		);
+		writeFileSync(
+			resolvePath(distDir, "claude-sdk-patched.json"),
+			JSON.stringify({ entry: "./custom-sdk.mjs" }),
+			"utf-8",
+		);
+
+		assert.equal(
+			resolveClaudeCliPath({ packageDir: tempDir, sdkPath }),
+			resolvePath(distDir, "custom-cli.mjs"),
+		);
+		assert.equal(
+			resolveClaudeSdkPath({ packageDir: tempDir, sdkPath }),
+			resolvePath(distDir, "custom-sdk.mjs"),
+		);
+	} finally {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+test("patched CLI keeps stream-json hook events enabled by default", () => {
+	const patchedCliPath = resolveClaudeCliPath({ packageDir, sdkPath });
+	const patchedCliSource = readFileSync(patchedCliPath, "utf-8");
+	const hookForwardingGuard =
+		'if($.outputFormat==="stream-json"&&$.verbose&&process.env.AGENT_OS_CLAUDE_DISABLE_HOOK_EVENTS!=="1")JMK((x)=>{';
+
+	assert.ok(
+		patchedCliSource.includes(hookForwardingGuard),
+		"expected patched CLI to guard stream-json hook events with AGENT_OS_CLAUDE_DISABLE_HOOK_EVENTS",
+	);
+	assert.ok(
+		!patchedCliSource.includes(
+			'if($.outputFormat==="stream-json"&&$.verbose&&false)JMK((x)=>{',
+		),
+		"expected patched CLI to remove the unconditional && false kill-switch",
+	);
+
+	const hookEvents = [];
+	const maybeRegisterHookEvents = (env, options, onHookEvent) => {
+		if (
+			options.outputFormat === "stream-json" &&
+			options.verbose &&
+			env.AGENT_OS_CLAUDE_DISABLE_HOOK_EVENTS !== "1"
+		) {
+			onHookEvent({ type: "hook_event" });
+		}
+	};
+
+	maybeRegisterHookEvents({}, { outputFormat: "stream-json", verbose: true }, (event) =>
+		hookEvents.push(event.type),
+	);
+	assert.deepEqual(hookEvents, ["hook_event"]);
+
+	const disabledHookEvents = [];
+	maybeRegisterHookEvents(
+		{ AGENT_OS_CLAUDE_DISABLE_HOOK_EVENTS: "1" },
+		{ outputFormat: "stream-json", verbose: true },
+		(event) => disabledHookEvents.push(event.type),
+	);
+	assert.deepEqual(disabledHookEvents, []);
+});

--- a/registry/agent/claude/tsconfig.json
+++ b/registry/agent/claude/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"declaration": true,
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/registry/agent/codex/package.json
+++ b/registry/agent/codex/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@agentos-software/codex",
+	"version": "0.2.0-rc.3",
+	"type": "module",
+	"license": "Apache-2.0",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc",
+		"check-types": "tsc --noEmit",
+		"test": "pnpm build && node --test tests/*.test.mjs"
+	},
+	"dependencies": {
+		"@agentos-software/codex-cli": "workspace:*"
+	},
+	"devDependencies": {
+		"@types/node": "^22.10.2",
+		"typescript": "^5.7.2"
+	}
+}

--- a/registry/agent/codex/src/index.ts
+++ b/registry/agent/codex/src/index.ts
@@ -1,0 +1,3 @@
+import codexSoftware from "@agentos-software/codex-cli";
+
+export default codexSoftware;

--- a/registry/agent/codex/tests/package.test.mjs
+++ b/registry/agent/codex/tests/package.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import codex from "../dist/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test("codex package does not advertise an ACP adapter until the real agent is wired", () => {
+	const manifest = JSON.parse(
+		readFileSync(join(__dirname, "..", "package.json"), "utf8"),
+	);
+
+	assert.equal(manifest.bin, undefined);
+	assert.equal(codex.name, "codex");
+	assert.equal(typeof codex.commandDir, "string");
+	assert.equal(codex.agent, undefined);
+});

--- a/registry/agent/codex/tsconfig.json
+++ b/registry/agent/codex/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"declaration": true,
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/registry/agent/opencode/package.json
+++ b/registry/agent/opencode/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@agentos-software/opencode",
+	"version": "0.2.0-rc.3",
+	"type": "module",
+	"license": "Apache-2.0",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"bin": {
+		"agentos-opencode-acp": "./dist/adapter.js"
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "node ./scripts/build-opencode-acp.mjs && tsc",
+		"check-types": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"bun": "1.3.11",
+		"@types/node": "^22.10.2",
+		"typescript": "^5.7.2"
+	}
+}

--- a/registry/agent/opencode/scripts/build-opencode-acp.mjs
+++ b/registry/agent/opencode/scripts/build-opencode-acp.mjs
@@ -1,0 +1,3681 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const SOURCE_REPOSITORY = "anomalyco/opencode";
+const SOURCE_VERSION = "1.3.13";
+const SOURCE_TARBALL_URL = `https://github.com/${SOURCE_REPOSITORY}/archive/refs/tags/v${SOURCE_VERSION}.tar.gz`;
+
+// Upstream `packages/app/package.json` pins `ghostty-web: github:anomalyco/ghostty-web#main`,
+// but the bundled bun.lock snapshots the SHA below. Because `main` is a moving ref, a fresh
+// `bun install --frozen-lockfile` resolves to whatever `main` points at *now* and fails the
+// lockfile check. Rewriting the manifest to the lockfile's SHA before install keeps frozen-
+// lockfile guarantees intact (i.e. CI still breaks loudly if either side drifts) without
+// trusting arbitrary new HEADs on the ghostty-web branch.
+const GHOSTTY_WEB_PINNED_SHA = "4af877d";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageDir = resolve(__dirname, "..");
+const distDir = resolve(packageDir, "dist");
+const cacheDir = resolve(packageDir, "node_modules", ".cache", "opencode-build");
+const patchPath = resolve(packageDir, "upstream", `opencode-v${SOURCE_VERSION}.patch`);
+const bundleDir = resolve(distDir, "opencode-acp");
+const manifestPath = resolve(distDir, "opencode-acp.manifest.json");
+const SQL_JS_VERSION = "1.14.1";
+const bunBin = resolve(
+	packageDir,
+	"node_modules",
+	".bin",
+	process.platform === "win32" ? "bun.cmd" : "bun",
+);
+
+function run(command, args, options = {}) {
+	const result = spawnSync(command, args, {
+		stdio: "inherit",
+		...options,
+	});
+	if (result.status !== 0) {
+		throw new Error(
+			`Command failed (${result.status ?? "unknown"}): ${command} ${args.join(" ")}`,
+		);
+	}
+	return result;
+}
+
+function pinGhosttyWebRef(sourceRoot) {
+	const manifestPath = resolve(sourceRoot, "packages", "app", "package.json");
+	const raw = readFileSync(manifestPath, "utf-8");
+	const movingRef = '"ghostty-web": "github:anomalyco/ghostty-web#main"';
+	const pinnedRef = `"ghostty-web": "github:anomalyco/ghostty-web#${GHOSTTY_WEB_PINNED_SHA}"`;
+	if (raw.includes(pinnedRef)) return;
+	if (!raw.includes(movingRef)) {
+		throw new Error(
+			`Expected ghostty-web ref ${movingRef} in ${manifestPath}; upstream layout changed — re-audit GHOSTTY_WEB_PINNED_SHA before updating.`,
+		);
+	}
+	writeFileSync(manifestPath, raw.replace(movingRef, pinnedRef));
+}
+
+const PATCHED_SOURCE_FILES = [
+	"packages/opencode/src/cli/cmd/acp.ts",
+	"packages/opencode/src/config/config.ts",
+	"packages/opencode/src/plugin/index.ts",
+	"packages/opencode/src/server/instance.ts",
+	"packages/opencode/src/server/server.ts",
+];
+
+async function ensureNodeAcpPatch(sourceRoot, tarballPath) {
+	const serverFile = resolve(
+		sourceRoot,
+		"packages",
+		"opencode",
+		"src",
+		"server",
+		"server.ts",
+	);
+	const pluginFile = resolve(
+		sourceRoot,
+		"packages",
+		"opencode",
+		"src",
+		"plugin",
+		"index.ts",
+	);
+	const acpFile = resolve(
+		sourceRoot,
+		"packages",
+		"opencode",
+		"src",
+		"cli",
+		"cmd",
+		"acp.ts",
+	);
+	const serverSource = readFileSync(serverFile, "utf-8");
+	const pluginSource = readFileSync(pluginFile, "utf-8");
+	const acpSource = readFileSync(acpFile, "utf-8");
+	const alreadyPatched =
+		serverSource.includes('from "node:http"') &&
+		!serverSource.includes('from "hono/bun"') &&
+		pluginSource.includes("Bun shell is unavailable in the Node ACP build") &&
+		acpSource.includes("const server = await Server.listen(opts)");
+
+	if (alreadyPatched) {
+		return;
+	}
+
+	const scratchRoot = await mkdtemp(join(tmpdir(), "agentos-opencode-patch-"));
+	try {
+		run("tar", ["-xzf", tarballPath, "--strip-components=1", "-C", scratchRoot]);
+		run("git", ["apply", "--whitespace=nowarn", patchPath], { cwd: scratchRoot });
+		for (const relativePath of PATCHED_SOURCE_FILES) {
+			copyFileSync(
+				resolve(scratchRoot, relativePath),
+				resolve(sourceRoot, relativePath),
+			);
+		}
+	} finally {
+		rmSync(scratchRoot, { recursive: true, force: true });
+	}
+
+	const verifiedServerSource = readFileSync(serverFile, "utf-8");
+	const verifiedPluginSource = readFileSync(pluginFile, "utf-8");
+	const verifiedAcpSource = readFileSync(acpFile, "utf-8");
+	if (
+		!verifiedServerSource.includes('from "node:http"') ||
+		verifiedServerSource.includes('from "hono/bun"') ||
+		!verifiedPluginSource.includes("Bun shell is unavailable in the Node ACP build") ||
+		!verifiedAcpSource.includes("const server = await Server.listen(opts)")
+	) {
+		throw new Error("Failed to stage the Node ACP patches into the prepared OpenCode source tree");
+	}
+}
+
+async function downloadFile(url, destination) {
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(`Failed to download ${url}: ${response.status} ${response.statusText}`);
+	}
+
+	const buffer = Buffer.from(await response.arrayBuffer());
+	await writeFile(destination, buffer);
+}
+
+async function readMigrations(sourceRoot) {
+	const migrationRoot = join(sourceRoot, "packages", "opencode", "migration");
+	const entries = (await readdir(migrationRoot, { withFileTypes: true }))
+		.filter((entry) => entry.isDirectory() && /^\d{14}/.test(entry.name))
+		.map((entry) => entry.name)
+		.sort();
+
+	return Promise.all(
+		entries.map(async (name) => {
+			const sql = await readFile(
+				join(migrationRoot, name, "migration.sql"),
+				"utf8",
+			);
+			const match = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(name);
+			const timestamp = match
+				? Date.UTC(
+						Number(match[1]),
+						Number(match[2]) - 1,
+						Number(match[3]),
+						Number(match[4]),
+						Number(match[5]),
+						Number(match[6]),
+					)
+				: 0;
+			return { name, sql, timestamp };
+		}),
+	);
+}
+
+async function rewriteSourceFile(sourceRoot, relativePath, transform) {
+	const filePath = resolve(sourceRoot, relativePath);
+	const original = await readFile(filePath, "utf8");
+	const next = transform(original);
+	if (next !== original) {
+		await writeFile(filePath, next);
+	}
+}
+
+async function ensureSqlJsDependency(sourceRoot) {
+	const packageJsonPath = resolve(
+		sourceRoot,
+		"packages",
+		"opencode",
+		"package.json",
+	);
+	const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+	const dependencies = packageJson.dependencies ?? {};
+	const bunStoreDir = resolve(sourceRoot, "node_modules", ".bun");
+	const hasInstalledSqlJs =
+		existsSync(bunStoreDir) &&
+		(await readdir(bunStoreDir)).some((entry) => entry.startsWith("sql.js@"));
+	if (dependencies["sql.js"] === SQL_JS_VERSION && hasInstalledSqlJs) {
+		return;
+	}
+
+	packageJson.dependencies = {
+		...dependencies,
+		"sql.js": SQL_JS_VERSION,
+	};
+	await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+	run(bunBin, ["install"], { cwd: sourceRoot });
+}
+
+async function applyNodeAcpRuntimeTweaks(sourceRoot) {
+	await writeFile(
+		resolve(sourceRoot, "packages/opencode/src/cli/cmd/acp.ts"),
+		`import type { Argv, InferredOptionTypes } from "yargs"
+import { cmd } from "./cmd"
+import { AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk"
+import { Log } from "../../util/log"
+
+const options = {
+  port: {
+    type: "number" as const,
+    describe: "port to listen on",
+    default: 0,
+  },
+  hostname: {
+    type: "string" as const,
+    describe: "hostname to listen on",
+    default: "127.0.0.1",
+  },
+  mdns: {
+    type: "boolean" as const,
+    describe: "enable mDNS service discovery (defaults hostname to 0.0.0.0)",
+    default: false,
+  },
+  "mdns-domain": {
+    type: "string" as const,
+    describe: "custom domain name for mDNS service (default: opencode.local)",
+    default: "opencode.local",
+  },
+  cors: {
+    type: "string" as const,
+    array: true,
+    describe: "additional domains to allow for CORS",
+    default: [] as string[],
+  },
+}
+
+type NetworkOptions = InferredOptionTypes<typeof options>
+
+function withNetworkOptions<T>(yargs: Argv<T>) {
+  return yargs.options(options)
+}
+
+async function resolveNetworkOptions(args: NetworkOptions) {
+  const { Config } = await import("../../config/config")
+  const config = await Config.getGlobal()
+  const portExplicitlySet = process.argv.includes("--port")
+  const hostnameExplicitlySet = process.argv.includes("--hostname")
+  const mdnsExplicitlySet = process.argv.includes("--mdns")
+  const mdnsDomainExplicitlySet = process.argv.includes("--mdns-domain")
+  const corsExplicitlySet = process.argv.includes("--cors")
+
+  const mdns = mdnsExplicitlySet ? args.mdns : (config?.server?.mdns ?? args.mdns)
+  const mdnsDomain = mdnsDomainExplicitlySet ? args["mdns-domain"] : (config?.server?.mdnsDomain ?? args["mdns-domain"])
+  const port = portExplicitlySet ? args.port : (config?.server?.port ?? args.port)
+  const hostname = hostnameExplicitlySet
+    ? args.hostname
+    : mdns && !config?.server?.hostname
+      ? "0.0.0.0"
+      : (config?.server?.hostname ?? args.hostname)
+  const configCors = config?.server?.cors ?? []
+  const argsCors = Array.isArray(args.cors) ? args.cors : args.cors ? [args.cors] : []
+  const cors = [...configCors, ...argsCors]
+
+  return { hostname, port, mdns, mdnsDomain, cors }
+}
+
+function wrapData<T>(data: T) {
+  return { data }
+}
+
+async function loadProviderCatalog(directory: string | undefined) {
+  const [{ Config }] = await Promise.all([import("../../config/config")])
+
+  return withDirectory(directory, async () => {
+    const config = await Config.get()
+    const providers: any[] = []
+
+    if (config?.provider?.anthropic || config?.model?.startsWith("anthropic/") || process.env.ANTHROPIC_API_KEY) {
+      providers.push({
+        id: "anthropic",
+        name: "Anthropic",
+        source: "config",
+        env: ["ANTHROPIC_API_KEY"],
+        options: {
+          ...(config?.provider?.anthropic?.options ?? {}),
+        },
+        models: {
+          "claude-sonnet-4-20250514": {
+            id: "claude-sonnet-4-20250514",
+            providerID: "anthropic",
+            api: { id: "claude-sonnet-4-20250514", url: "", npm: "@ai-sdk/anthropic" },
+            name: "Claude Sonnet 4",
+            family: "claude-sonnet-4",
+            capabilities: {
+              temperature: true,
+              reasoning: true,
+              attachment: true,
+              toolcall: true,
+              input: { text: true, audio: false, image: true, video: false, pdf: true },
+              output: { text: true, audio: false, image: false, video: false, pdf: false },
+              interleaved: false,
+            },
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+            limit: { context: 200000, output: 32000 },
+            status: "active",
+            options: {},
+            headers: {},
+            release_date: "2025-05-14",
+            variants: {},
+          },
+          "claude-opus-4-1-20250805": {
+            id: "claude-opus-4-1-20250805",
+            providerID: "anthropic",
+            api: { id: "claude-opus-4-1-20250805", url: "", npm: "@ai-sdk/anthropic" },
+            name: "Claude Opus 4.1",
+            family: "claude-opus-4-1",
+            capabilities: {
+              temperature: true,
+              reasoning: true,
+              attachment: true,
+              toolcall: true,
+              input: { text: true, audio: false, image: true, video: false, pdf: true },
+              output: { text: true, audio: false, image: false, video: false, pdf: false },
+              interleaved: false,
+            },
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+            limit: { context: 200000, output: 32000 },
+            status: "active",
+            options: {},
+            headers: {},
+            release_date: "2025-08-05",
+            variants: {},
+          },
+          "claude-haiku-4-5-20251001": {
+            id: "claude-haiku-4-5-20251001",
+            providerID: "anthropic",
+            api: { id: "claude-haiku-4-5-20251001", url: "", npm: "@ai-sdk/anthropic" },
+            name: "Claude Haiku 4.5",
+            family: "claude-haiku-4-5",
+            capabilities: {
+              temperature: true,
+              reasoning: false,
+              attachment: true,
+              toolcall: true,
+              input: { text: true, audio: false, image: true, video: false, pdf: true },
+              output: { text: true, audio: false, image: false, video: false, pdf: false },
+              interleaved: false,
+            },
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+            limit: { context: 200000, output: 16000 },
+            status: "active",
+            options: {},
+            headers: {},
+            release_date: "2025-10-01",
+            variants: {},
+          },
+        },
+      })
+    }
+
+    if (config?.provider?.openai || config?.model?.startsWith("openai/") || process.env.OPENAI_API_KEY) {
+      providers.push({
+        id: "openai",
+        name: "OpenAI",
+        source: "config",
+        env: ["OPENAI_API_KEY"],
+        options: {
+          ...(config?.provider?.openai?.options ?? {}),
+        },
+        models: {
+          "gpt-5": {
+            id: "gpt-5",
+            providerID: "openai",
+            api: { id: "gpt-5", url: "", npm: "@ai-sdk/openai" },
+            name: "GPT-5",
+            family: "gpt-5",
+            capabilities: {
+              temperature: true,
+              reasoning: true,
+              attachment: true,
+              toolcall: true,
+              input: { text: true, audio: false, image: true, video: false, pdf: true },
+              output: { text: true, audio: false, image: false, video: false, pdf: false },
+              interleaved: false,
+            },
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+            limit: { context: 200000, output: 32000 },
+            status: "active",
+            options: {},
+            headers: {},
+            release_date: "2025-01-01",
+            variants: {},
+          },
+          "gpt-5-mini": {
+            id: "gpt-5-mini",
+            providerID: "openai",
+            api: { id: "gpt-5-mini", url: "", npm: "@ai-sdk/openai" },
+            name: "GPT-5 Mini",
+            family: "gpt-5-mini",
+            capabilities: {
+              temperature: true,
+              reasoning: true,
+              attachment: true,
+              toolcall: true,
+              input: { text: true, audio: false, image: true, video: false, pdf: true },
+              output: { text: true, audio: false, image: false, video: false, pdf: false },
+              interleaved: false,
+            },
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+            limit: { context: 200000, output: 16000 },
+            status: "active",
+            options: {},
+            headers: {},
+            release_date: "2025-01-01",
+            variants: {},
+          },
+        },
+      })
+    }
+
+    if (
+      config?.provider?.google ||
+      config?.model?.startsWith("google/") ||
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY
+    ) {
+      providers.push({
+        id: "google",
+        name: "Google",
+        source: "config",
+        env: ["GOOGLE_GENERATIVE_AI_API_KEY"],
+        options: {
+          ...(config?.provider?.google?.options ?? {}),
+        },
+        models: {
+          "gemini-2.5-pro": {
+            id: "gemini-2.5-pro",
+            providerID: "google",
+            api: { id: "gemini-2.5-pro", url: "", npm: "@ai-sdk/google" },
+            name: "Gemini 2.5 Pro",
+            family: "gemini-2.5-pro",
+            capabilities: {
+              temperature: true,
+              reasoning: true,
+              attachment: true,
+              toolcall: true,
+              input: { text: true, audio: false, image: true, video: false, pdf: true },
+              output: { text: true, audio: false, image: false, video: false, pdf: false },
+              interleaved: false,
+            },
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+            limit: { context: 200000, output: 32000 },
+            status: "active",
+            options: {},
+            headers: {},
+            release_date: "2025-01-01",
+            variants: {},
+          },
+          "gemini-2.5-flash": {
+            id: "gemini-2.5-flash",
+            providerID: "google",
+            api: { id: "gemini-2.5-flash", url: "", npm: "@ai-sdk/google" },
+            name: "Gemini 2.5 Flash",
+            family: "gemini-2.5-flash",
+            capabilities: {
+              temperature: true,
+              reasoning: true,
+              attachment: true,
+              toolcall: true,
+              input: { text: true, audio: false, image: true, video: false, pdf: true },
+              output: { text: true, audio: false, image: false, video: false, pdf: false },
+              interleaved: false,
+            },
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+            limit: { context: 200000, output: 16000 },
+            status: "active",
+            options: {},
+            headers: {},
+            release_date: "2025-01-01",
+            variants: {},
+          },
+        },
+      })
+    }
+
+    if (
+      config?.provider?.["google-vertex"] ||
+      config?.model?.startsWith("google-vertex/") ||
+      (process.env.GOOGLE_VERTEX_PROJECT && process.env.GOOGLE_VERTEX_LOCATION)
+    ) {
+      providers.push({
+        id: "google-vertex",
+        name: "Google Vertex",
+        source: "config",
+        env: [],
+        options: {
+          ...(config?.provider?.["google-vertex"]?.options ?? {}),
+        },
+        models: {
+          "gemini-2.5-pro": {
+            id: "gemini-2.5-pro",
+            providerID: "google-vertex",
+            api: { id: "gemini-2.5-pro", url: "", npm: "@ai-sdk/google-vertex" },
+            name: "Gemini 2.5 Pro",
+            family: "gemini-2.5-pro",
+            capabilities: {
+              temperature: true,
+              reasoning: true,
+              attachment: true,
+              toolcall: true,
+              input: { text: true, audio: false, image: true, video: false, pdf: true },
+              output: { text: true, audio: false, image: false, video: false, pdf: false },
+              interleaved: false,
+            },
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+            limit: { context: 200000, output: 32000 },
+            status: "active",
+            options: {},
+            headers: {},
+            release_date: "2025-01-01",
+            variants: {},
+          },
+        },
+      })
+    }
+
+    if (config?.provider?.groq || config?.model?.startsWith("groq/") || process.env.GROQ_API_KEY) {
+      providers.push({
+        id: "groq",
+        name: "Groq",
+        source: "config",
+        env: ["GROQ_API_KEY"],
+        options: {
+          ...(config?.provider?.groq?.options ?? {}),
+        },
+        models: {
+          "llama-3.3-70b-versatile": {
+            id: "llama-3.3-70b-versatile",
+            providerID: "groq",
+            api: { id: "llama-3.3-70b-versatile", url: "", npm: "@ai-sdk/groq" },
+            name: "Llama 3.3 70B Versatile",
+            family: "llama-3.3-70b",
+            capabilities: {
+              temperature: true,
+              reasoning: true,
+              attachment: false,
+              toolcall: true,
+              input: { text: true, audio: false, image: false, video: false, pdf: false },
+              output: { text: true, audio: false, image: false, video: false, pdf: false },
+              interleaved: false,
+            },
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+            limit: { context: 200000, output: 32000 },
+            status: "active",
+            options: {},
+            headers: {},
+            release_date: "2025-01-01",
+            variants: {},
+          },
+        },
+      })
+    }
+
+    if (config?.provider?.mistral || config?.model?.startsWith("mistral/") || process.env.MISTRAL_API_KEY) {
+      providers.push({
+        id: "mistral",
+        name: "Mistral",
+        source: "config",
+        env: ["MISTRAL_API_KEY"],
+        options: {
+          ...(config?.provider?.mistral?.options ?? {}),
+        },
+        models: {
+          "mistral-small-latest": {
+            id: "mistral-small-latest",
+            providerID: "mistral",
+            api: { id: "mistral-small-latest", url: "", npm: "@ai-sdk/mistral" },
+            name: "Mistral Small Latest",
+            family: "mistral-small",
+            capabilities: {
+              temperature: true,
+              reasoning: true,
+              attachment: true,
+              toolcall: true,
+              input: { text: true, audio: false, image: true, video: false, pdf: true },
+              output: { text: true, audio: false, image: false, video: false, pdf: false },
+              interleaved: false,
+            },
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+            limit: { context: 200000, output: 32000 },
+            status: "active",
+            options: {},
+            headers: {},
+            release_date: "2025-01-01",
+            variants: {},
+          },
+        },
+      })
+    }
+
+    if (providers.length === 0) {
+      providers.push({
+        id: "anthropic",
+        name: "Anthropic",
+        source: "custom",
+        env: ["ANTHROPIC_API_KEY"],
+        options: {},
+        models: {
+          "claude-sonnet-4-20250514": {
+            id: "claude-sonnet-4-20250514",
+            providerID: "anthropic",
+            api: { id: "claude-sonnet-4-20250514", url: "", npm: "@ai-sdk/anthropic" },
+            name: "Claude Sonnet 4",
+            family: "claude-sonnet-4",
+            capabilities: {
+              temperature: true,
+              reasoning: true,
+              attachment: true,
+              toolcall: true,
+              input: { text: true, audio: false, image: true, video: false, pdf: true },
+              output: { text: true, audio: false, image: false, video: false, pdf: false },
+              interleaved: false,
+            },
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+            limit: { context: 200000, output: 32000 },
+            status: "active",
+            options: {},
+            headers: {},
+            release_date: "2025-05-14",
+            variants: {},
+          },
+        },
+      })
+    }
+
+    const defaults = Object.fromEntries(
+      providers.map((provider) => {
+        const specifiedModel =
+          typeof config.model === "string" && config.model.startsWith(provider.id + "/")
+            ? config.model.slice(provider.id.length + 1)
+            : undefined
+        return [
+          provider.id,
+          specifiedModel ?? Object.keys(provider.models)[0] ?? "",
+        ]
+      }),
+    )
+
+    return { providers, default: defaults }
+  })
+}
+
+async function runServiceWithCurrentInstance<T>(
+  serviceModule: { Service: any; defaultLayer: any },
+  ctx: any,
+  fn: (service: any) => any,
+): Promise<T> {
+  const [{ Effect, ManagedRuntime }, { InstanceRef }, { memoMap }, { Instance }] = await Promise.all([
+    import("effect"),
+    import("../../effect/instance-ref"),
+    import("../../effect/run-service"),
+    import("../../project/instance"),
+  ])
+  console.error("[opencode-acp] serviceRuntime:ctx", ctx.directory)
+  ;(globalThis as typeof globalThis & { __agentosOpencodeInstanceFallback?: unknown }).__agentosOpencodeInstanceFallback =
+    ctx
+  const runtime = ManagedRuntime.make(serviceModule.defaultLayer, { memoMap })
+  try {
+    const result = await Instance.restore(
+      ctx,
+      () =>
+        runtime.runPromise(
+          Effect.provideService(serviceModule.Service.use(fn), InstanceRef, ctx),
+        ),
+    )
+    console.error("[opencode-acp] serviceRuntime:done", ctx.directory)
+    return result
+  } catch (error) {
+    console.error(
+      "[opencode-acp] serviceRuntime:error",
+      error instanceof Error ? error.stack ?? error.message : String(error),
+    )
+    throw error
+  }
+}
+
+async function loadAgentCatalog(directory: string | undefined) {
+  const { Config } = await import("../../config/config")
+
+  return withDirectory(directory, async () => {
+    const cfg = await Config.get()
+    const agents = new Map<string, any>([
+      [
+        "build",
+        {
+          name: "build",
+          description: "The default agent. Executes tools based on configured permissions.",
+          mode: "primary",
+        },
+      ],
+      [
+        "plan",
+        {
+          name: "plan",
+          description: "Plan mode. Disallows all edit tools.",
+          mode: "primary",
+        },
+      ],
+      [
+        "general",
+        {
+          name: "general",
+          description:
+            "General-purpose agent for researching complex questions and executing multi-step tasks. Use this agent to execute multiple units of work in parallel.",
+          mode: "subagent",
+        },
+      ],
+      [
+        "explore",
+        {
+          name: "explore",
+          description:
+            "Fast agent specialized for exploring codebases. Use this when you need to quickly find files, search code, or answer questions about the codebase.",
+          mode: "subagent",
+        },
+      ],
+      ["compaction", { name: "compaction", mode: "primary", hidden: true }],
+      ["title", { name: "title", mode: "primary", hidden: true }],
+      ["summary", { name: "summary", mode: "primary", hidden: true }],
+    ])
+
+    for (const [key, value] of Object.entries(cfg.agent ?? {})) {
+      if (value?.disable) {
+        agents.delete(key)
+        continue
+      }
+      const current = agents.get(key) ?? {
+        name: key,
+        mode: "all",
+      }
+      agents.set(key, {
+        ...current,
+        ...(value?.name ? { name: value.name } : {}),
+        ...(value?.description ? { description: value.description } : {}),
+        ...(value?.mode ? { mode: value.mode } : {}),
+        ...(value?.hidden !== undefined ? { hidden: value.hidden } : {}),
+      })
+    }
+
+    const defaultAgent = cfg.default_agent ?? "build"
+    return Array.from(agents.values()).sort((a, b) => {
+      const aRank = a.name === defaultAgent ? 0 : 1
+      const bRank = b.name === defaultAgent ? 0 : 1
+      if (aRank !== bRank) return aRank - bRank
+      return a.name.localeCompare(b.name)
+    })
+  })
+}
+
+async function loadCommandCatalog(directory: string | undefined) {
+  const { Config } = await import("../../config/config")
+
+  return withDirectory(directory, async () => {
+    const cfg = await Config.get()
+    const commands = new Map<string, any>([
+      ["init", { name: "init", description: "create/update AGENTS.md" }],
+      ["review", { name: "review", description: "review changes [commit|branch|pr], defaults to uncommitted" }],
+    ])
+
+    for (const [name, command] of Object.entries(cfg.command ?? {})) {
+      commands.set(name, {
+        name,
+        ...(command?.description ? { description: command.description } : {}),
+      })
+    }
+
+    return Array.from(commands.values()).sort((a, b) => a.name.localeCompare(b.name))
+  })
+}
+
+async function withDirectory<T>(
+  directory: string | undefined,
+  fn: (ctx: any) => Promise<T>,
+): Promise<T> {
+  console.error("[opencode-acp] withDirectory:start", directory ?? process.cwd())
+  const [{ Instance }, { InstanceBootstrap }] = await Promise.all([
+    import("../../project/instance"),
+    import("../../project/bootstrap"),
+  ])
+  console.error("[opencode-acp] withDirectory:modules:done", directory ?? process.cwd())
+  return Instance.provide({
+    directory: directory ?? process.cwd(),
+    init: InstanceBootstrap,
+    fn: () => {
+      const ctx = Instance.current
+      ;(globalThis as typeof globalThis & { __agentosOpencodeInstanceFallback?: unknown }).__agentosOpencodeInstanceFallback =
+        ctx
+      return fn(ctx)
+    },
+  })
+}
+
+async function ensureProjectors() {
+  if ((globalThis as any).__agentosOpencodeProjectorsReady) return
+  console.error("[opencode-acp] projectors:ensure:start")
+  const [{ SyncEvent }, { default: sessionProjectors }] = await Promise.all([
+    import("../../sync"),
+    import("../../session/projectors"),
+  ])
+  SyncEvent.init({
+    projectors: sessionProjectors,
+  })
+  ;(globalThis as any).__agentosOpencodeProjectorsReady = true
+  console.error("[opencode-acp] projectors:ensure:done")
+}
+
+async function createGlobalEventStream(signal?: AbortSignal) {
+  const { GlobalBus } = await import("../../bus/global")
+  let closed = false
+  const queue: any[] = []
+  let nextResolve: ((result: IteratorResult<any>) => void) | undefined
+
+  const close = () => {
+    if (closed) return
+    closed = true
+    GlobalBus.off("event", onEvent)
+    signal?.removeEventListener("abort", close)
+    nextResolve?.({ done: true, value: undefined })
+    nextResolve = undefined
+  }
+
+  const onEvent = (event: any) => {
+    if (closed) return
+    if (nextResolve) {
+      const resolve = nextResolve
+      nextResolve = undefined
+      resolve({ done: false, value: event })
+      return
+    }
+    queue.push(event)
+  }
+
+  GlobalBus.on("event", onEvent)
+  if (signal) {
+    if (signal.aborted) close()
+    else signal.addEventListener("abort", close, { once: true })
+  }
+
+  return {
+    stream: (async function* () {
+      try {
+        while (true) {
+          if (queue.length > 0) {
+            yield queue.shift()
+            continue
+          }
+
+          const next = await new Promise<IteratorResult<any>>((resolve) => {
+            nextResolve = resolve
+          })
+          if (next.done) return
+          yield next.value
+        }
+      } finally {
+        close()
+      }
+    })(),
+  }
+}
+
+function createLocalSdk() {
+  return {
+    global: {
+      event: async ({ signal }: { signal?: AbortSignal }) => createGlobalEventStream(signal),
+    },
+    permission: {
+      reply: async ({ requestID, reply, directory }: any) =>
+        wrapData(
+          await withDirectory(directory, async () => {
+            const { Permission } = await import("../../permission")
+            await Permission.reply({ requestID, reply })
+            return true
+          }),
+        ),
+    },
+    config: {
+      get: async ({ directory }: any) =>
+        wrapData(
+          await (async () => {
+            const { Config } = await import("../../config/config")
+            return withDirectory(directory, async () => {
+              console.error("[opencode-acp] sdk.config.get:start", directory ?? process.cwd())
+              const result = await Config.get()
+              console.error("[opencode-acp] sdk.config.get:done", directory ?? process.cwd())
+              return result
+            })
+          })(),
+        ),
+      providers: async ({ directory }: any) =>
+        wrapData(
+          await (async () => {
+            console.error("[opencode-acp] sdk.config.providers:start", directory ?? process.cwd())
+            return withDirectory(directory, async () => {
+              const result = await loadProviderCatalog(directory)
+              console.error(
+                "[opencode-acp] sdk.config.providers:done",
+                directory ?? process.cwd(),
+                result.providers.length,
+              )
+              return result
+            })
+          })(),
+        ),
+    },
+    app: {
+      agents: async ({ directory }: any) =>
+        wrapData(
+          await loadAgentCatalog(directory),
+        ),
+    },
+    command: {
+      list: async ({ directory }: any) =>
+        wrapData(
+          await loadCommandCatalog(directory),
+        ),
+    },
+    mcp: {
+      add: async ({ directory, name, config }: any) =>
+        wrapData(
+          await (async () => {
+            const { MCP } = await import("../../mcp")
+            return withDirectory(directory, async () => MCP.add(name, config))
+          })(),
+        ),
+    },
+    session: {
+      create: async ({ directory, title, permission, workspaceID, parentID }: any) =>
+        wrapData(
+          await (async () => {
+            await ensureProjectors()
+            return withDirectory(directory, async (ctx) => {
+              const { Session } = await import("../../session")
+              console.error("[opencode-acp] sdk.session.create:start", directory ?? process.cwd())
+              try {
+                const result = await runServiceWithCurrentInstance(Session, ctx, (service) =>
+                  service.create({
+                    ...(title ? { title } : {}),
+                    ...(permission ? { permission } : {}),
+                    ...(workspaceID ? { workspaceID } : {}),
+                    ...(parentID ? { parentID } : {}),
+                  }),
+                )
+                console.error("[opencode-acp] sdk.session.create:done", directory ?? process.cwd())
+                return result
+              } catch (error) {
+                console.error(
+                  "[opencode-acp] sdk.session.create:error",
+                  error instanceof Error ? error.stack ?? error.message : String(error),
+                )
+                throw error
+              }
+            })
+          })(),
+        ),
+      get: async ({ sessionID, directory }: any) =>
+        wrapData(
+          await (async () => {
+            const { Session } = await import("../../session")
+            return withDirectory(directory, async (ctx) =>
+              runServiceWithCurrentInstance(Session, ctx, (service) => service.get(sessionID)),
+            )
+          })(),
+        ),
+      list: async ({ directory, roots, start, search, limit }: any) =>
+        wrapData(
+          await (async () => {
+            const { Session } = await import("../../session")
+            return withDirectory(directory, async (ctx) => {
+              return runServiceWithCurrentInstance(Session, ctx, (service) =>
+                service.list({ directory, roots, start, search, limit }),
+              )
+            })
+          })(),
+        ),
+      fork: async ({ sessionID, messageID, directory }: any) =>
+        wrapData(
+          await (async () => {
+            const { Session } = await import("../../session")
+            await ensureProjectors()
+            return withDirectory(directory, async (ctx) =>
+              runServiceWithCurrentInstance(Session, ctx, (service) =>
+                service.fork({
+                  sessionID,
+                  ...(messageID ? { messageID } : {}),
+                }),
+              ),
+            )
+          })(),
+        ),
+      messages: async ({ sessionID, limit, directory }: any) =>
+        wrapData(
+          await (async () => {
+            const { Session } = await import("../../session")
+            return withDirectory(directory, async (ctx) =>
+              runServiceWithCurrentInstance(Session, ctx, (service) =>
+                service.messages({ sessionID, ...(limit ? { limit } : {}) }),
+              ),
+            )
+          })(),
+        ),
+      message: async ({ sessionID, messageID, directory }: any) =>
+        wrapData(
+          await (async () => {
+            const { MessageV2 } = await import("../../session/message-v2")
+            return withDirectory(directory, async () => MessageV2.get({ sessionID, messageID }))
+          })(),
+        ),
+      prompt: async ({ sessionID, directory, ...input }: any) =>
+        wrapData(
+          await (async () => {
+            const { SessionPrompt } = await import("../../session/prompt")
+            await ensureProjectors()
+            return withDirectory(directory, async (ctx) =>
+              runServiceWithCurrentInstance(SessionPrompt, ctx, (service) =>
+                service.prompt({ sessionID, ...input }),
+              ),
+            )
+          })(),
+        ),
+      command: async ({ sessionID, directory, ...input }: any) =>
+        wrapData(
+          await (async () => {
+            const { SessionPrompt } = await import("../../session/prompt")
+            await ensureProjectors()
+            return withDirectory(directory, async (ctx) =>
+              runServiceWithCurrentInstance(SessionPrompt, ctx, (service) =>
+                service.command({ sessionID, ...input }),
+              ),
+            )
+          })(),
+        ),
+      summarize: async ({ sessionID, directory, providerID, modelID, auto = false }: any) =>
+        wrapData(
+          await (async () => {
+            const [{ Session }, { SessionRevert }, { SessionCompaction }, { SessionPrompt }, { Agent }] =
+              await Promise.all([
+                import("../../session"),
+                import("../../session/revert"),
+                import("../../session/compaction"),
+                import("../../session/prompt"),
+                import("../../agent/agent"),
+              ])
+            await ensureProjectors()
+            return withDirectory(directory, async (ctx) => {
+              const session = await Session.get(sessionID)
+              await SessionRevert.cleanup(session)
+              const messages = await Session.messages({ sessionID })
+              let currentAgent = await Agent.defaultAgent()
+              for (let i = messages.length - 1; i >= 0; i--) {
+                const info = messages[i].info
+                if (info.role === "user") {
+                  currentAgent = info.agent || (await Agent.defaultAgent())
+                  break
+                }
+              }
+              await SessionCompaction.create({
+                sessionID,
+                agent: currentAgent,
+                model: { providerID, modelID },
+                auto,
+              })
+              await runServiceWithCurrentInstance(SessionPrompt, ctx, (service) =>
+                service.loop({ sessionID }),
+              )
+              return true
+            })
+          })(),
+        ),
+      abort: async ({ sessionID, directory }: any) =>
+        wrapData(
+          await (async () => {
+            const { SessionPrompt } = await import("../../session/prompt")
+            return withDirectory(directory, async (ctx) => {
+              await runServiceWithCurrentInstance(SessionPrompt, ctx, (service) =>
+                service.cancel(sessionID),
+              )
+              return true
+            })
+          })(),
+        ),
+    },
+  } as any
+}
+
+export const AcpCommand = cmd({
+  command: "acp",
+  describe: "start ACP (Agent Client Protocol) server",
+  builder: (yargs) => {
+    return withNetworkOptions(yargs).option("cwd", {
+      describe: "working directory",
+      type: "string",
+      default: process.cwd(),
+    })
+  },
+  handler: async (args: NetworkOptions) => {
+    process.env.OPENCODE_CLIENT = "acp"
+    process.env.OPENCODE_DISABLE_MODELS_FETCH = process.env.OPENCODE_DISABLE_MODELS_FETCH ?? "1"
+    process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS ?? "1"
+    const [{ ACP }] = await Promise.all([import("../../acp/agent")])
+
+    const log = Log.create({ service: "acp-command" })
+    console.error("[opencode-acp] bootstrap:entered")
+    console.error("[opencode-acp] network:resolve:start")
+    const opts = await resolveNetworkOptions(args)
+    console.error("[opencode-acp] network:resolve:done", JSON.stringify(opts))
+
+    console.error("[opencode-acp] sdk:create:start")
+    const sdk = createLocalSdk()
+    console.error("[opencode-acp] sdk:create:done")
+
+    console.error("[opencode-acp] streams:create:start")
+    const input = new WritableStream<Uint8Array>({
+      write(chunk) {
+        return new Promise<void>((resolve, reject) => {
+          process.stdout.write(chunk, (err) => {
+            if (err) {
+              reject(err)
+            } else {
+              resolve()
+            }
+          })
+        })
+      },
+    })
+    const output = new ReadableStream<Uint8Array>({
+      start(controller) {
+        process.stdin.on("data", (chunk: Buffer) => {
+          controller.enqueue(new Uint8Array(chunk))
+        })
+        process.stdin.on("end", () => controller.close())
+        process.stdin.on("error", (err) => controller.error(err))
+      },
+    })
+    console.error("[opencode-acp] streams:create:done")
+
+    console.error("[opencode-acp] ndjson:start")
+    const stream = ndJsonStream(input, output)
+    console.error("[opencode-acp] ndjson:done")
+    console.error("[opencode-acp] agent:init:start")
+    const agent = await ACP.init({ sdk })
+    console.error("[opencode-acp] agent:init:done")
+
+    console.error("[opencode-acp] connection:start")
+    new AgentSideConnection((conn) => {
+      return agent.create(conn, { sdk })
+    }, stream)
+    console.error("[opencode-acp] connection:done")
+
+    log.info("setup connection")
+    process.stdin.resume()
+    await new Promise((resolve, reject) => {
+      process.stdin.on("end", resolve)
+      process.stdin.on("error", reject)
+    })
+  },
+})
+`,
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/server/instance.ts",
+		(contents) =>
+			contents
+				.replace('import { TuiRoutes } from "./routes/tui"\n', "")
+				.replace('import { PtyRoutes } from "./routes/pty"\n', "")
+				.replace('    .route("/pty", PtyRoutes())\n', "")
+				.replace('    .route("/tui", TuiRoutes())\n', ""),
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/agent/agent.ts",
+		(contents) =>
+			contents.replace(
+				`                    [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]:
+                      "allow",`,
+				`                    [path.relative(ctx.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]:
+                      "allow",`,
+			),
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/shell/shell.ts",
+		(contents) => contents.replaceAll("Bun.which(", "which("),
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/server/server.ts",
+		(contents) =>
+			contents
+				.replace('import { MDNS } from "./mdns"\n', "")
+				.replace(
+					`    if (shouldPublishMDNS) {
+      MDNS.publish(server.port, opts.mdnsDomain)
+    } else if (opts.mdns) {`,
+					`    let mdns:
+      | {
+          publish(port: number, domain?: string): void
+          unpublish(): void
+        }
+      | undefined
+    if (shouldPublishMDNS) {
+      ;({ MDNS: mdns } = await import("./mdns"))
+      mdns.publish(server.port, opts.mdnsDomain)
+    } else if (opts.mdns) {`,
+				)
+				.replace(
+					"      if (shouldPublishMDNS) MDNS.unpublish()\n",
+					"      if (shouldPublishMDNS) mdns?.unpublish()\n",
+				),
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/project/bootstrap.ts",
+		(contents) =>
+			contents.replace(
+				`  Bus.subscribe(Command.Event.Executed, async (payload) => {
+    if (payload.properties.name === Command.Default.INIT) {
+      Project.setInitialized(Instance.project.id)
+    }
+  })
+`,
+				`  Log.Default.info("bootstrap step", { step: "bus.subscribe:skipped" })
+`,
+			),
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/acp/agent.ts",
+		(contents) =>
+			contents
+				.replaceAll(
+					`      console.error("[opencode-acp] agent.loadSessionMode:commands:done", directory, commands.length)
+`,
+					"",
+				)
+				.replace(
+					`          const defaultAgentName = await AgentModule.defaultAgent()
+          const resolvedModeId =
+            availableModes.find((mode) => mode.name === defaultAgentName)?.id ?? availableModes[0].id
+`,
+					`          const resolvedModeId = availableModes[0].id
+`,
+				)
+				.replace(
+					`        const model = await defaultModel(this.config, directory)
+`,
+					`        console.error("[opencode-acp] agent.newSession:defaultModel:start", directory)
+        const model = await defaultModel(this.config, directory)
+        console.error("[opencode-acp] agent.newSession:defaultModel:done", directory, model.providerID, model.modelID)
+`,
+				)
+				.replace(
+					`        const state = await this.sessionManager.create(params.cwd, params.mcpServers, model)
+`,
+					`        console.error("[opencode-acp] agent.newSession:sessionManager.create:start", directory)
+        const state = await this.sessionManager.create(params.cwd, params.mcpServers, model)
+        console.error("[opencode-acp] agent.newSession:sessionManager.create:done", directory, state.id)
+`,
+				)
+				.replace(
+					`        const load = await this.loadSessionMode({
+`,
+					`        console.error("[opencode-acp] agent.newSession:loadSessionMode:start", directory)
+        const load = await this.loadSessionMode({
+`,
+				)
+				.replace(
+					`      const providers = await this.sdk.config.providers({ directory }).then((x) => x.data!.providers)
+`,
+					`      console.error("[opencode-acp] agent.loadSessionMode:providers:start", directory)
+      const providers = await this.sdk.config.providers({ directory }).then((x) => x.data!.providers)
+      console.error("[opencode-acp] agent.loadSessionMode:providers:done", directory, providers.length)
+`,
+				)
+				.replace(
+					`      const modeState = await this.resolveModeState(directory, sessionId)
+`,
+					`      console.error("[opencode-acp] agent.loadSessionMode:resolveModeState:start", directory)
+      const modeState = await this.resolveModeState(directory, sessionId)
+      console.error("[opencode-acp] agent.loadSessionMode:resolveModeState:done", directory, modeState.availableModes.length)
+`,
+				)
+				.replace(
+					`      const commands = await this.config.sdk.command
+`,
+					`      console.error("[opencode-acp] agent.loadSessionMode:commands:start", directory)
+      const commands = await this.config.sdk.command
+`,
+				),
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/project/bootstrap.ts",
+		(contents) =>
+			contents.replace(
+				`  Log.Default.info("bootstrap step", { step: "snapshot.init:start" })
+  Snapshot.init()
+  Log.Default.info("bootstrap step", { step: "snapshot.init:done" })
+`,
+				`  Log.Default.info("bootstrap step", { step: "snapshot.init:skipped" })
+`,
+			),
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/util/filesystem.ts",
+		(contents) => {
+			if (contents.includes("cachedAgentOsGuestPathMappings")) {
+				return contents;
+			}
+
+			return contents
+				.replace(
+					'import { dirname, join, relative, resolve as pathResolve, win32 } from "path"\n',
+					`import { dirname, join, relative, resolve as pathResolve, win32 } from "path"
+
+type AgentOsGuestPathMapping = {
+  guestPath?: string
+  hostPath?: string
+}
+
+let cachedAgentOsGuestPathMappings:
+  | Array<{ guestPath: string; hostPath: string }>
+  | undefined
+
+function runtimeWindowsPath(p: string): string {
+  if (process.platform !== "win32") return p
+  return p
+    .replace(/^\\/([a-zA-Z]):(?:[\\\\/]|$)/, (_, drive) => \`\${drive.toUpperCase()}:/\`)
+    .replace(/^\\/([a-zA-Z])(?:\\/|$)/, (_, drive) => \`\${drive.toUpperCase()}:/\`)
+    .replace(/^\\/cygdrive\\/([a-zA-Z])(?:\\/|$)/, (_, drive) => \`\${drive.toUpperCase()}:/\`)
+    .replace(/^\\/mnt\\/([a-zA-Z])(?:\\/|$)/, (_, drive) => \`\${drive.toUpperCase()}:/\`)
+}
+
+function agentOsGuestPathMappings() {
+  if (cachedAgentOsGuestPathMappings) return cachedAgentOsGuestPathMappings
+  const raw = process.env.AGENT_OS_GUEST_PATH_MAPPINGS
+  if (!raw) {
+    cachedAgentOsGuestPathMappings = []
+    return cachedAgentOsGuestPathMappings
+  }
+
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) {
+      cachedAgentOsGuestPathMappings = []
+      return cachedAgentOsGuestPathMappings
+    }
+
+    cachedAgentOsGuestPathMappings = parsed
+      .filter(
+        (item): item is AgentOsGuestPathMapping =>
+          typeof item === "object" &&
+          item !== null &&
+          typeof item.guestPath === "string" &&
+          typeof item.hostPath === "string",
+      )
+      .map((item) => ({
+        guestPath: item.guestPath === "/" ? "/" : pathResolve(runtimeWindowsPath(item.guestPath)),
+        hostPath: pathResolve(runtimeWindowsPath(item.hostPath)),
+      }))
+      .sort((left, right) => right.guestPath.length - left.guestPath.length)
+    return cachedAgentOsGuestPathMappings
+  } catch {
+    cachedAgentOsGuestPathMappings = []
+    return cachedAgentOsGuestPathMappings
+  }
+}
+
+function runtimePath(p: string): string {
+  if (!p.startsWith("/")) return p
+
+  const normalized = pathResolve(runtimeWindowsPath(p))
+  for (const mapping of agentOsGuestPathMappings()) {
+    if (
+      mapping.guestPath !== "/" &&
+      normalized !== mapping.guestPath &&
+      !normalized.startsWith(\`\${mapping.guestPath}/\`)
+    ) {
+      continue
+    }
+
+    const suffix =
+      mapping.guestPath === "/"
+        ? normalized.slice(1)
+        : normalized.slice(mapping.guestPath.length).replace(/^[/\\\\]+/, "")
+    return suffix ? join(mapping.hostPath, suffix) : mapping.hostPath
+  }
+
+  return p
+}
+`,
+				)
+				.replace(
+					`    return existsSync(p)
+`,
+					`    return existsSync(runtimePath(p))
+`,
+				)
+				.replace(
+					`      return statSync(p).isDirectory()
+`,
+					`      return statSync(runtimePath(p)).isDirectory()
+`,
+				)
+				.replace(
+					`    return statSync(p, { throwIfNoEntry: false }) ?? undefined
+`,
+					`    return statSync(runtimePath(p), { throwIfNoEntry: false }) ?? undefined
+`,
+				)
+				.replace(
+					`    return statFile(p).catch((e) => {
+`,
+					`    return statFile(runtimePath(p)).catch((e) => {
+`,
+				)
+				.replace(
+					`    return readFile(p, "utf-8")
+`,
+					`    return readFile(runtimePath(p), "utf-8")
+`,
+				)
+				.replace(
+					`    return JSON.parse(await readFile(p, "utf-8"))
+`,
+					`    return JSON.parse(await readFile(runtimePath(p), "utf-8"))
+`,
+				)
+				.replace(
+					`    return readFile(p)
+`,
+					`    return readFile(runtimePath(p))
+`,
+				)
+				.replace(
+					`    const buf = await readFile(p)
+`,
+					`    const buf = await readFile(runtimePath(p))
+`,
+				)
+				.replace(
+					`    try {
+      if (mode) {
+        await writeFile(p, content, { mode })
+      } else {
+        await writeFile(p, content)
+      }
+    } catch (e) {
+      if (isEnoent(e)) {
+        await mkdir(dirname(p), { recursive: true })
+        if (mode) {
+          await writeFile(p, content, { mode })
+        } else {
+          await writeFile(p, content)
+        }
+        return
+      }
+      throw e
+    }
+`,
+					`    const target = runtimePath(p)
+    try {
+      if (mode) {
+        await writeFile(target, content, { mode })
+      } else {
+        await writeFile(target, content)
+      }
+    } catch (e) {
+      if (isEnoent(e)) {
+        await mkdir(dirname(target), { recursive: true })
+        if (mode) {
+          await writeFile(target, content, { mode })
+        } else {
+          await writeFile(target, content)
+        }
+        return
+      }
+      throw e
+    }
+`,
+				)
+				.replace(
+					`    const dir = dirname(p)
+`,
+					`    const target = runtimePath(p)
+    const dir = dirname(target)
+`,
+				)
+				.replace(
+					`    const writeStream = createWriteStream(p)
+`,
+					`    const writeStream = createWriteStream(target)
+`,
+				)
+				.replace(
+					`      await chmod(p, mode)
+`,
+					`      await chmod(target, mode)
+`,
+				);
+		},
+	);
+
+	for (const relativePath of [
+		"packages/opencode/src/cli/cmd/mcp.ts",
+		"packages/opencode/src/config/config.ts",
+		"packages/opencode/src/config/migrate-tui-config.ts",
+		"packages/opencode/src/config/paths.ts",
+		"packages/opencode/src/plugin/install.ts",
+	]) {
+		await rewriteSourceFile(sourceRoot, relativePath, (contents) =>
+			contents.replaceAll(
+				'"jsonc-parser"',
+				'"jsonc-parser/lib/esm/main.js"',
+			),
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/plugin/index.ts",
+		(contents) =>
+			contents.replace(
+				`  const state = Instance.state(async () => {
+    const client = createOpencodeClient({
+`,
+				`  const state = Instance.state(async () => {
+    if (Flag.OPENCODE_CLIENT === "acp") {
+      log.info("skipping plugin runtime in ACP mode")
+      return {
+        hooks: [],
+        input: {
+          client: undefined as any,
+          project: Instance.project,
+          worktree: Instance.worktree,
+          directory: Instance.directory,
+          serverUrl: "",
+          $: Bun.$,
+        } as PluginInput,
+      }
+    }
+
+    const client = createOpencodeClient({
+`,
+			),
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/session/index.ts",
+		(contents) =>
+			contents
+				.replace('import { SessionPrompt } from "./prompt"\n', "")
+				.replace('import { Command } from "../command"\n', "")
+				.replace(
+					`      const initialize = Effect.fn("Session.initialize")(function* (input: {
+        sessionID: SessionID
+        modelID: ModelID
+        providerID: ProviderID
+        messageID: MessageID
+      }) {
+        yield* Effect.promise(() =>
+          SessionPrompt.command({
+            sessionID: input.sessionID,
+            messageID: input.messageID,
+            model: input.providerID + "/" + input.modelID,
+            command: Command.Default.INIT,
+            arguments: "",
+          }),
+        )
+      })
+`,
+					`      const initialize = Effect.fn("Session.initialize")(function* (input: {
+        sessionID: SessionID
+        modelID: ModelID
+        providerID: ProviderID
+        messageID: MessageID
+      }) {
+        const [{ SessionPrompt }, { Command }] = yield* Effect.promise(() =>
+          Promise.all([import("./prompt"), import("../command")]),
+        )
+        yield* Effect.promise(() =>
+          SessionPrompt.command({
+            sessionID: input.sessionID,
+            messageID: input.messageID,
+            model: input.providerID + "/" + input.modelID,
+            command: Command.Default.INIT,
+            arguments: "",
+          }),
+        )
+      })
+`,
+			),
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/session/prompt.ts",
+		(contents) =>
+			contents
+				.replace(
+					/        const text = yield\* Effect\.promise\(async \(signal\) => \{\n[\s\S]*?          return result\.text\n        \}\)\n/,
+					`        const instanceCtx = yield* InstanceState.context
+        const text = yield* Effect.promise((signal) =>
+          Instance.restore(instanceCtx, async () => {
+            const mdl = ag.model
+              ? await Provider.getModel(ag.model.providerID, ag.model.modelID)
+              : ((await Provider.getSmallModel(input.providerID)) ??
+                (await Provider.getModel(input.providerID, input.modelID)))
+            const msgs = onlySubtasks
+              ? [{ role: "user" as const, content: subtasks.map((p) => p.prompt).join("\\n") }]
+              : await MessageV2.toModelMessages(context, mdl)
+            const result = await LLM.stream({
+              agent: ag,
+              user: firstInfo,
+              system: [],
+              small: true,
+              tools: {},
+              model: mdl,
+              abort: signal,
+              sessionID: input.session.id,
+              retries: 2,
+              messages: [{ role: "user", content: "Generate a title for this conversation:\\n" }, ...msgs],
+            })
+            return result.text
+          }),
+        )
+`,
+				)
+				.replace(
+					`      const getModel = (providerID: ProviderID, modelID: ModelID, sessionID: SessionID) =>
+        Effect.promise(() =>
+          Provider.getModel(providerID, modelID).catch((e) => {
+            if (Provider.ModelNotFoundError.isInstance(e)) {
+              const hint = e.data.suggestions?.length ? \` Did you mean: \${e.data.suggestions.join(", ")}?\` : ""
+              Bus.publish(Session.Event.Error, {
+                sessionID,
+                error: new NamedError.Unknown({
+                  message: \`Model not found: \${e.data.providerID}/\${e.data.modelID}.\${hint}\`,
+                }).toObject(),
+              })
+            }
+            throw e
+          }),
+        )
+`,
+					`      const getModel = (providerID: ProviderID, modelID: ModelID, sessionID: SessionID) =>
+        Effect.gen(function* () {
+          const instanceCtx = yield* InstanceState.context
+          return yield* Effect.promise(() =>
+            Instance.restore(instanceCtx, () =>
+              Provider.getModel(providerID, modelID).catch((e) => {
+                if (Provider.ModelNotFoundError.isInstance(e)) {
+                  const hint = e.data.suggestions?.length ? \` Did you mean: \${e.data.suggestions.join(", ")}?\` : ""
+                  Bus.publish(Session.Event.Error, {
+                    sessionID,
+                    error: new NamedError.Unknown({
+                      message: \`Model not found: \${e.data.providerID}/\${e.data.modelID}.\${hint}\`,
+                    }).toObject(),
+                  })
+                }
+                throw e
+              }),
+            ),
+          )
+        })
+`,
+				)
+				.replace(
+					`        const model = input.model ?? ag.model ?? (yield* lastModel(input.sessionID))
+        const full =
+          !input.variant && ag.variant
+            ? yield* Effect.promise(() => Provider.getModel(model.providerID, model.modelID).catch(() => undefined))
+            : undefined
+`,
+					`        const model = input.model ?? ag.model ?? (yield* lastModel(input.sessionID))
+        const instanceCtx = yield* InstanceState.context
+        const full =
+          !input.variant && ag.variant
+            ? yield* Effect.promise(() =>
+                Instance.restore(instanceCtx, () =>
+                  Provider.getModel(model.providerID, model.modelID).catch(() => undefined),
+                ),
+              )
+            : undefined
+`,
+				)
+				.replace(
+					`                      Effect.promise(() => Provider.getModel(info.model.providerID, info.model.modelID)).pipe(
+`,
+					`                      Effect.gen(function* () {
+                        const instanceCtx = yield* InstanceState.context
+                        return yield* Effect.promise(() =>
+                          Instance.restore(instanceCtx, () =>
+                            Provider.getModel(info.model.providerID, info.model.modelID),
+                          ),
+                        )
+                      }).pipe(
+`,
+				)
+				.replace(
+					`                const tools = yield* resolveTools({
+                  agent,
+                  session,
+                  model,
+                  tools: lastUser.tools,
+                  processor: handle,
+                  bypassAgentCheck,
+                  messages: msgs,
+                })
+`,
+					`                const tools = yield* resolveTools({
+                  agent,
+                  session,
+                  model,
+                  tools: lastUser.tools,
+                  processor: handle,
+                  bypassAgentCheck,
+                  messages: msgs,
+                })
+`,
+				)
+				.replace(
+					`                const [skills, env, instructions, modelMsgs] = yield* Effect.promise(() =>
+                  Promise.all([
+                    SystemPrompt.skills(agent),
+                    SystemPrompt.environment(model),
+                    InstructionPrompt.system(),
+                    MessageV2.toModelMessages(msgs, model),
+                  ]),
+                )
+`,
+					`                const instanceCtx = yield* InstanceState.context
+                const [skills, env, instructions, modelMsgs] = yield* Effect.promise(() =>
+                  Instance.restore(instanceCtx, () =>
+                    (async () => {
+                      console.error("[opencode-acp] prompt.system:skills:start", sessionID)
+                      const skills = await Instance.restore(instanceCtx, () => SystemPrompt.skills(agent))
+                      console.error("[opencode-acp] prompt.system:skills:done", sessionID)
+                      console.error("[opencode-acp] prompt.system:env:start", sessionID)
+                      const env = await Instance.restore(instanceCtx, () => SystemPrompt.environment(model))
+                      console.error("[opencode-acp] prompt.system:env:done", sessionID)
+                      console.error("[opencode-acp] prompt.system:instructions:start", sessionID)
+                      const instructions = await Instance.restore(instanceCtx, () => InstructionPrompt.system())
+                      console.error("[opencode-acp] prompt.system:instructions:done", sessionID)
+                      console.error("[opencode-acp] prompt.system:modelMessages:start", sessionID)
+                      const modelMsgs = await Instance.restore(instanceCtx, () =>
+                        MessageV2.toModelMessages(msgs, model),
+                      )
+                      console.error("[opencode-acp] prompt.system:modelMessages:done", sessionID)
+                      return [skills, env, instructions, modelMsgs] as const
+                    })(),
+                  ),
+                )
+`,
+				)
+				.replace(
+					`  const defaultLayer = Layer.unwrap(
+    Effect.sync(() =>
+      layer.pipe(
+        Layer.provide(SessionStatus.layer),
+        Layer.provide(SessionCompaction.defaultLayer),
+        Layer.provide(SessionProcessor.defaultLayer),
+        Layer.provide(Command.defaultLayer),
+        Layer.provide(Permission.layer),
+        Layer.provide(MCP.defaultLayer),
+        Layer.provide(LSP.defaultLayer),
+        Layer.provide(FileTime.defaultLayer),
+        Layer.provide(ToolRegistry.defaultLayer),
+        Layer.provide(Truncate.layer),
+        Layer.provide(AppFileSystem.defaultLayer),
+        Layer.provide(Plugin.defaultLayer),
+        Layer.provide(Session.defaultLayer),
+        Layer.provide(Agent.defaultLayer),
+        Layer.provide(Bus.layer),
+      ),
+    ),
+  )
+`,
+					`  export const defaultLayer = Layer.unwrap(
+    Effect.sync(() =>
+      layer.pipe(
+        Layer.provide(SessionStatus.layer),
+        Layer.provide(SessionCompaction.defaultLayer),
+        Layer.provide(SessionProcessor.defaultLayer),
+        Layer.provide(Command.defaultLayer),
+        Layer.provide(Permission.layer),
+        Layer.provide(MCP.defaultLayer),
+        Layer.provide(LSP.defaultLayer),
+        Layer.provide(FileTime.defaultLayer),
+        Layer.provide(ToolRegistry.defaultLayer),
+        Layer.provide(Truncate.layer),
+        Layer.provide(AppFileSystem.defaultLayer),
+        Layer.provide(Plugin.defaultLayer),
+        Layer.provide(Session.defaultLayer),
+        Layer.provide(Agent.defaultLayer),
+        Layer.provide(Bus.layer),
+      ),
+    ),
+  )
+`,
+				),
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/session/llm.ts",
+		(contents) => {
+			let updated = contents;
+			if (
+				!updated.includes(
+					'import { InstanceState } from "@/effect/instance-state"\n',
+				)
+			) {
+				updated = updated.replace(
+					'import { Installation } from "@/installation"\n',
+					'import { Installation } from "@/installation"\nimport { InstanceState } from "@/effect/instance-state"\n',
+				);
+			}
+			updated = updated
+				.replace(
+					`        stream(input) {
+          return Stream.scoped(
+            Stream.unwrap(
+              Effect.gen(function* () {
+                const ctrl = yield* Effect.acquireRelease(
+                  Effect.sync(() => new AbortController()),
+                  (ctrl) => Effect.sync(() => ctrl.abort()),
+                )
+
+                const result = yield* Effect.promise(() => LLM.stream({ ...input, abort: ctrl.signal }))
+
+                return Stream.fromAsyncIterable(result.fullStream, (e) =>
+                  e instanceof Error ? e : new Error(String(e)),
+                )
+              }),
+            ),
+          )
+        },
+`,
+					`        stream(input) {
+          return Stream.scoped(
+            Stream.unwrap(
+              Effect.gen(function* () {
+                const instanceCtx = yield* InstanceState.context
+                const ctrl = yield* Effect.acquireRelease(
+                  Effect.sync(() => new AbortController()),
+                  (ctrl) => Effect.sync(() => ctrl.abort()),
+                )
+
+                const result = yield* Effect.promise(() =>
+                  Instance.restore(instanceCtx, () => LLM.stream({ ...input, abort: ctrl.signal })),
+                )
+
+                return Stream.fromAsyncIterable(result.fullStream, (e) =>
+                  e instanceof Error ? e : new Error(String(e)),
+                )
+              }),
+            ),
+          )
+        },
+`,
+				)
+				.replace(
+					`    const [language, cfg, provider, auth] = await Promise.all([
+      Provider.getLanguage(input.model),
+      Config.get(),
+      Provider.getProvider(input.model.providerID),
+      Auth.get(input.model.providerID),
+    ])
+`,
+					`    const instanceCtx = Instance.current
+    const [language, cfg, provider, auth] = await Instance.restore(instanceCtx, () =>
+      Promise.all([
+        Provider.getLanguage(input.model),
+        Config.get(),
+        Provider.getProvider(input.model.providerID),
+        Auth.get(input.model.providerID),
+      ]),
+    )
+`,
+				)
+				.replace(
+					`    await Plugin.trigger(
+      "experimental.chat.system.transform",
+      { sessionID: input.sessionID, model: input.model },
+      { system },
+    )
+`,
+					`    await Instance.restore(instanceCtx, () =>
+      Plugin.trigger(
+        "experimental.chat.system.transform",
+        { sessionID: input.sessionID, model: input.model },
+        { system },
+      ),
+    )
+`,
+				)
+				.replace(
+					`    const params = await Plugin.trigger(
+      "chat.params",
+      {
+        sessionID: input.sessionID,
+        agent: input.agent.name,
+        model: input.model,
+        provider,
+        message: input.user,
+      },
+      {
+        temperature: input.model.capabilities.temperature
+          ? (input.agent.temperature ?? ProviderTransform.temperature(input.model))
+          : undefined,
+        topP: input.agent.topP ?? ProviderTransform.topP(input.model),
+        topK: ProviderTransform.topK(input.model),
+        options,
+      },
+    )
+`,
+					`    const params = await Instance.restore(instanceCtx, () =>
+      Plugin.trigger(
+        "chat.params",
+        {
+          sessionID: input.sessionID,
+          agent: input.agent.name,
+          model: input.model,
+          provider,
+          message: input.user,
+        },
+        {
+          temperature: input.model.capabilities.temperature
+            ? (input.agent.temperature ?? ProviderTransform.temperature(input.model))
+            : undefined,
+          topP: input.agent.topP ?? ProviderTransform.topP(input.model),
+          topK: ProviderTransform.topK(input.model),
+          options,
+        },
+      ),
+    )
+`,
+				)
+				.replace(
+					`    const { headers } = await Plugin.trigger(
+      "chat.headers",
+      {
+        sessionID: input.sessionID,
+        agent: input.agent.name,
+        model: input.model,
+        provider,
+        message: input.user,
+      },
+      {
+        headers: {},
+      },
+    )
+`,
+					`    const { headers } = await Instance.restore(instanceCtx, () =>
+      Plugin.trigger(
+        "chat.headers",
+        {
+          sessionID: input.sessionID,
+          agent: input.agent.name,
+          model: input.model,
+          provider,
+          message: input.user,
+        },
+        {
+          headers: {},
+        },
+      ),
+    )
+`,
+				)
+				.replace(
+					`    const tools = await resolveTools(input)
+`,
+					`    const tools = await Instance.restore(instanceCtx, () => resolveTools(input))
+`,
+				)
+				.replace(
+					`      headers: {
+        ...(input.model.providerID.startsWith("opencode")
+          ? {
+              "x-opencode-project": Instance.project.id,
+              "x-opencode-session": input.sessionID,
+              "x-opencode-request": input.user.id,
+              "x-opencode-client": Flag.OPENCODE_CLIENT,
+            }
+          : {
+              "User-Agent": \`opencode/\${Installation.VERSION}\`,
+            }),
+        ...input.model.headers,
+        ...headers,
+      },
+`,
+					`      headers: {
+        ...(input.model.providerID.startsWith("opencode")
+          ? Instance.restore(instanceCtx, () => ({
+              "x-opencode-project": Instance.project.id,
+              "x-opencode-session": input.sessionID,
+              "x-opencode-request": input.user.id,
+              "x-opencode-client": Flag.OPENCODE_CLIENT,
+            }))
+          : {
+              "User-Agent": \`opencode/\${Installation.VERSION}\`,
+            }),
+        ...input.model.headers,
+        ...headers,
+      },
+`,
+				)
+				.replace(
+					`    return streamText({
+`,
+					`    return Instance.restore(instanceCtx, () => streamText({
+`,
+				)
+				.replace(
+					`    })
+  }
+`,
+					`    }))
+  }
+`,
+				);
+			return updated;
+		},
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/session/prompt.ts",
+		(contents) =>
+			contents.replace(
+				`            execute(args, options) {
+              return Effect.runPromise(
+                Effect.gen(function* () {
+                  const ctx = context(args, options)
+                  yield* plugin.trigger(
+                    "tool.execute.before",
+                    { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID },
+                    { args },
+                  )
+                  const result = yield* Effect.promise(() => item.execute(args, ctx))
+                  const output = {
+                    ...result,
+                    attachments: result.attachments?.map((attachment) => ({
+                      ...attachment,
+                      id: PartID.ascending(),
+                      sessionID: ctx.sessionID,
+                      messageID: input.processor.message.id,
+                    })),
+                  }
+                  yield* plugin.trigger(
+                    "tool.execute.after",
+                    { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID, args },
+                    output,
+                  )
+                  return output
+                }),
+              )
+            },
+`,
+				`            execute(args, options) {
+              const instanceCtx =
+                ((globalThis as typeof globalThis & { __agentosOpencodeInstanceFallback?: unknown })
+                  .__agentosOpencodeInstanceFallback ??
+                  Instance.current) as any
+              return Instance.restore(instanceCtx, () =>
+                Effect.runPromise(
+                  Effect.gen(function* () {
+                    const ctx = context(args, options)
+                    yield* plugin.trigger(
+                      "tool.execute.before",
+                      { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID },
+                      { args },
+                    )
+                    const result = yield* Effect.promise(() => item.execute(args, ctx))
+                    const output = {
+                      ...result,
+                      attachments: result.attachments?.map((attachment) => ({
+                        ...attachment,
+                        id: PartID.ascending(),
+                        sessionID: ctx.sessionID,
+                        messageID: input.processor.message.id,
+                      })),
+                    }
+                    yield* plugin.trigger(
+                      "tool.execute.after",
+                      { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID, args },
+                      output,
+                    )
+                    return output
+                  }),
+                ),
+              )
+            },
+`,
+			),
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/session/instruction.ts",
+		(contents) =>
+			contents
+				.replace(
+					`async function resolveRelative(instruction: string): Promise<string[]> {
+  if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
+    return Filesystem.globUp(instruction, Instance.directory, Instance.worktree).catch(() => [])
+  }
+  if (!Flag.OPENCODE_CONFIG_DIR) {
+    log.warn(
+      \`Skipping relative instruction "\${instruction}" - no OPENCODE_CONFIG_DIR set while project config is disabled\`,
+    )
+    return []
+  }
+  return Filesystem.globUp(instruction, Flag.OPENCODE_CONFIG_DIR, Flag.OPENCODE_CONFIG_DIR).catch(() => [])
+}
+`,
+					`async function resolveRelative(instruction: string): Promise<string[]> {
+  const ctx = Instance.current
+  if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
+    return Instance.restore(ctx, () =>
+      Filesystem.globUp(instruction, ctx.directory, ctx.worktree).catch(() => []),
+    )
+  }
+  if (!Flag.OPENCODE_CONFIG_DIR) {
+    log.warn(
+      \`Skipping relative instruction "\${instruction}" - no OPENCODE_CONFIG_DIR set while project config is disabled\`,
+    )
+    return []
+  }
+  return Filesystem.globUp(instruction, Flag.OPENCODE_CONFIG_DIR, Flag.OPENCODE_CONFIG_DIR).catch(() => [])
+}
+`,
+				)
+				.replace(
+					`  export async function systemPaths() {
+    const config = await Config.get()
+`,
+					`  export async function systemPaths() {
+    const ctx = Instance.current
+    const config = await Instance.restore(ctx, () => Config.get())
+`,
+				)
+				.replace(
+					`        const matches = await Filesystem.findUp(file, Instance.directory, Instance.worktree)
+`,
+					`        const matches = await Instance.restore(ctx, () =>
+          Filesystem.findUp(file, ctx.directory, ctx.worktree),
+        )
+`,
+				)
+				.replace(
+					`          : await resolveRelative(instruction)
+`,
+					`          : await Instance.restore(ctx, () => resolveRelative(instruction))
+`,
+				)
+				.replace(
+					`  export async function system() {
+    const config = await Config.get()
+    const paths = await systemPaths()
+`,
+					`  export async function system() {
+    const ctx = Instance.current
+    const config = await Instance.restore(ctx, () => Config.get())
+    const paths = await Instance.restore(ctx, () => systemPaths())
+`,
+				)
+				.replace(
+					`  export async function resolve(messages: MessageV2.WithParts[], filepath: string, messageID: string) {
+    const system = await systemPaths()
+    const already = loaded(messages)
+    const results: { filepath: string; content: string }[] = []
+
+    const target = path.resolve(filepath)
+    let current = path.dirname(target)
+    const root = path.resolve(Instance.directory)
+`,
+					`  export async function resolve(messages: MessageV2.WithParts[], filepath: string, messageID: string) {
+    const ctx = Instance.current
+    const system = await Instance.restore(ctx, () => systemPaths())
+    const already = loaded(messages)
+    const results: { filepath: string; content: string }[] = []
+
+    const target = path.resolve(filepath)
+    let current = path.dirname(target)
+    const root = path.resolve(ctx.directory)
+`,
+				),
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/provider/provider.ts",
+		(contents) =>
+			contents
+				.replace(
+					'import { Config } from "../config/config"\n',
+					'import { Config } from "../config/config"\nimport { Instance } from "../project/instance"\n',
+				)
+				.replace(
+					`  async function loadProviders() {
+    const cfg = await Config.get()
+`,
+					`  async function loadProviders() {
+    const ctx = Instance.current
+    const cfg = await Instance.restore(ctx, () => Config.get())
+`,
+				)
+				.replace(
+					`  export async function defaultModel() {
+    const cfg = await Config.get()
+`,
+					`  export async function defaultModel() {
+    const ctx = Instance.current
+    const cfg = await Instance.restore(ctx, () => Config.get())
+`,
+				)
+				.replace(
+					`    const providers = await loadProviders()
+    for (const provider of Object.values(providers)) {
+`,
+					`    const providers = await Instance.restore(ctx, () => loadProviders())
+    for (const provider of Object.values(providers)) {
+`,
+				),
+		);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/effect/instance-state.ts",
+		(contents) =>
+			contents.replace(
+				`    const fiber = Fiber.getCurrent()
+    const ctx = fiber ? ServiceMap.getReferenceUnsafe(fiber.services, InstanceRef) : undefined
+    if (!ctx) return fn
+    return ((...args: any[]) => Instance.restore(ctx, () => fn(...args))) as F
+`,
+				`    const fiber = Fiber.getCurrent()
+    const ctx = fiber ? ServiceMap.getReferenceUnsafe(fiber.services, InstanceRef) : undefined
+    const fallback = (globalThis as typeof globalThis & { __agentosOpencodeInstanceFallback?: unknown })
+      .__agentosOpencodeInstanceFallback as typeof ctx
+    const boundCtx = ctx ?? fallback
+    if (!boundCtx) return fn
+    return ((...args: any[]) => Instance.restore(boundCtx, () => fn(...args))) as F
+`,
+			).replace(
+				`  export const context = Effect.fnUntraced(function* () {
+    return (yield* InstanceRef) ?? Instance.current
+  })()
+`,
+				`  export const context = Effect.fnUntraced(function* () {
+    const ref = yield* InstanceRef
+    if (ref) return ref
+    const fallback = (globalThis as typeof globalThis & { __agentosOpencodeInstanceFallback?: unknown })
+      .__agentosOpencodeInstanceFallback
+    if (fallback) return fallback as typeof ref
+    try {
+      return Instance.current
+    } catch (error) {
+      console.error("[opencode-acp] missing-instance-context", new Error().stack)
+      throw error
+    }
+  })()
+`,
+			),
+	);
+
+	await writeFile(
+		resolve(sourceRoot, "packages/opencode/src/effect/run-service.ts"),
+		`import { Effect, Layer, ManagedRuntime } from "effect"
+import * as ServiceMap from "effect/ServiceMap"
+import { Instance } from "@/project/instance"
+import { Context } from "@/util/context"
+import { InstanceRef } from "./instance-ref"
+
+export const memoMap = Layer.makeMemoMapUnsafe()
+
+function attach<A, E, R>(effect: Effect.Effect<A, E, R>) {
+  try {
+    const ctx = Instance.current
+    return {
+      ctx,
+      effect: Effect.provideService(effect, InstanceRef, ctx),
+    }
+  } catch (err) {
+    if (!(err instanceof Context.NotFound)) throw err
+  }
+  return { ctx: undefined, effect }
+}
+
+export function makeRuntime<I, S, E>(service: ServiceMap.Service<I, S>, layer: Layer.Layer<I, E>) {
+  let rt: ManagedRuntime.ManagedRuntime<I, E> | undefined
+  const getRuntime = () => (rt ??= ManagedRuntime.make(layer, { memoMap }))
+
+  return {
+    runSync: <A, Err>(fn: (svc: S) => Effect.Effect<A, Err, I>) => {
+      const attached = attach(service.use(fn))
+      return attached.ctx
+        ? Instance.restore(attached.ctx, () => getRuntime().runSync(attached.effect))
+        : getRuntime().runSync(attached.effect)
+    },
+    runPromiseExit: <A, Err>(fn: (svc: S) => Effect.Effect<A, Err, I>, options?: Effect.RunOptions) => {
+      const attached = attach(service.use(fn))
+      return attached.ctx
+        ? Instance.restore(attached.ctx, () => getRuntime().runPromiseExit(attached.effect, options))
+        : getRuntime().runPromiseExit(attached.effect, options)
+    },
+    runPromise: <A, Err>(fn: (svc: S) => Effect.Effect<A, Err, I>, options?: Effect.RunOptions) => {
+      const attached = attach(service.use(fn))
+      return attached.ctx
+        ? Instance.restore(attached.ctx, () => getRuntime().runPromise(attached.effect, options))
+        : getRuntime().runPromise(attached.effect, options)
+    },
+    runFork: <A, Err>(fn: (svc: S) => Effect.Effect<A, Err, I>) => {
+      const attached = attach(service.use(fn))
+      return attached.ctx
+        ? Instance.restore(attached.ctx, () => getRuntime().runFork(attached.effect))
+        : getRuntime().runFork(attached.effect)
+    },
+    runCallback: <A, Err>(fn: (svc: S) => Effect.Effect<A, Err, I>) => {
+      const attached = attach(service.use(fn))
+      return attached.ctx
+        ? Instance.restore(attached.ctx, () => getRuntime().runCallback(attached.effect))
+        : getRuntime().runCallback(attached.effect)
+    },
+  }
+}
+`,
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/tool/tool.ts",
+		(contents) =>
+			contents
+				.replace(
+					'import { Truncate } from "./truncate"\n',
+					'import { Truncate } from "./truncate"\nimport { InstanceState } from "@/effect/instance-state"\n',
+				)
+				.replace(
+					`        const toolInfo = init instanceof Function ? await init(initCtx) : init
+        const execute = toolInfo.execute
+        toolInfo.execute = async (args, ctx) => {
+`,
+					`        const toolInfo =
+          init instanceof Function ? await InstanceState.bind(() => init(initCtx))() : init
+        const execute = toolInfo.execute
+        toolInfo.execute = InstanceState.bind(async (args, ctx) => {
+`,
+				)
+				.replace(
+					`        }
+        return toolInfo
+`,
+					`        })
+        return toolInfo
+`,
+				),
+		);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/storage/db.ts",
+		(contents) =>
+			contents.replace(
+				`    db.run("PRAGMA journal_mode = WAL")
+    db.run("PRAGMA synchronous = NORMAL")
+    db.run("PRAGMA busy_timeout = 5000")
+    db.run("PRAGMA cache_size = -64000")
+    db.run("PRAGMA foreign_keys = ON")
+    db.run("PRAGMA wal_checkpoint(PASSIVE)")`,
+				`    db.$client.exec("PRAGMA journal_mode = WAL")
+    db.$client.exec("PRAGMA synchronous = NORMAL")
+    db.$client.exec("PRAGMA busy_timeout = 5000")
+    db.$client.exec("PRAGMA cache_size = -64000")
+    db.$client.exec("PRAGMA foreign_keys = ON")
+    db.$client.exec("PRAGMA wal_checkpoint(PASSIVE)")`,
+			),
+	);
+}
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/provider/provider.ts",
+		(contents) =>
+			contents
+				.replace(
+					`// Direct imports for bundled providers
+import { createAmazonBedrock, type AmazonBedrockProviderSettings } from "@ai-sdk/amazon-bedrock"
+import { createAnthropic } from "@ai-sdk/anthropic"
+import { createAzure } from "@ai-sdk/azure"
+import { createGoogleGenerativeAI } from "@ai-sdk/google"
+import { createVertex } from "@ai-sdk/google-vertex"
+import { createVertexAnthropic } from "@ai-sdk/google-vertex/anthropic"
+import { createOpenAI } from "@ai-sdk/openai"
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
+import { createOpenRouter, type LanguageModelV2 } from "@openrouter/ai-sdk-provider"
+import { createOpenaiCompatible as createGitHubCopilotOpenAICompatible } from "./sdk/openai-compatible/src"
+import { createXai } from "@ai-sdk/xai"
+import { createMistral } from "@ai-sdk/mistral"
+import { createGroq } from "@ai-sdk/groq"
+import { createDeepInfra } from "@ai-sdk/deepinfra"
+import { createCerebras } from "@ai-sdk/cerebras"
+import { createCohere } from "@ai-sdk/cohere"
+import { createGateway } from "@ai-sdk/gateway"
+import { createTogetherAI } from "@ai-sdk/togetherai"
+import { createPerplexity } from "@ai-sdk/perplexity"
+import { createVercel } from "@ai-sdk/vercel"
+import { createGitLab } from "@gitlab/gitlab-ai-provider"
+import { ProviderTransform } from "./transform"
+`,
+					`import type { LanguageModelV2 } from "@openrouter/ai-sdk-provider"
+import { ProviderTransform } from "./transform"
+`,
+				)
+				.replace(
+					`  const BUNDLED_PROVIDERS: Record<string, (options: any) => SDK> = {
+    "@ai-sdk/amazon-bedrock": createAmazonBedrock,
+    "@ai-sdk/anthropic": createAnthropic,
+    "@ai-sdk/azure": createAzure,
+    "@ai-sdk/google": createGoogleGenerativeAI,
+    "@ai-sdk/google-vertex": createVertex,
+    "@ai-sdk/google-vertex/anthropic": createVertexAnthropic,
+    "@ai-sdk/openai": createOpenAI,
+    "@ai-sdk/openai-compatible": createOpenAICompatible,
+    "@openrouter/ai-sdk-provider": createOpenRouter,
+    "@ai-sdk/xai": createXai,
+    "@ai-sdk/mistral": createMistral,
+    "@ai-sdk/groq": createGroq,
+    "@ai-sdk/deepinfra": createDeepInfra,
+    "@ai-sdk/cerebras": createCerebras,
+    "@ai-sdk/cohere": createCohere,
+    "@ai-sdk/gateway": createGateway,
+    "@ai-sdk/togetherai": createTogetherAI,
+    "@ai-sdk/perplexity": createPerplexity,
+    "@ai-sdk/vercel": createVercel,
+    "@gitlab/gitlab-ai-provider": createGitLab,
+    // @ts-ignore (TODO: kill this code so we dont have to maintain it)
+    "@ai-sdk/github-copilot": createGitHubCopilotOpenAICompatible,
+  }
+`,
+					`  const BUNDLED_PROVIDERS: Record<string, (options: any) => Promise<SDK>> = {
+    "@ai-sdk/amazon-bedrock": async (options) =>
+      (await import("@ai-sdk/amazon-bedrock")).createAmazonBedrock(options),
+    "@ai-sdk/anthropic": async (options) => (await import("@ai-sdk/anthropic")).createAnthropic(options),
+    "@ai-sdk/azure": async (options) => (await import("@ai-sdk/azure")).createAzure(options),
+    "@ai-sdk/google": async (options) => (await import("@ai-sdk/google")).createGoogleGenerativeAI(options),
+    "@ai-sdk/google-vertex": async (options) => (await import("@ai-sdk/google-vertex")).createVertex(options),
+    "@ai-sdk/google-vertex/anthropic": async (options) =>
+      (await import("@ai-sdk/google-vertex/anthropic")).createVertexAnthropic(options),
+    "@ai-sdk/openai": async (options) => (await import("@ai-sdk/openai")).createOpenAI(options),
+    "@ai-sdk/openai-compatible": async (options) =>
+      (await import("@ai-sdk/openai-compatible")).createOpenAICompatible(options),
+    "@openrouter/ai-sdk-provider": async (options) =>
+      (await import("@openrouter/ai-sdk-provider")).createOpenRouter(options),
+    "@ai-sdk/xai": async (options) => (await import("@ai-sdk/xai")).createXai(options),
+    "@ai-sdk/mistral": async (options) => (await import("@ai-sdk/mistral")).createMistral(options),
+    "@ai-sdk/groq": async (options) => (await import("@ai-sdk/groq")).createGroq(options),
+    "@ai-sdk/deepinfra": async (options) => (await import("@ai-sdk/deepinfra")).createDeepInfra(options),
+    "@ai-sdk/cerebras": async (options) => (await import("@ai-sdk/cerebras")).createCerebras(options),
+    "@ai-sdk/cohere": async (options) => (await import("@ai-sdk/cohere")).createCohere(options),
+    "@ai-sdk/gateway": async (options) => (await import("@ai-sdk/gateway")).createGateway(options),
+    "@ai-sdk/togetherai": async (options) => (await import("@ai-sdk/togetherai")).createTogetherAI(options),
+    "@ai-sdk/perplexity": async (options) => (await import("@ai-sdk/perplexity")).createPerplexity(options),
+    "@ai-sdk/vercel": async (options) => (await import("@ai-sdk/vercel")).createVercel(options),
+    "@gitlab/gitlab-ai-provider": async (options) =>
+      (await import("@gitlab/gitlab-ai-provider")).createGitLab(options),
+    "@ai-sdk/github-copilot": async (options) =>
+      (await import("./sdk/openai-compatible/src")).createOpenaiCompatible(options),
+  }
+`,
+				)
+				.replace(
+					"        async getModel(sdk: ReturnType<typeof createGitLab>, modelID: string) {\n",
+					"        async getModel(sdk: any, modelID: string) {\n",
+				)
+				.replace(
+					`        const loaded = bundledFn({
+          name: model.providerID,
+          ...options,
+        })
+`,
+					`        const loaded = await bundledFn({
+          name: model.providerID,
+          ...options,
+        })
+`,
+				),
+	);
+
+	await writeFile(
+		resolve(sourceRoot, "packages/opencode/src/provider/provider.ts"),
+		`import z from "zod"
+import { createAnthropic } from "@ai-sdk/anthropic"
+import { createGoogleGenerativeAI } from "@ai-sdk/google"
+import { createVertex } from "@ai-sdk/google-vertex"
+import { createVertexAnthropic } from "@ai-sdk/google-vertex/anthropic"
+import { createGroq } from "@ai-sdk/groq"
+import { createMistral } from "@ai-sdk/mistral"
+import { createOpenAI } from "@ai-sdk/openai"
+import type { LanguageModelV3 } from "@ai-sdk/provider"
+import { NamedError } from "@opencode-ai/util/error"
+import { Config } from "../config/config"
+import { ModelID, ProviderID } from "./schema"
+
+type ProviderConfig = {
+  name?: string
+  env?: string[]
+  npm?: string
+  api?: string
+  options?: Record<string, any>
+  models?: Record<string, any>
+}
+
+type ProviderSeed = {
+  name: string
+  env: string[]
+  npm: string
+  models: Array<{
+    id: string
+    name: string
+    family?: string
+    reasoning?: boolean
+    attachment?: boolean
+    input?: Partial<{ text: boolean; audio: boolean; image: boolean; video: boolean; pdf: boolean }>
+    output?: Partial<{ text: boolean; audio: boolean; image: boolean; video: boolean; pdf: boolean }>
+    limit?: Partial<{ context: number; input: number; output: number }>
+    cost?: Partial<{
+      input: number
+      output: number
+      cache: Partial<{ read: number; write: number }>
+    }>
+    releaseDate?: string
+  }>
+}
+
+export namespace Provider {
+  export const Model = z
+    .object({
+      id: ModelID.zod,
+      providerID: ProviderID.zod,
+      api: z.object({
+        id: z.string(),
+        url: z.string(),
+        npm: z.string(),
+      }),
+      name: z.string(),
+      family: z.string().optional(),
+      capabilities: z.object({
+        temperature: z.boolean(),
+        reasoning: z.boolean(),
+        attachment: z.boolean(),
+        toolcall: z.boolean(),
+        input: z.object({
+          text: z.boolean(),
+          audio: z.boolean(),
+          image: z.boolean(),
+          video: z.boolean(),
+          pdf: z.boolean(),
+        }),
+        output: z.object({
+          text: z.boolean(),
+          audio: z.boolean(),
+          image: z.boolean(),
+          video: z.boolean(),
+          pdf: z.boolean(),
+        }),
+        interleaved: z.union([
+          z.boolean(),
+          z.object({
+            field: z.enum(["reasoning_content", "reasoning_details"]),
+          }),
+        ]),
+      }),
+      cost: z.object({
+        input: z.number(),
+        output: z.number(),
+        cache: z.object({
+          read: z.number(),
+          write: z.number(),
+        }),
+        experimentalOver200K: z
+          .object({
+            input: z.number(),
+            output: z.number(),
+            cache: z.object({
+              read: z.number(),
+              write: z.number(),
+            }),
+          })
+          .optional(),
+      }),
+      limit: z.object({
+        context: z.number(),
+        input: z.number().optional(),
+        output: z.number(),
+      }),
+      status: z.enum(["alpha", "beta", "deprecated", "active"]),
+      options: z.record(z.string(), z.any()),
+      headers: z.record(z.string(), z.string()),
+      release_date: z.string(),
+      variants: z.record(z.string(), z.record(z.string(), z.any())).optional(),
+    })
+    .meta({
+      ref: "Model",
+    })
+  export type Model = z.infer<typeof Model>
+
+  export const Info = z
+    .object({
+      id: ProviderID.zod,
+      name: z.string(),
+      source: z.enum(["env", "config", "custom", "api"]),
+      env: z.string().array(),
+      key: z.string().optional(),
+      options: z.record(z.string(), z.any()),
+      models: z.record(z.string(), Model),
+    })
+    .meta({
+      ref: "Provider",
+    })
+  export type Info = z.infer<typeof Info>
+
+  const DEFAULT_CONTEXT_LIMIT = 200_000
+  const DEFAULT_OUTPUT_LIMIT = 32_000
+
+  const PROVIDER_SEEDS: Record<string, ProviderSeed> = {
+    anthropic: {
+      name: "Anthropic",
+      env: ["ANTHROPIC_API_KEY"],
+      npm: "@ai-sdk/anthropic",
+      models: [
+        {
+          id: "claude-sonnet-4-20250514",
+          name: "Claude Sonnet 4",
+          family: "claude-sonnet-4",
+          reasoning: true,
+          attachment: true,
+          input: { image: true, pdf: true },
+          releaseDate: "2025-05-14",
+        },
+        {
+          id: "claude-opus-4-1-20250805",
+          name: "Claude Opus 4.1",
+          family: "claude-opus-4-1",
+          reasoning: true,
+          attachment: true,
+          input: { image: true, pdf: true },
+          releaseDate: "2025-08-05",
+        },
+        {
+          id: "claude-haiku-4-5-20251001",
+          name: "Claude Haiku 4.5",
+          family: "claude-haiku-4-5",
+          reasoning: false,
+          attachment: true,
+          input: { image: true, pdf: true },
+          limit: { output: 16_000 },
+          releaseDate: "2025-10-01",
+        },
+      ],
+    },
+    openai: {
+      name: "OpenAI",
+      env: ["OPENAI_API_KEY"],
+      npm: "@ai-sdk/openai",
+      models: [
+        {
+          id: "gpt-5",
+          name: "GPT-5",
+          family: "gpt-5",
+          reasoning: true,
+          attachment: true,
+          input: { image: true, pdf: true },
+          releaseDate: "2025-01-01",
+        },
+        {
+          id: "gpt-5-mini",
+          name: "GPT-5 Mini",
+          family: "gpt-5-mini",
+          reasoning: true,
+          attachment: true,
+          input: { image: true, pdf: true },
+          limit: { output: 16_000 },
+          releaseDate: "2025-01-01",
+        },
+        {
+          id: "gpt-5-nano",
+          name: "GPT-5 Nano",
+          family: "gpt-5-nano",
+          reasoning: false,
+          attachment: true,
+          input: { image: true, pdf: true },
+          limit: { output: 8_000 },
+          releaseDate: "2025-01-01",
+        },
+      ],
+    },
+    google: {
+      name: "Google",
+      env: ["GOOGLE_GENERATIVE_AI_API_KEY"],
+      npm: "@ai-sdk/google",
+      models: [
+        {
+          id: "gemini-2.5-pro",
+          name: "Gemini 2.5 Pro",
+          family: "gemini-2.5-pro",
+          reasoning: true,
+          attachment: true,
+          input: { image: true, pdf: true },
+          releaseDate: "2025-01-01",
+        },
+        {
+          id: "gemini-2.5-flash",
+          name: "Gemini 2.5 Flash",
+          family: "gemini-2.5-flash",
+          reasoning: true,
+          attachment: true,
+          input: { image: true, pdf: true },
+          limit: { output: 16_000 },
+          releaseDate: "2025-01-01",
+        },
+      ],
+    },
+    "google-vertex": {
+      name: "Google Vertex",
+      env: [],
+      npm: "@ai-sdk/google-vertex",
+      models: [
+        {
+          id: "gemini-2.5-pro",
+          name: "Gemini 2.5 Pro",
+          family: "gemini-2.5-pro",
+          reasoning: true,
+          attachment: true,
+          input: { image: true, pdf: true },
+          releaseDate: "2025-01-01",
+        },
+      ],
+    },
+    groq: {
+      name: "Groq",
+      env: ["GROQ_API_KEY"],
+      npm: "@ai-sdk/groq",
+      models: [
+        {
+          id: "llama-3.3-70b-versatile",
+          name: "Llama 3.3 70B Versatile",
+          family: "llama-3.3-70b",
+          reasoning: true,
+          releaseDate: "2025-01-01",
+        },
+      ],
+    },
+    mistral: {
+      name: "Mistral",
+      env: ["MISTRAL_API_KEY"],
+      npm: "@ai-sdk/mistral",
+      models: [
+        {
+          id: "mistral-small-latest",
+          name: "Mistral Small Latest",
+          family: "mistral-small",
+          reasoning: true,
+          attachment: true,
+          input: { image: true, pdf: true },
+          releaseDate: "2025-01-01",
+        },
+      ],
+    },
+  }
+
+  const providerCache = new Map<string, any>()
+  const languageCache = new Map<string, LanguageModelV3>()
+  const SDK_FACTORIES: Record<string, (options: Record<string, any>) => any> = {
+    "@ai-sdk/anthropic": createAnthropic,
+    "@ai-sdk/google": createGoogleGenerativeAI,
+    "@ai-sdk/google-vertex": createVertex,
+    "@ai-sdk/google-vertex/anthropic": createVertexAnthropic,
+    "@ai-sdk/groq": createGroq,
+    "@ai-sdk/mistral": createMistral,
+    "@ai-sdk/openai": createOpenAI,
+  }
+  const priority = ["gpt-5", "claude-sonnet-4", "big-pickle", "gemini-3-pro"]
+
+  function firstEnv(names: string[]) {
+    for (const name of names) {
+      const value = process.env[name]
+      if (typeof value === "string" && value.length > 0) {
+        return value
+      }
+    }
+    return undefined
+  }
+
+  function cloneRecord<T extends Record<string, any>>(value: T | undefined): T {
+    return { ...(value ?? ({} as T)) }
+  }
+
+  function buildModel(
+    providerID: ProviderID,
+    seed: ProviderSeed,
+    input: {
+      id: string
+      name?: string
+      family?: string
+      reasoning?: boolean
+      attachment?: boolean
+      toolCall?: boolean
+      status?: "alpha" | "beta" | "deprecated" | "active"
+      input?: Partial<{ text: boolean; audio: boolean; image: boolean; video: boolean; pdf: boolean }>
+      output?: Partial<{ text: boolean; audio: boolean; image: boolean; video: boolean; pdf: boolean }>
+      limit?: Partial<{ context: number; input: number; output: number }>
+      cost?: Partial<{
+        input: number
+        output: number
+        cache: Partial<{ read: number; write: number }>
+      }>
+      headers?: Record<string, string>
+      options?: Record<string, any>
+      api?: {
+        id?: string
+        url?: string
+        npm?: string
+      }
+      releaseDate?: string
+      variants?: Record<string, Record<string, any>>
+    },
+  ): Model {
+    return {
+      id: ModelID.make(input.id),
+      providerID,
+      api: {
+        id: input.api?.id ?? input.id,
+        url: input.api?.url ?? "",
+        npm: input.api?.npm ?? seed.npm,
+      },
+      name: input.name ?? input.id,
+      family: input.family,
+      capabilities: {
+        temperature: true,
+        reasoning: input.reasoning ?? false,
+        attachment: input.attachment ?? false,
+        toolcall: input.toolCall ?? true,
+        input: {
+          text: input.input?.text ?? true,
+          audio: input.input?.audio ?? false,
+          image: input.input?.image ?? false,
+          video: input.input?.video ?? false,
+          pdf: input.input?.pdf ?? false,
+        },
+        output: {
+          text: input.output?.text ?? true,
+          audio: input.output?.audio ?? false,
+          image: input.output?.image ?? false,
+          video: input.output?.video ?? false,
+          pdf: input.output?.pdf ?? false,
+        },
+        interleaved: false,
+      },
+      cost: {
+        input: input.cost?.input ?? 0,
+        output: input.cost?.output ?? 0,
+        cache: {
+          read: input.cost?.cache?.read ?? 0,
+          write: input.cost?.cache?.write ?? 0,
+        },
+      },
+      limit: {
+        context: input.limit?.context ?? DEFAULT_CONTEXT_LIMIT,
+        ...(input.limit?.input !== undefined ? { input: input.limit.input } : {}),
+        output: input.limit?.output ?? DEFAULT_OUTPUT_LIMIT,
+      },
+      status: input.status ?? "active",
+      options: cloneRecord(input.options),
+      headers: cloneRecord(input.headers),
+      release_date: input.releaseDate ?? "2025-01-01",
+      variants: input.variants ?? {},
+    }
+  }
+
+  function buildSeedModels(providerID: ProviderID, seed: ProviderSeed) {
+    return Object.fromEntries(
+      seed.models.map((model) => [model.id, buildModel(providerID, seed, model)]),
+    ) as Record<string, Model>
+  }
+
+  function applyConfiguredModels(
+    providerID: ProviderID,
+    seed: ProviderSeed,
+    provider: Info,
+    configuredProvider: ProviderConfig | undefined,
+  ) {
+    for (const [modelID, raw] of Object.entries(configuredProvider?.models ?? {})) {
+      const existing = provider.models[modelID]
+      provider.models[modelID] = buildModel(providerID, seed, {
+        id: modelID,
+        name: raw?.name ?? existing?.name ?? modelID,
+        family: raw?.family ?? existing?.family,
+        reasoning: raw?.reasoning ?? existing?.capabilities.reasoning ?? false,
+        attachment: raw?.attachment ?? existing?.capabilities.attachment ?? false,
+        toolCall: raw?.tool_call ?? existing?.capabilities.toolcall ?? true,
+        status: raw?.status ?? existing?.status ?? "active",
+        input: {
+          text: raw?.modalities?.input?.includes("text") ?? existing?.capabilities.input.text ?? true,
+          audio: raw?.modalities?.input?.includes("audio") ?? existing?.capabilities.input.audio ?? false,
+          image: raw?.modalities?.input?.includes("image") ?? existing?.capabilities.input.image ?? false,
+          video: raw?.modalities?.input?.includes("video") ?? existing?.capabilities.input.video ?? false,
+          pdf: raw?.modalities?.input?.includes("pdf") ?? existing?.capabilities.input.pdf ?? false,
+        },
+        output: {
+          text: raw?.modalities?.output?.includes("text") ?? existing?.capabilities.output.text ?? true,
+          audio: raw?.modalities?.output?.includes("audio") ?? existing?.capabilities.output.audio ?? false,
+          image: raw?.modalities?.output?.includes("image") ?? existing?.capabilities.output.image ?? false,
+          video: raw?.modalities?.output?.includes("video") ?? existing?.capabilities.output.video ?? false,
+          pdf: raw?.modalities?.output?.includes("pdf") ?? existing?.capabilities.output.pdf ?? false,
+        },
+        limit: {
+          context: raw?.limit?.context ?? existing?.limit.context,
+          input: raw?.limit?.input ?? existing?.limit.input,
+          output: raw?.limit?.output ?? existing?.limit.output,
+        },
+        cost: {
+          input: raw?.cost?.input ?? existing?.cost.input,
+          output: raw?.cost?.output ?? existing?.cost.output,
+          cache: {
+            read: raw?.cost?.cache_read ?? existing?.cost.cache.read,
+            write: raw?.cost?.cache_write ?? existing?.cost.cache.write,
+          },
+        },
+        headers: {
+          ...existing?.headers,
+          ...cloneRecord(raw?.headers),
+        },
+        options: {
+          ...existing?.options,
+          ...cloneRecord(raw?.options),
+        },
+        api: {
+          id: raw?.id ?? existing?.api.id ?? modelID,
+          url: raw?.provider?.api ?? configuredProvider?.api ?? existing?.api.url ?? "",
+          npm: raw?.provider?.npm ?? configuredProvider?.npm ?? existing?.api.npm ?? seed.npm,
+        },
+        releaseDate: raw?.release_date ?? existing?.release_date,
+        variants: raw?.variants ?? existing?.variants,
+      })
+    }
+  }
+
+  async function loadProviders() {
+    const cfg = await Config.get()
+    const configured = (cfg.provider ?? {}) as Record<string, ProviderConfig>
+    const providers: Record<string, Info> = {}
+
+    for (const [providerName, seed] of Object.entries(PROVIDER_SEEDS)) {
+      const providerID = ProviderID.make(providerName)
+      const configuredProvider = configured[providerName]
+      const configuredModel = typeof cfg.model === "string" && cfg.model.startsWith(providerName + "/")
+      const key = firstEnv(configuredProvider?.env ?? seed.env) ?? configuredProvider?.options?.apiKey
+
+      if (!configuredProvider && !configuredModel && !key) {
+        continue
+      }
+
+      const info: Info = {
+        id: providerID,
+        name: configuredProvider?.name ?? seed.name,
+        source: configuredProvider ? "config" : key ? "env" : "custom",
+        env: configuredProvider?.env ?? seed.env,
+        ...(typeof key === "string" && key.length > 0 ? { key } : {}),
+        options: {
+          ...cloneRecord(configuredProvider?.options),
+        },
+        models: buildSeedModels(providerID, seed),
+      }
+
+      applyConfiguredModels(providerID, seed, info, configuredProvider)
+      providers[providerID] = info
+    }
+
+    if (Object.keys(providers).length === 0) {
+      const fallback = PROVIDER_SEEDS.anthropic
+      providers[ProviderID.anthropic] = {
+        id: ProviderID.anthropic,
+        name: fallback.name,
+        source: "custom",
+        env: fallback.env,
+        options: {},
+        models: buildSeedModels(ProviderID.anthropic, fallback),
+      }
+    }
+
+    return providers as Record<ProviderID, Info>
+  }
+
+  function modelKey(providerID: ProviderID, modelID: ModelID) {
+    return String(providerID) + "/" + String(modelID)
+  }
+
+  export async function list() {
+    return loadProviders()
+  }
+
+  export async function getProvider(providerID: ProviderID) {
+    const providers = await loadProviders()
+    const provider = providers[providerID]
+    if (!provider) {
+      throw new InitError({ providerID })
+    }
+    return provider
+  }
+
+  export async function getModel(providerID: ProviderID, modelID: ModelID) {
+    const provider = await getProvider(providerID)
+    const model = provider.models[modelID]
+    if (model) return model
+
+    const suggestions = Object.keys(provider.models).filter(
+      (candidate) => candidate.includes(String(modelID)) || String(modelID).includes(candidate),
+    )
+    throw new ModelNotFoundError({
+      providerID,
+      modelID,
+      ...(suggestions.length ? { suggestions: suggestions.slice(0, 3) } : {}),
+    })
+  }
+
+  async function getSdk(provider: Info, model: Model) {
+    const cacheKey = JSON.stringify({
+      providerID: provider.id,
+      apiId: model.api.id,
+      baseURL: provider.options?.baseURL,
+      headers: provider.options?.headers,
+      key: provider.key,
+    })
+    if (providerCache.has(cacheKey)) {
+      return providerCache.get(cacheKey)
+    }
+
+    const options = {
+      ...cloneRecord(provider.options),
+      ...(provider.key ? { apiKey: provider.key } : {}),
+      headers: {
+        ...cloneRecord(provider.options?.headers),
+        ...cloneRecord(model.headers),
+      },
+    }
+
+    const factory = SDK_FACTORIES[model.api.npm]
+    if (!factory) {
+      throw new InitError(
+        { providerID: provider.id },
+        {
+          cause: new Error(
+            "Unsupported provider in ACP VM build: " + provider.id + " (" + model.api.npm + ")",
+          ),
+        },
+      )
+    }
+
+    const sdk = factory(options)
+
+    providerCache.set(cacheKey, sdk)
+    return sdk
+  }
+
+  export async function getLanguage(model: Model) {
+    const key = modelKey(model.providerID, model.id)
+    const cached = languageCache.get(key)
+    if (cached) return cached
+
+    try {
+      const provider = await getProvider(model.providerID)
+      const sdk = await getSdk(provider, model)
+      const language =
+        model.providerID === ProviderID.openai && typeof sdk.responses === "function"
+          ? sdk.responses(model.api.id)
+          : sdk.languageModel(model.api.id)
+      languageCache.set(key, language)
+      return language
+    } catch (cause) {
+      throw new InitError({ providerID: model.providerID }, { cause })
+    }
+  }
+
+  export async function closest(providerID: ProviderID, query: string[]) {
+    const provider = await getProvider(providerID).catch(() => undefined)
+    if (!provider) return undefined
+    for (const item of query) {
+      const match = Object.keys(provider.models).find((modelID) => modelID.includes(item))
+      if (match) return { providerID, modelID: ModelID.make(match) }
+    }
+    return undefined
+  }
+
+  export async function getSmallModel(providerID: ProviderID) {
+    const provider = await getProvider(providerID).catch(() => undefined)
+    if (!provider) return undefined
+
+    const preferred =
+      providerID === ProviderID.anthropic
+        ? ["haiku", "mini", "nano"]
+        : ["mini", "nano", "haiku"]
+
+    for (const token of preferred) {
+      const match = Object.values(provider.models).find((model) => model.id.includes(token))
+      if (match) return match
+    }
+
+    return undefined
+  }
+
+  export async function defaultModel() {
+    const cfg = await Config.get()
+    if (cfg.model) {
+      const parsed = parseModel(cfg.model)
+      const model = await getModel(parsed.providerID, parsed.modelID).catch(() => undefined)
+      if (model) {
+        return {
+          providerID: parsed.providerID,
+          modelID: parsed.modelID,
+        }
+      }
+    }
+
+    const providers = await loadProviders()
+    for (const provider of Object.values(providers)) {
+      const [model] = sort(Object.values(provider.models))
+      if (model) {
+        return {
+          providerID: provider.id,
+          modelID: model.id,
+        }
+      }
+    }
+
+    return {
+      providerID: ProviderID.anthropic,
+      modelID: ModelID.make("claude-sonnet-4-20250514"),
+    }
+  }
+
+  export function sort<T extends { id: string }>(models: T[]) {
+    return [...models].sort((a, b) => {
+      const aPriority = priority.findIndex((item) => a.id.includes(item))
+      const bPriority = priority.findIndex((item) => b.id.includes(item))
+      const aRank = aPriority === -1 ? Number.MAX_SAFE_INTEGER : aPriority
+      const bRank = bPriority === -1 ? Number.MAX_SAFE_INTEGER : bPriority
+      if (aRank !== bRank) return aRank - bRank
+
+      const aLatest = a.id.includes("latest") ? 1 : 0
+      const bLatest = b.id.includes("latest") ? 1 : 0
+      if (aLatest !== bLatest) return aLatest - bLatest
+
+      return a.id.localeCompare(b.id)
+    })
+  }
+
+  export function parseModel(model: string) {
+    const [providerID, ...rest] = model.split("/")
+    return {
+      providerID: ProviderID.make(providerID),
+      modelID: ModelID.make(rest.join("/")),
+    }
+  }
+
+  export const ModelNotFoundError = NamedError.create(
+    "ProviderModelNotFoundError",
+    z.object({
+      providerID: ProviderID.zod,
+      modelID: ModelID.zod,
+      suggestions: z.array(z.string()).optional(),
+    }),
+  )
+
+  export const InitError = NamedError.create(
+    "ProviderInitError",
+    z.object({
+      providerID: ProviderID.zod,
+    }),
+  )
+}
+`,
+	);
+
+	await writeFile(
+		resolve(sourceRoot, "packages/opencode/src/plugin/index.ts"),
+		`import { Effect, Layer, ServiceMap } from "effect"
+
+export namespace Plugin {
+  export interface Interface {
+    readonly trigger: <Name extends string, Input, Output>(
+      name: Name,
+      input: Input,
+      output: Output,
+    ) => Effect.Effect<Output>
+    readonly list: () => Effect.Effect<any[]>
+    readonly init: () => Effect.Effect<void>
+  }
+
+  export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Plugin") {}
+
+  const noop = Service.of({
+    trigger: <Name extends string, Input, Output>(_name: Name, _input: Input, output: Output) =>
+      Effect.succeed(output),
+    list: () => Effect.succeed([]),
+    init: () => Effect.void,
+  })
+
+  export const layer = Layer.succeed(Service, noop)
+  export const defaultLayer = layer
+
+  export async function trigger<Name extends string, Input, Output>(
+    _name: Name,
+    _input: Input,
+    output: Output,
+  ): Promise<Output> {
+    return output
+  }
+
+  export async function list(): Promise<any[]> {
+    return []
+  }
+
+  export async function init(): Promise<void> {}
+}
+`,
+	);
+
+	await writeFile(
+		resolve(sourceRoot, "packages/opencode/src/project/bootstrap.ts"),
+		`import { Instance } from "./instance"
+import { Log } from "@/util/log"
+
+export async function InstanceBootstrap() {
+  Log.Default.info("bootstrapping", { directory: Instance.directory })
+  Log.Default.info("bootstrap step", { step: "minimal:init" })
+}
+`,
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/project/instance.ts",
+		(contents) =>
+			contents
+				.replace(
+					`function boot(input: { directory: string; init?: () => Promise<any>; project?: Project.Info; worktree?: string }) {
+  return iife(async () => {
+`,
+					`function boot(input: { directory: string; init?: () => Promise<any>; project?: Project.Info; worktree?: string }) {
+  return iife(async () => {
+    Log.Default.info("instance boot:start", { directory: input.directory })
+`,
+				)
+				.replace(
+					`    await context.provide(ctx, async () => {
+      await input.init?.()
+    })
+    return ctx
+`,
+					`    Log.Default.info("instance boot:ctx", {
+      directory: ctx.directory,
+      worktree: ctx.worktree,
+      projectID: ctx.project.id,
+    })
+    await context.provide(ctx, async () => {
+      Log.Default.info("instance boot:init:start", { directory: ctx.directory })
+      await input.init?.()
+      Log.Default.info("instance boot:init:done", { directory: ctx.directory })
+    })
+    Log.Default.info("instance boot:done", { directory: ctx.directory })
+    return ctx
+`,
+				)
+				.replace(
+					`    const ctx = await existing
+    return context.provide(ctx, async () => {
+      return input.fn()
+    })
+`,
+					`    Log.Default.info("instance provide:await:start", { directory })
+    const ctx = await existing
+    Log.Default.info("instance provide:await:done", { directory })
+    return context.provide(ctx, async () => {
+      Log.Default.info("instance provide:fn:start", { directory })
+      const result = await input.fn()
+      Log.Default.info("instance provide:fn:done", { directory })
+      return result
+    })
+`,
+				),
+	);
+
+	await rewriteSourceFile(
+		sourceRoot,
+		"packages/opencode/src/project/project.ts",
+		(contents) =>
+			contents.includes('log.info("phase2 select project"')
+				? contents
+				: contents
+				.replace(
+					`        // Phase 2: upsert
+        const row = yield* db((d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, data.id)).get())
+`,
+					`        // Phase 2: upsert
+        log.info("phase2 select project", { projectID: data.id })
+        const row = yield* db((d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, data.id)).get())
+        log.info("phase2 select project done", { projectID: data.id, found: !!row })
+`,
+				)
+				.replace(
+					`        yield* db((d) =>
+          d
+            .insert(ProjectTable)
+            .values({
+`,
+					`        log.info("phase2 upsert project", {
+          projectID: result.id,
+          sandboxes: result.sandboxes.length,
+        })
+        yield* db((d) =>
+          d
+            .insert(ProjectTable)
+            .values({
+`,
+				)
+				.replace(
+					`        if (data.id !== ProjectID.global) {
+`,
+					`        log.info("phase2 upsert project done", { projectID: result.id })
+        if (data.id !== ProjectID.global) {
+`,
+				),
+	);
+
+	await writeFile(
+		resolve(sourceRoot, "packages/opencode/src/share/share-next.ts"),
+		`export namespace ShareNext {
+  const EMPTY_API = {
+    create: "",
+    sync: () => "",
+    remove: () => "",
+    data: () => "",
+  }
+
+  export async function url() {
+    return ""
+  }
+
+  export async function request() {
+    return {
+      headers: {},
+      api: EMPTY_API,
+      baseUrl: "",
+    }
+  }
+
+  export async function init() {}
+
+  export async function create(_sessionID: string) {
+    return { id: "", url: "", secret: "" }
+  }
+
+  export async function remove(_sessionID: string) {}
+}
+`,
+	);
+
+	await writeFile(
+		resolve(sourceRoot, "packages/opencode/src/cli/cmd/tui/win32.ts"),
+		`export function win32DisableProcessedInput() {}
+export function win32FlushInputBuffer() {}
+export function win32InstallCtrlCGuard() {
+  return
+}
+`,
+	);
+}
+
+function patchBuiltBundle(bundlePath) {
+	const original = readFileSync(bundlePath, "utf-8");
+	if (
+		original.includes(
+			"bash tool command scan failed, falling back to raw permission request",
+		)
+	) {
+		return;
+	}
+
+	const updated = original.replace(
+		`      async execute(params, ctx) {
+        const cwd = params.workdir ? await resolvePath(params.workdir, Instance.directory, shell2) : Instance.directory;
+        if (params.timeout !== undefined && params.timeout < 0) {
+          throw new Error(\`Invalid timeout value: \${params.timeout}. Timeout must be a positive number.\`);
+        }
+        const timeout4 = params.timeout ?? DEFAULT_TIMEOUT;
+        const ps2 = PS.has(name21);
+        const root = await parse10(params.command, ps2);
+        const scan5 = await collect6(root, cwd, ps2, shell2);
+        if (!Instance.containsPath(cwd))
+          scan5.dirs.add(cwd);
+        await ask(ctx, scan5);
+        return run7({
+`,
+		`      async execute(params, ctx) {
+        const cwd = params.workdir ? await resolvePath(params.workdir, Instance.directory, shell2) : Instance.directory;
+        if (params.timeout !== undefined && params.timeout < 0) {
+          throw new Error(\`Invalid timeout value: \${params.timeout}. Timeout must be a positive number.\`);
+        }
+        const timeout4 = params.timeout ?? DEFAULT_TIMEOUT;
+        const ps2 = PS.has(name21);
+        let scan5;
+        try {
+          const root = await parse10(params.command, ps2);
+          scan5 = await collect6(root, cwd, ps2, shell2);
+        } catch (error48) {
+          log7.warn("bash tool command scan failed, falling back to raw permission request", {
+            command: params.command,
+            error: error48 instanceof Error ? error48.message : String(error48)
+          });
+          scan5 = {
+            dirs: new Set,
+            patterns: new Set([params.command]),
+            always: new Set([params.command])
+          };
+        }
+        if (!Instance.containsPath(cwd))
+          scan5.dirs.add(cwd);
+        await ask(ctx, scan5);
+        return run7({
+`,
+	);
+
+	if (updated === original) {
+		throw new Error(
+			"Failed to patch built OpenCode ACP bundle for bash scan fallback",
+		);
+	}
+
+	writeFileSync(bundlePath, updated);
+}
+
+async function assertPreparedSource(sourceRoot) {
+	const instanceSource = await readFile(
+		resolve(sourceRoot, "packages/opencode/src/server/instance.ts"),
+		"utf8",
+	);
+	if (
+		instanceSource.includes('import { PtyRoutes } from "./routes/pty"') ||
+		instanceSource.includes('import { TuiRoutes } from "./routes/tui"') ||
+		instanceSource.includes('.route("/pty", PtyRoutes())') ||
+		instanceSource.includes('.route("/tui", TuiRoutes())')
+	) {
+		throw new Error("Prepared OpenCode source still exposes PTY/TUI routes in the ACP build");
+	}
+
+	const shellSource = await readFile(
+		resolve(sourceRoot, "packages/opencode/src/shell/shell.ts"),
+		"utf8",
+	);
+	if (shellSource.includes("Bun.which(")) {
+		throw new Error("Prepared OpenCode source still references Bun.which in shell.ts");
+	}
+
+	const win32Source = await readFile(
+		resolve(sourceRoot, "packages/opencode/src/cli/cmd/tui/win32.ts"),
+		"utf8",
+	);
+	if (win32Source.includes("bun:ffi")) {
+		throw new Error("Prepared OpenCode source still references bun:ffi in the Win32 TUI shim");
+	}
+
+	const dbNodeSource = await readFile(
+		resolve(sourceRoot, "packages/opencode/src/storage/db.node.ts"),
+		"utf8",
+	);
+	if (
+		!dbNodeSource.includes('from "drizzle-orm/node-sqlite"') ||
+		!dbNodeSource.includes('from "node:sqlite"')
+	) {
+		throw new Error("Prepared OpenCode source does not use the native node:sqlite database path");
+	}
+}
+
+async function assertBundleClean(bundlePath) {
+	const bundle = await readFile(bundlePath, "utf8");
+	for (const pattern of [
+		"bun:ffi",
+		"bun-pty",
+		"hono/bun",
+		'.route("/pty", PtyRoutes())',
+		'.route("/tui", TuiRoutes())',
+		"Bun.which(",
+		"bun:sqlite",
+	]) {
+		if (bundle.includes(pattern)) {
+			throw new Error(
+				`OpenCode ACP bundle still contains forbidden runtime dependency: ${pattern}`,
+			);
+		}
+	}
+}
+
+async function main() {
+	if (!existsSync(bunBin)) {
+		throw new Error(
+			`bun is not installed for @agentos-software/opencode (expected ${bunBin}). Run pnpm install first.`,
+		);
+	}
+
+	mkdirSync(distDir, { recursive: true });
+	mkdirSync(cacheDir, { recursive: true });
+	rmSync(bundleDir, { recursive: true, force: true });
+
+	const patch = readFileSync(patchPath, "utf-8");
+	const buildScript = readFileSync(fileURLToPath(import.meta.url), "utf-8");
+	const patchHash = createHash("sha256")
+		.update(`${SOURCE_VERSION}\n${patch}\n${buildScript}`)
+		.digest("hex")
+		.slice(0, 16);
+	const sourceRoot = join(cacheDir, `source-v${SOURCE_VERSION}-${patchHash}`);
+	const preparedMarker = join(sourceRoot, ".agentos-prepared.json");
+	const tarballPath = join(cacheDir, `opencode-v${SOURCE_VERSION}.tar.gz`);
+
+	if (!existsSync(preparedMarker)) {
+		rmSync(sourceRoot, { recursive: true, force: true });
+		mkdirSync(sourceRoot, { recursive: true });
+
+		if (!existsSync(tarballPath)) {
+			process.stdout.write(`Downloading OpenCode v${SOURCE_VERSION} source...\n`);
+			await downloadFile(SOURCE_TARBALL_URL, tarballPath);
+		}
+
+		run("tar", ["-xzf", tarballPath, "--strip-components=1", "-C", sourceRoot]);
+		pinGhosttyWebRef(sourceRoot);
+		run(bunBin, ["install", "--frozen-lockfile"], { cwd: sourceRoot });
+		await ensureNodeAcpPatch(sourceRoot, tarballPath);
+		await applyNodeAcpRuntimeTweaks(sourceRoot);
+		await assertPreparedSource(sourceRoot);
+
+		writeFileSync(
+			preparedMarker,
+			JSON.stringify(
+				{
+					sourceVersion: SOURCE_VERSION,
+					sourceRepository: SOURCE_REPOSITORY,
+					patchHash,
+				},
+				null,
+				2,
+				) + "\n",
+		);
+	}
+
+	await ensureNodeAcpPatch(sourceRoot, tarballPath);
+	await applyNodeAcpRuntimeTweaks(sourceRoot);
+	await assertPreparedSource(sourceRoot);
+
+	const migrations = await readMigrations(sourceRoot);
+	const buildHelperDir = await mkdtemp(join(tmpdir(), "agentos-opencode-build-"));
+	const buildHelperPath = join(buildHelperDir, "build-opencode-acp.mjs");
+	const bunVersion =
+		spawnSync(bunBin, ["--version"], { encoding: "utf-8" }).stdout?.trim() ??
+		"unknown";
+
+	try {
+		await writeFile(
+			buildHelperPath,
+			`
+import { mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+const outdir = process.env.OUTDIR;
+if (!outdir) {
+	throw new Error("OUTDIR is required");
+}
+
+const result = await Bun.build({
+	target: "node",
+	format: "esm",
+	outdir,
+	entrypoints: ["./packages/opencode/src/cli/cmd/acp.ts"],
+	define: {
+		OPENCODE_MIGRATIONS: ${JSON.stringify(JSON.stringify(migrations))},
+		OPENCODE_LIBC: ${JSON.stringify(JSON.stringify("glibc"))},
+	},
+});
+if (!result.success) {
+	for (const log of result.logs) {
+		console.error(log);
+	}
+	throw new Error("OpenCode ACP bundle build failed");
+}
+for (const output of result.outputs) {
+	const filePath = join(outdir, output.path);
+	await mkdir(dirname(filePath), { recursive: true });
+	await Bun.write(filePath, output);
+}
+`,
+		);
+
+		run(bunBin, [buildHelperPath], {
+			cwd: sourceRoot,
+			env: {
+				...process.env,
+				OUTDIR: bundleDir,
+			},
+		});
+	} finally {
+		rmSync(buildHelperDir, { recursive: true, force: true });
+	}
+
+	await assertBundleClean(join(bundleDir, "acp.js"));
+	patchBuiltBundle(join(bundleDir, "acp.js"));
+
+	writeFileSync(
+		manifestPath,
+		JSON.stringify(
+			{
+				source: {
+					repository: SOURCE_REPOSITORY,
+					version: SOURCE_VERSION,
+					tarballUrl: SOURCE_TARBALL_URL,
+				},
+				build: {
+					bunVersion,
+					patchHash,
+					externalDependencies: [],
+					entry: "./opencode-acp/acp.js",
+				},
+			},
+			null,
+			2,
+		) + "\n",
+	);
+}
+
+void main().catch((error) => {
+	process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+	process.exitCode = 1;
+});

--- a/registry/agent/opencode/src/adapter.ts
+++ b/registry/agent/opencode/src/adapter.ts
@@ -1,0 +1,27 @@
+process.env.OPENCODE_DISABLE_CONFIG_DEP_INSTALL ??= "1";
+process.env.OPENCODE_DISABLE_EMBEDDED_WEB_UI ??= "1";
+
+// @ts-expect-error Generated at build time by scripts/build-opencode-acp.mjs.
+const { AcpCommand } = (await import("./opencode-acp/acp.js")) as {
+	AcpCommand: {
+		handler(args: {
+			port: number;
+			hostname: string;
+			mdns: boolean;
+			"mdns-domain": string;
+			cors: string[];
+			cwd: string;
+		}): Promise<void>;
+	};
+};
+
+await AcpCommand.handler({
+	port: 0,
+	hostname: "127.0.0.1",
+	mdns: false,
+	"mdns-domain": "opencode.local",
+	cors: [],
+	cwd: process.cwd(),
+});
+
+export {};

--- a/registry/agent/opencode/src/index.ts
+++ b/registry/agent/opencode/src/index.ts
@@ -1,0 +1,25 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageDir = resolve(__dirname, "..");
+
+const opencode = {
+	name: "opencode",
+	type: "agent" as const,
+	packageDir,
+	requires: ["@agentos-software/opencode"],
+	agent: {
+		id: "opencode",
+		// OpenCode still speaks ACP natively, but Agent OS runs a source-built
+		// Node ACP bundle entirely inside the VM rather than a host binary wrapper.
+		acpAdapter: "@agentos-software/opencode",
+		agentPackage: "@agentos-software/opencode",
+		staticEnv: {
+			OPENCODE_DISABLE_CONFIG_DEP_INSTALL: "1",
+			OPENCODE_DISABLE_EMBEDDED_WEB_UI: "1",
+		},
+	},
+};
+
+export default opencode;

--- a/registry/agent/opencode/src/opencode-acp.mjs.d.ts
+++ b/registry/agent/opencode/src/opencode-acp.mjs.d.ts
@@ -1,0 +1,14 @@
+declare module "./opencode-acp.mjs" {
+	export const AcpCommand: {
+		handler(args: {
+			port: number;
+			hostname: string;
+			mdns: boolean;
+			"mdns-domain": string;
+			cors: string[];
+			cwd: string;
+		}): Promise<void>;
+	};
+}
+
+export {};

--- a/registry/agent/opencode/tsconfig.json
+++ b/registry/agent/opencode/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"declaration": true,
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/registry/agent/opencode/upstream/opencode-v1.3.13.patch
+++ b/registry/agent/opencode/upstream/opencode-v1.3.13.patch
@@ -1,0 +1,251 @@
+diff --git a/packages/opencode/src/cli/cmd/acp.ts b/packages/opencode/src/cli/cmd/acp.ts
+index 99a9a81ab..2fb9038b0 100644
+--- a/packages/opencode/src/cli/cmd/acp.ts
++++ b/packages/opencode/src/cli/cmd/acp.ts
+@@ -23,7 +23,7 @@ export const AcpCommand = cmd({
+     process.env.OPENCODE_CLIENT = "acp"
+     await bootstrap(process.cwd(), async () => {
+       const opts = await resolveNetworkOptions(args)
+-      const server = Server.listen(opts)
++      const server = await Server.listen(opts)
+ 
+       const sdk = createOpencodeClient({
+         baseUrl: `http://${server.hostname}:${server.port}`,
+diff --git a/packages/opencode/src/config/config.ts b/packages/opencode/src/config/config.ts
+index f86d8d32a..fdb4dc107 100644
+--- a/packages/opencode/src/config/config.ts
++++ b/packages/opencode/src/config/config.ts
+@@ -90,6 +90,11 @@ export namespace Config {
+   }
+ 
+   export async function installDependencies(dir: string, input?: InstallInput) {
++    if (process.env.OPENCODE_DISABLE_CONFIG_DEP_INSTALL === "1") {
++      log.info("skipping dependency install", { dir, reason: "disabled_by_env" })
++      return
++    }
++
+     if (!(await needsInstall(dir))) return
+ 
+     await using _ = await Flock.acquire(`config-install:${Filesystem.resolve(dir)}`, {
+diff --git a/packages/opencode/src/plugin/index.ts b/packages/opencode/src/plugin/index.ts
+index b05dd8625..f2afc5979 100644
+--- a/packages/opencode/src/plugin/index.ts
++++ b/packages/opencode/src/plugin/index.ts
+@@ -50,7 +50,10 @@ export namespace Plugin {
+   export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Plugin") {}
+ 
+   // Built-in plugins that are directly imported (not installed from npm)
+-  const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin, GitlabAuthPlugin, PoeAuthPlugin]
++  const INTERNAL_PLUGINS: PluginInstance[] =
++    process.env.OPENCODE_ENABLE_INTERNAL_AUTH_PLUGINS === "1"
++      ? [CodexAuthPlugin, CopilotAuthPlugin, GitlabAuthPlugin, PoeAuthPlugin]
++      : []
+ 
+   function isServerPlugin(value: unknown): value is PluginInstance {
+     return typeof value === "function"
+@@ -128,7 +131,9 @@ export namespace Plugin {
+             get serverUrl(): URL {
+               return Server.url ?? new URL("http://localhost:4096")
+             },
+-            $: Bun.$,
++            $: ((..._args: unknown[]) => {
++              throw new Error("Bun shell is unavailable in the Node ACP build")
++            }) as PluginInput["$"],
+           }
+ 
+           for (const plugin of INTERNAL_PLUGINS) {
+diff --git a/packages/opencode/src/server/instance.ts b/packages/opencode/src/server/instance.ts
+index 4bb6efaf9..fc634f5c2 100644
+--- a/packages/opencode/src/server/instance.ts
++++ b/packages/opencode/src/server/instance.ts
+@@ -18,7 +18,6 @@ import { QuestionRoutes } from "./routes/question"
+ import { PermissionRoutes } from "./routes/permission"
+ import { ProjectRoutes } from "./routes/project"
+ import { SessionRoutes } from "./routes/session"
+-import { PtyRoutes } from "./routes/pty"
+ import { McpRoutes } from "./routes/mcp"
+ import { FileRoutes } from "./routes/file"
+ import { ConfigRoutes } from "./routes/config"
+@@ -44,7 +43,6 @@ export const InstanceRoutes = (app?: Hono) =>
+   (app ?? new Hono())
+     .onError(errorHandler(log))
+     .route("/project", ProjectRoutes())
+-    .route("/pty", PtyRoutes())
+     .route("/config", ConfigRoutes())
+     .route("/experimental", ExperimentalRoutes())
+     .route("/session", SessionRoutes())
+diff --git a/packages/opencode/src/server/server.ts b/packages/opencode/src/server/server.ts
+index ec245ed59..8df8fe679 100644
+--- a/packages/opencode/src/server/server.ts
++++ b/packages/opencode/src/server/server.ts
+@@ -9,7 +9,6 @@ import { Auth } from "../auth"
+ import { Flag } from "../flag/flag"
+ import { ProviderID } from "../provider/schema"
+ import { WorkspaceRouterMiddleware } from "./router"
+-import { websocket } from "hono/bun"
+ import { errors } from "./error"
+ import { GlobalRoutes } from "./routes/global"
+ import { MDNS } from "./mdns"
+@@ -17,6 +16,9 @@ import { lazy } from "@/util/lazy"
+ import { errorHandler } from "./middleware"
+ import { InstanceRoutes } from "./instance"
+ import { initProjectors } from "./projectors"
++import { createServer, type IncomingMessage, type ServerResponse } from "node:http"
++import type { AddressInfo } from "node:net"
++import { Readable } from "node:stream"
+ 
+ // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
+ globalThis.AI_SDK_LOG_WARNINGS = false
+@@ -264,7 +266,106 @@ export namespace Server {
+   /** @deprecated do not use this dumb shit */
+   export let url: URL
+ 
+-  export function listen(opts: {
++  type NodeServeHandle = {
++    hostname: string
++    port: number
++    stop: (closeActiveConnections?: boolean) => Promise<void>
++  }
++
++  function toRequestUrl(req: IncomingMessage, fallbackHost: string, fallbackPort: number) {
++    const host = req.headers.host ?? `${fallbackHost}:${fallbackPort}`
++    return new URL(req.url ?? "/", `http://${host}`)
++  }
++
++  function toHeaders(req: IncomingMessage) {
++    const headers = new Headers()
++    for (const [key, value] of Object.entries(req.headers)) {
++      if (Array.isArray(value)) {
++        for (const item of value) headers.append(key, item)
++        continue
++      }
++      if (typeof value === "string") headers.set(key, value)
++    }
++    return headers
++  }
++
++  async function writeResponse(res: ServerResponse, response: Response) {
++    res.statusCode = response.status
++    res.statusMessage = response.statusText
++    response.headers.forEach((value, key) => {
++      res.setHeader(key, value)
++    })
++
++    if (!response.body) {
++      res.end()
++      return
++    }
++
++    await new Promise<void>((resolve, reject) => {
++      const body = Readable.fromWeb(response.body as globalThis.ReadableStream<Uint8Array>)
++      body.on("error", reject)
++      res.on("error", reject)
++      res.on("close", resolve)
++      body.pipe(res)
++    })
++  }
++
++  async function serveNode(opts: {
++    hostname: string
++    port: number
++    fetch: (request: Request) => Response | Promise<Response>
++  }): Promise<NodeServeHandle> {
++    const server = createServer(async (req, res) => {
++      try {
++        const request = new Request(toRequestUrl(req, opts.hostname, opts.port), {
++          method: req.method,
++          headers: toHeaders(req),
++          body:
++            req.method && req.method !== "GET" && req.method !== "HEAD"
++              ? (Readable.toWeb(req) as globalThis.ReadableStream<Uint8Array>)
++              : undefined,
++          duplex: "half",
++        })
++        const response = await opts.fetch(request)
++        await writeResponse(res, response)
++      } catch (error) {
++        log.error("node server request failed", { error })
++        if (!res.headersSent) {
++          res.statusCode = 500
++          res.setHeader("content-type", "text/plain; charset=utf-8")
++        }
++        res.end("Internal Server Error")
++      }
++    })
++
++    await new Promise<void>((resolve, reject) => {
++      server.once("error", reject)
++      server.listen(opts.port, opts.hostname, () => {
++        server.off("error", reject)
++        resolve()
++      })
++    })
++
++    const address = server.address()
++    if (!address || typeof address === "string") {
++      throw new Error("Failed to resolve server address")
++    }
++
++    return {
++      hostname: opts.hostname,
++      port: (address as AddressInfo).port,
++      stop() {
++        return new Promise<void>((resolve, reject) => {
++          server.close((error) => {
++            if (error) reject(error)
++            else resolve()
++          })
++        })
++      },
++    }
++  }
++
++  export async function listen(opts: {
+     port: number
+     hostname: string
+     mdns?: boolean
+@@ -273,20 +374,18 @@ export namespace Server {
+   }) {
+     url = new URL(`http://${opts.hostname}:${opts.port}`)
+     const app = ControlPlaneRoutes({ cors: opts.cors })
+-    const args = {
+-      hostname: opts.hostname,
+-      idleTimeout: 0,
+-      fetch: app.fetch,
+-      websocket: websocket,
+-    } as const
+-    const tryServe = (port: number) => {
++    const tryServe = async (port: number) => {
+       try {
+-        return Bun.serve({ ...args, port })
++        return await serveNode({
++          hostname: opts.hostname,
++          port,
++          fetch: app.fetch,
++        })
+       } catch {
+         return undefined
+       }
+     }
+-    const server = opts.port === 0 ? (tryServe(4096) ?? tryServe(0)) : tryServe(opts.port)
++    const server = opts.port === 0 ? ((await tryServe(4096)) ?? (await tryServe(0))) : await tryServe(opts.port)
+     if (!server) throw new Error(`Failed to start server on port ${opts.port}`)
+ 
+     const shouldPublishMDNS =
+@@ -296,7 +395,7 @@ export namespace Server {
+       opts.hostname !== "localhost" &&
+       opts.hostname !== "::1"
+     if (shouldPublishMDNS) {
+-      MDNS.publish(server.port!, opts.mdnsDomain)
++      MDNS.publish(server.port, opts.mdnsDomain)
+     } else if (opts.mdns) {
+       log.warn("mDNS enabled but hostname is loopback; skipping mDNS publish")
+     }
+@@ -307,6 +406,7 @@ export namespace Server {
+       return originalStop(closeActiveConnections)
+     }
+ 
++    url = new URL(`http://${opts.hostname}:${server.port}`)
+     return server
+   }
+ }

--- a/registry/agent/pi-cli/package.json
+++ b/registry/agent/pi-cli/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "@agentos-software/pi-cli",
+	"version": "0.2.0-rc.3",
+	"type": "module",
+	"license": "Apache-2.0",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@mariozechner/pi-coding-agent": "^0.60.0",
+		"pi-acp": "^0.0.23"
+	},
+	"devDependencies": {
+		"@types/node": "^22.10.2",
+		"typescript": "^5.7.2"
+	}
+}

--- a/registry/agent/pi-cli/src/index.ts
+++ b/registry/agent/pi-cli/src/index.ts
@@ -1,0 +1,25 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageDir = resolve(__dirname, "..");
+
+const piCli = {
+	name: "pi-cli",
+	type: "agent" as const,
+	packageDir,
+	requires: ["pi-acp", "@mariozechner/pi-coding-agent"],
+	agent: {
+		id: "pi-cli",
+		acpAdapter: "pi-acp",
+		agentPackage: "@mariozechner/pi-coding-agent",
+		env: (ctx: { resolveBin(packageName: string, binName?: string): string }) => ({
+			PI_ACP_PI_COMMAND: ctx.resolveBin(
+				"@mariozechner/pi-coding-agent",
+				"pi",
+			),
+		}),
+	},
+};
+
+export default piCli;

--- a/registry/agent/pi-cli/tsconfig.json
+++ b/registry/agent/pi-cli/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"declaration": true,
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/registry/agent/pi/package.json
+++ b/registry/agent/pi/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@agentos-software/pi",
+	"version": "0.2.0-rc.3",
+	"type": "module",
+	"license": "Apache-2.0",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"bin": {
+		"pi-sdk-acp": "./dist/adapter.js"
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc && node scripts/build-snapshot-bundle.mjs",
+		"build:snapshot": "node scripts/build-snapshot-bundle.mjs",
+		"check-types": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@agentclientprotocol/sdk": "^0.16.1",
+		"@mariozechner/pi-coding-agent": "0.60.0",
+		"@mariozechner/pi-ai": "0.60.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.10.2",
+		"typescript": "^5.7.2"
+	}
+}

--- a/registry/agent/pi/scripts/build-snapshot-bundle.mjs
+++ b/registry/agent/pi/scripts/build-snapshot-bundle.mjs
@@ -1,0 +1,226 @@
+/**
+ * Builds the Pi SDK snapshot bundle (Step 2a).
+ *
+ * Bundles src/snapshot-entry.ts into a single IIFE at dist/sdk-snapshot.js that
+ * evaluates the SDK graph and publishes it on globalThis.__PI_SDK_RUNTIME__. node:
+ * builtins stay external (provided by the V8 runtime's bridge polyfills, already in
+ * the snapshot heap); heavy provider SDKs reached only via dynamic import() stay
+ * external so they remain lazy and load post-restore from the VFS.
+ *
+ * The build env intentionally clears DISPLAY/WAYLAND_DISPLAY (C0 mitigation): the
+ * optional @mariozechner/clipboard NAPI addon is behind a DISPLAY guard; with it
+ * unset the SDK bakes `clipboard = null` so no native pointer enters the snapshot.
+ */
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { pathToFileURL } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(here, "..");
+
+// esbuild lives in the workspace pnpm store; resolve it from there.
+const require = createRequire(import.meta.url);
+const repoRoot = join(pkgRoot, "..", "..", "..");
+let esbuildPath;
+try {
+	esbuildPath = require.resolve("esbuild", { paths: [pkgRoot, repoRoot] });
+} catch {
+	const { globSync } = await import("node:fs");
+	const matches = globSync(
+		join(repoRoot, "node_modules/.pnpm/esbuild@*/node_modules/esbuild/lib/main.js"),
+	);
+	if (matches.length === 0) throw new Error("esbuild not found in workspace");
+	esbuildPath = matches.sort().reverse()[0];
+}
+const { build } = await import(pathToFileURL(esbuildPath).href);
+// Entry/outfile are overridable (PI_SNAPSHOT_ENTRY / PI_SNAPSHOT_OUTFILE) for
+// bisection/testing; default to the committed entry + artifact.
+const entryPoint = process.env.PI_SNAPSHOT_ENTRY || join(pkgRoot, "src", "snapshot-entry.ts");
+const outfile = process.env.PI_SNAPSHOT_OUTFILE || join(pkgRoot, "dist", "sdk-snapshot.js");
+
+// Provider SDKs the pi-ai layer pulls only via dynamic import(); keep them lazy.
+const lazyExternals = [
+	"@anthropic-ai/sdk",
+	"openai",
+	"@google/genai",
+	"@mistralai/mistralai",
+	"@aws-sdk/client-bedrock-runtime",
+	"proxy-agent",
+	"@mariozechner/clipboard",
+];
+
+// The adapter deliberately imports deep `dist/core/*` paths to skip the SDK's TUI
+// graph, but the package `exports` map only exposes `.`/`./hooks`. Mirror the
+// adapter: resolve the deep specifiers to absolute file paths under the package's
+// dist dir, bypassing the exports map (esbuild bundles absolute paths fine).
+const { realpathSync, existsSync } = await import("node:fs");
+const piCodingRoot = [
+	join(pkgRoot, "node_modules/@mariozechner/pi-coding-agent"),
+	join(repoRoot, "node_modules/@mariozechner/pi-coding-agent"),
+].find((p) => existsSync(p));
+if (!piCodingRoot) throw new Error("pi-coding-agent not found in node_modules");
+const piCodingReal = realpathSync(piCodingRoot);
+const piCodingDist = join(piCodingReal, "dist");
+// pnpm sibling layout: pi-coding-agent's own deps (incl. pi-agent-core) live in the
+// same `.pnpm/<hash>/node_modules/@mariozechner` dir. Resolve transitive
+// @mariozechner/* deps from there so we bundle exactly what the SDK links against.
+const piSiblingScope = dirname(piCodingReal); // .../node_modules/@mariozechner
+const deepImportPlugin = {
+	name: "pi-deep-imports",
+	setup(b) {
+		b.onResolve({ filter: /^@mariozechner\/pi-coding-agent\/dist\// }, (a) => {
+			const rel = a.path.replace("@mariozechner/pi-coding-agent/dist/", "");
+			return { path: join(piCodingDist, rel) };
+		});
+		b.onResolve({ filter: /^@mariozechner\/pi-agent-core/ }, (a) => {
+			const sub = a.path.replace("@mariozechner/pi-agent-core", "") || "/dist/index.js";
+			return { path: join(piSiblingScope, "pi-agent-core", sub) };
+		});
+	},
+};
+
+// Bisection helper (PI_SNAPSHOT_STUB_MODULES=a,b,c): alias the named bare specifiers
+// to an empty module so they're elided from the snapshot graph — used to find which
+// heavy dep creates an un-serializable native handle at module-init.
+const stubModules = (process.env.PI_SNAPSHOT_STUB_MODULES || "")
+	.split(",")
+	.map((s) => s.trim())
+	.filter(Boolean);
+const stubPlugin = {
+	name: "pi-stub-modules",
+	setup(b) {
+		if (stubModules.length === 0) return;
+		// Substring match against the import specifier (catches bare specifiers AND
+		// relative paths like ../modes/interactive/theme/theme.js).
+		b.onResolve({ filter: /.*/ }, (a) => {
+			if (stubModules.some((m) => a.path.includes(m))) {
+				return { path: a.path, namespace: "pi-stub" };
+			}
+			return undefined;
+		});
+		b.onLoad({ filter: /.*/, namespace: "pi-stub" }, () => ({
+			// Pure CJS so esbuild interop synthesizes ANY named import as a no-op.
+			contents:
+				"module.exports = new Proxy(function () {}, { get: function () { return function () {}; } });",
+			loader: "js",
+		}));
+	},
+};
+
+// Make the bundle SNAPSHOT-SAFE by eliminating its two top-level I/O hazards at
+// build time, so the IIFE evaluates as pure JS (no fs read, no pending promise)
+// when run into the V8 snapshot where bridge fns are stubs. See the C0 scan.
+const snapshotSafePlugin = {
+	name: "pi-snapshot-safe",
+	setup(b) {
+		// config.js bakes VERSION/APP_NAME from a top-level readFileSync(package.json).
+		// Inline the real package.json content so no fs read happens at eval.
+		const piCodingPkgJson = readFileSync(
+			join(piCodingReal, "package.json"),
+			"utf8",
+		);
+		b.onLoad({ filter: /\/pi-coding-agent\/dist\/config\.js$/ }, (a) => {
+			let src = readFileSync(a.path, "utf8");
+			const needle = 'readFileSync(getPackageJsonPath(), "utf-8")';
+			if (!src.includes(needle)) {
+				throw new Error(
+					"snapshot-safe: config.js readFileSync(package.json) shape changed; update the transform",
+				);
+			}
+			src = src.replace(needle, JSON.stringify(piCodingPkgJson));
+			return { contents: src, loader: "js" };
+		});
+		// env-api-keys.js eagerly fires 3 fire-and-forget dynamicImport().then()
+		// at top level, leaving pending promises. Convert to synchronous require()
+		// (grabs the polyfill module reference only — no I/O, no pending promise),
+		// preserving the feature post-restore.
+		const ENV_API_KEYS_EAGER_IMPORTS = 3;
+		b.onLoad({ filter: /\/pi-ai\/dist\/env-api-keys\.js$/ }, (a) => {
+			let src = readFileSync(a.path, "utf8");
+			const re =
+				/dynamicImport\((NODE_\w+_SPECIFIER)\)\.then\(\(m\)\s*=>\s*\{\s*(_\w+)\s*=\s*m\.(\w+);\s*\}\);/g;
+			// Count matches BEFORE replacing: a `src === before` check only catches a
+			// total shape change. If upstream adds a 4th eager import (or drops one),
+			// the regex would silently transform a subset and leave a pending-promise
+			// hazard at module-init — re-breaking snapshot-safety with no build error.
+			// Assert the exact expected count so any drift fails the build loudly.
+			const matchCount = (src.match(re) || []).length;
+			if (matchCount !== ENV_API_KEYS_EAGER_IMPORTS) {
+				throw new Error(
+					`snapshot-safe: env-api-keys.js eager dynamicImport shape changed ` +
+						`(found ${matchCount}, expected ${ENV_API_KEYS_EAGER_IMPORTS}); update the transform`,
+				);
+			}
+			src = src.replace(
+				re,
+				(_m, spec, lhs, prop) => `try { ${lhs} = require(${spec}).${prop}; } catch {}`,
+			);
+			return { contents: src, loader: "js" };
+		});
+		// pi-tui/dist/utils.js creates a module-level `new Intl.Segmenter(...)` — an
+		// ICU-backed native (External) object that V8's SnapshotCreator cannot
+		// serialize ("global handle not serialized: <Foreign>"). Lazy-init it behind
+		// a Proxy so the real segmenter is created on first use (post-restore, where
+		// Intl is fully available) instead of at module-init. The headless ACP adapter
+		// never renders the TUI, so the segmenter is only touched after restore anyway.
+		b.onLoad({ filter: /\/pi-tui\/dist\/utils\.js$/ }, (a) => {
+			let src = readFileSync(a.path, "utf8");
+			const needle =
+				'const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });';
+			if (!src.includes(needle)) {
+				throw new Error(
+					"snapshot-safe: pi-tui utils.js Intl.Segmenter singleton shape changed; update the transform",
+				);
+			}
+			src = src.replace(
+				needle,
+				"const segmenter = (() => { let s; const get = () => (s || (s = new Intl.Segmenter(undefined, { granularity: \"grapheme\" }))); return new Proxy({}, { get: (_, k) => { const v = get()[k]; return typeof v === \"function\" ? v.bind(get()) : v; } }); })();",
+			);
+			return { contents: src, loader: "js" };
+		});
+	},
+};
+
+// esbuild stubs `import.meta` to `{}` in IIFE output, so import.meta.url is
+// undefined and the SDK's top-level install-detection (fileURLToPath(import.meta.url))
+// crashes. Pin it to a single deterministic URL: the SDK's projected guest path, so
+// any top-level dir/version computation resolves to where the SDK actually lives in
+// the VM. Override with PI_SNAPSHOT_BASE_URL (e.g. the real host path for testing).
+const baseUrl =
+	process.env.PI_SNAPSHOT_BASE_URL ||
+	"file:///root/node_modules/@mariozechner/pi-coding-agent/dist/index.js";
+
+const result = await build({
+	entryPoints: [entryPoint],
+	outfile,
+	bundle: true,
+	format: "iife",
+	platform: "node", // node: builtins become external require() calls
+	target: "esnext",
+	external: lazyExternals,
+	plugins: [stubPlugin, deepImportPlugin, snapshotSafePlugin],
+	define: {
+		"import.meta.url": JSON.stringify(baseUrl),
+		// C0 mitigation: force the headless path in the clipboard native-addon
+		// guard so `require("@mariozechner/clipboard")` (a NAPI addon) is never
+		// triggered at snapshot-eval time, regardless of the sidecar's env.
+		"process.env.DISPLAY": '""',
+		"process.env.WAYLAND_DISPLAY": '""',
+		"process.env.TERMUX_VERSION": '""',
+	},
+	legalComments: "none",
+	logLevel: "info",
+	metafile: true,
+});
+
+const bytes = readFileSync(outfile);
+const sha256 = createHash("sha256").update(bytes).digest("hex");
+writeFileSync(`${outfile}.sha256`, `${sha256}\n`);
+
+const inputs = Object.keys(result.metafile.inputs).length;
+console.log(
+	`\nsdk-snapshot.js: ${(bytes.length / 1024).toFixed(0)} KiB · ${inputs} modules inlined · sha256 ${sha256.slice(0, 12)}…`,
+);

--- a/registry/agent/pi/src/adapter.ts
+++ b/registry/agent/pi/src/adapter.ts
@@ -1,0 +1,1505 @@
+#!/usr/bin/env node
+
+/**
+ * Pi SDK ACP Adapter
+ *
+ * ACP-compliant adapter that embeds the Pi coding agent SDK directly
+ * instead of spawning a subprocess. This avoids loading ~100MB of TUI
+ * code that the CLI pulls in even in headless mode.
+ *
+ * Speaks ACP JSON-RPC over stdin/stdout using @agentclientprotocol/sdk.
+ * Internally builds a real Pi AgentSession without loading the CLI's
+ * resource loader path, which pulls jiti into the VM runtime.
+ */
+
+import {
+	type Agent,
+	AgentSideConnection,
+	type RequestError,
+	ndJsonStream,
+} from "@agentclientprotocol/sdk";
+import type {
+	AuthenticateRequest,
+	AuthenticateResponse,
+	CancelNotification,
+	InitializeRequest,
+	InitializeResponse,
+	NewSessionRequest,
+	NewSessionResponse,
+	PromptRequest,
+	PromptResponse,
+	SetSessionModeRequest,
+	SetSessionModeResponse,
+	SessionNotification,
+} from "@agentclientprotocol/sdk";
+import type {
+	AgentSessionEvent,
+} from "@mariozechner/pi-coding-agent";
+import {
+	existsSync,
+	readFileSync,
+	readdirSync,
+	writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { isAbsolute, join, resolve as resolvePath } from "node:path";
+import { PassThrough } from "node:stream";
+
+// ── Phase tracing (opt-in via PI_TRACE_FILE) ────────────────────────
+// Emits Chrome-trace ("X") events for newSession sub-phases so the otherwise
+// opaque ACP `session/new` span can be broken down and compared against the
+// bare-node equivalent. The file is written in the guest VFS and read by the
+// host (e.g. the benchmark) via vm.readFile.
+function startPhaseTrace() {
+	const spans: { name: string; ts: number; dur: number }[] = [];
+	const t0 = Date.now();
+	return {
+		async span<T>(name: string, fn: () => Promise<T> | T): Promise<T> {
+			const start = Date.now();
+			try {
+				return await fn();
+			} finally {
+				spans.push({ name, ts: (start - t0) * 1000, dur: (Date.now() - start) * 1000 });
+			}
+		},
+		flush(extra: Record<string, unknown> = {}) {
+			const file = process.env.PI_TRACE_FILE;
+			if (!file) return;
+			const events = [
+				{ name: "newSession", cat: "pi", ph: "X", pid: 1, tid: 1, ts: 0, dur: (Date.now() - t0) * 1000, args: extra },
+				...spans.map((s) => ({ name: s.name, cat: "pi", ph: "X", pid: 1, tid: 1, ts: s.ts, dur: s.dur })),
+			];
+			try {
+				writeFileSync(file, JSON.stringify(events));
+			} catch {
+				/* tracing is best-effort */
+			}
+		},
+	};
+}
+
+const PI_SDK_PACKAGE = "@mariozechner/pi-coding-agent";
+const MODULE_ACCESS_NODE_MODULES = "/root/node_modules";
+const require = createRequire(import.meta.url);
+
+const realStdin = process.stdin;
+const bufferedStdin = new PassThrough();
+(bufferedStdin as PassThrough & { isTTY?: boolean; fd?: number }).isTTY =
+	realStdin.isTTY;
+(bufferedStdin as PassThrough & { isTTY?: boolean; fd?: number }).fd =
+	realStdin.fd;
+if (typeof realStdin.setRawMode === "function") {
+	(
+		bufferedStdin as PassThrough & {
+			setRawMode?: (mode: boolean) => void;
+		}
+	).setRawMode = realStdin.setRawMode.bind(realStdin);
+}
+Object.defineProperty(process, "stdin", {
+	configurable: true,
+	enumerable: true,
+	value: bufferedStdin,
+});
+
+type SessionManagerLike = {
+	inMemory(cwd?: string): unknown;
+};
+
+type ModelLike = {
+	id: string;
+	provider: string;
+	baseUrl?: string;
+	reasoning?: boolean;
+};
+
+type MinimalResourceLoaderLike = {
+	reload(): Promise<void>;
+	getExtensions(): {
+		extensions: unknown[];
+		errors: unknown[];
+		runtime: {
+			flagValues: Map<string, unknown>;
+			pendingProviderRegistrations: Array<{
+				name: string;
+				config: unknown;
+			}>;
+		};
+	};
+	getSkills(): { skills: unknown[]; diagnostics: unknown[] };
+	getPrompts(): { prompts: unknown[]; diagnostics: unknown[] };
+	getThemes(): { themes: unknown[]; diagnostics: unknown[] };
+	getAgentsFiles(): { agentsFiles: unknown[] };
+	getSystemPrompt(): string;
+	getAppendSystemPrompt(): string[];
+	getPathMetadata(): Map<string, unknown>;
+	extendResources(_paths: string[]): void;
+};
+
+type PiAgentCoreLike = new (config: {
+	initialState: {
+		systemPrompt: string;
+		model: ModelLike | undefined;
+		thinkingLevel: string;
+		tools: unknown[];
+	};
+	convertToLlm: (messages: unknown[]) => unknown[];
+	onPayload: (payload: unknown, model: unknown) => Promise<unknown>;
+	sessionId: string;
+	transformContext: (messages: unknown[]) => Promise<unknown[]>;
+	steeringMode: unknown;
+	followUpMode: unknown;
+	transport: unknown;
+	thinkingBudgets: unknown;
+	maxRetryDelayMs: number;
+	getApiKey: (provider?: string) => Promise<string>;
+}) => {
+	state: {
+		model?: ModelLike;
+		thinkingLevel: string;
+	};
+	subscribe(listener: (event: unknown) => void): () => void;
+	prompt(text: string): Promise<void>;
+	abort(): void;
+	setThinkingLevel(level: string): void;
+	setTools(tools: PiToolLike[]): void;
+	setSystemPrompt(prompt: string): void;
+	replaceMessages(messages: unknown[]): void;
+};
+
+type SettingsManagerInstanceLike = {
+	getDefaultProvider(): string | undefined;
+	getDefaultModel(): string | undefined;
+	getDefaultThinkingLevel(): string | undefined;
+	getBlockImages(): boolean;
+	getSteeringMode(): unknown;
+	getFollowUpMode(): unknown;
+	getTransport(): unknown;
+	getThinkingBudgets(): unknown;
+	getRetrySettings(): { maxDelayMs: number };
+	getShellCommandPrefix(): string | undefined;
+	getImageAutoResize(): boolean;
+};
+
+type ModelRegistryInstanceLike = {
+	find(provider: string, modelId: string): ModelLike | undefined;
+	getAvailable(): Promise<ModelLike[]>;
+	getApiKey(model: ModelLike): Promise<string | undefined>;
+	getApiKeyForProvider(provider: string): Promise<string | undefined>;
+	isUsingOAuth(model: ModelLike): boolean;
+};
+
+type SessionManagerInstanceLike = {
+	buildSessionContext(): {
+		messages: unknown[];
+		model?: { provider: string; modelId: string };
+		thinkingLevel?: string;
+	};
+	getBranch(): Array<{ type: string }>;
+	appendModelChange(provider: string, modelId: string): void;
+	appendThinkingLevelChange(thinkingLevel: string): void;
+	getSessionId(): string;
+};
+
+type PiToolLike = {
+	name: string;
+	description?: string;
+	parameters?: unknown;
+	execute(
+		toolCallId: string,
+		args: unknown,
+		signal: AbortSignal,
+		onUpdate?: (partialResult: unknown) => void,
+	): Promise<{
+		content: unknown;
+		details?: unknown;
+	}>;
+};
+
+type ExtensionFactoryLike = (api: unknown) => unknown;
+
+type PiSessionLike = {
+	readonly sessionId: string;
+	readonly thinkingLevel: string;
+	readonly messages: unknown[];
+	subscribe(
+		listener: (event: AgentSessionEvent) => void,
+	): () => void;
+	getAvailableThinkingLevels(): string[];
+	prompt(text: string): Promise<void>;
+	abort(): Promise<void>;
+	setThinkingLevel(level: string): void;
+};
+
+type PiSdkRuntime = {
+	Agent: PiAgentCoreLike;
+	AuthStorage: {
+		create(authPath?: string): unknown;
+	};
+	DefaultResourceLoader: new (options: {
+		cwd?: string;
+		agentDir?: string;
+		settingsManager?: SettingsManagerInstanceLike;
+		appendSystemPrompt?: string;
+		extensionFactories?: ExtensionFactoryLike[];
+		noExtensions?: boolean;
+	}) => MinimalResourceLoaderLike;
+	DEFAULT_THINKING_LEVEL: string;
+	ModelRegistry: new (authStorage: unknown, modelsPath?: string) => {
+		find(provider: string, modelId: string): ModelLike | undefined;
+		getAvailable(): Promise<ModelLike[]>;
+		getApiKey(model: ModelLike): Promise<string | undefined>;
+		getApiKeyForProvider(provider: string): Promise<string | undefined>;
+		isUsingOAuth(model: ModelLike): boolean;
+	};
+	SettingsManager: {
+		create(cwd?: string, agentDir?: string): SettingsManagerInstanceLike;
+	};
+	SessionManager: SessionManagerLike;
+	convertToLlm(messages: unknown[]): unknown[];
+	getAgentDir(): string;
+	getDocsPath(): string;
+	createAgentSession(options?: {
+		cwd?: string;
+		agentDir?: string;
+		sessionManager?: unknown;
+		resourceLoader?: MinimalResourceLoaderLike;
+		settingsManager?: SettingsManagerInstanceLike;
+		tools?: PiToolLike[];
+		customTools?: PiToolLike[];
+	}): Promise<{ session: PiSessionLike; modelFallbackMessage?: string }>;
+	createCodingTools(
+		cwd: string,
+		options?: {
+			read?: { autoResizeImages?: boolean };
+			bash?: {
+				commandPrefix?: string;
+			};
+		},
+	): PiToolLike[];
+	createAllTools(
+		cwd: string,
+		options?: {
+			read?: { autoResizeImages?: boolean };
+			bash?: {
+				commandPrefix?: string;
+			};
+		},
+	): Record<string, PiToolLike>;
+};
+
+let piSdkRuntimePromise: Promise<PiSdkRuntime> | undefined;
+
+class MinimalPiSession implements PiSessionLike {
+	private readonly listeners = new Set<
+		(event: AgentSessionEvent) => void
+	>();
+
+	constructor(
+		private readonly agent: InstanceType<PiAgentCoreLike>,
+		private readonly sessionManager: SessionManagerInstanceLike,
+		private readonly settingsManager: SettingsManagerInstanceLike,
+		private readonly resourceLoader: MinimalResourceLoaderLike,
+		private readonly runtime: Pick<PiSdkRuntime, "createAllTools">,
+		private readonly cwd: string,
+		private readonly appendPrompt?: string,
+	) {
+		this.agent.subscribe((event) => {
+			this.emit(event as AgentSessionEvent);
+		});
+		this.rebuildRuntime();
+	}
+
+	get sessionId(): string {
+		return this.sessionManager.getSessionId();
+	}
+
+	get thinkingLevel(): string {
+		return this.agent.state.thinkingLevel;
+	}
+
+	get messages(): unknown[] {
+		return (this.agent as { state: { messages?: unknown[] } }).state.messages ?? [];
+	}
+
+	subscribe(listener: (event: AgentSessionEvent) => void): () => void {
+		this.listeners.add(listener);
+		return () => this.listeners.delete(listener);
+	}
+
+	getAvailableThinkingLevels(): string[] {
+		return this.agent.state.model?.reasoning
+			? ["off", "minimal", "low", "medium", "high"]
+			: ["off"];
+	}
+
+	async prompt(text: string): Promise<void> {
+		await this.agent.prompt(text);
+	}
+
+	async abort(): Promise<void> {
+		this.agent.abort();
+	}
+
+	setThinkingLevel(level: string): void {
+		const nextLevel = this.agent.state.model?.reasoning ? level : "off";
+		this.agent.setThinkingLevel(nextLevel);
+		this.sessionManager.appendThinkingLevelChange(nextLevel);
+	}
+
+	private emit(event: AgentSessionEvent): void {
+		for (const listener of this.listeners) {
+			listener(event);
+		}
+	}
+
+	private rebuildRuntime(): void {
+		const baseTools = this.runtime.createAllTools(this.cwd, {
+			read: {
+				autoResizeImages: this.settingsManager.getImageAutoResize(),
+			},
+			bash: {
+				commandPrefix: this.settingsManager.getShellCommandPrefix(),
+			},
+		});
+		const activeToolNames = ["read", "bash", "edit", "write"].filter(
+			(name) => name in baseTools,
+		);
+		this.agent.setTools(
+			activeToolNames.map((name) => baseTools[name]).filter(Boolean),
+		);
+		this.agent.setSystemPrompt(
+			buildAdapterSystemPrompt(this.cwd, this.appendPrompt),
+		);
+	}
+}
+
+function buildAdapterSystemPrompt(
+	cwd: string,
+	appendPrompt?: string,
+): string {
+	const date = new Date().toISOString().slice(0, 10);
+	const extra = appendPrompt ? `\n\n${appendPrompt}` : "";
+	return (
+		"You are an expert coding assistant operating inside Pi's ACP adapter.\n" +
+		"Use the available tools when they help complete the user's request.\n" +
+		"Be concise, prefer direct file and shell operations, and describe file paths clearly." +
+		`${extra}\nCurrent date: ${date}\nCurrent working directory: ${cwd}`
+	);
+}
+
+const DISCOVERED_EXTENSION_INDEX_CANDIDATES = [
+	"index.js",
+	"index.mjs",
+	"index.cjs",
+] as const;
+
+function isDiscoveredExtensionEntry(name: string): boolean {
+	return (
+		name.endsWith(".js") || name.endsWith(".mjs") || name.endsWith(".cjs")
+	);
+}
+
+function discoverAutoExtensionPaths(cwd: string, agentDir: string): string[] {
+	const extensionRoots = [join(agentDir, "extensions"), join(cwd, ".pi", "extensions")];
+	const discovered = new Set<string>();
+
+	for (const root of extensionRoots) {
+		if (!existsSync(root)) {
+			continue;
+		}
+		for (const entry of readdirSync(root, { withFileTypes: true })) {
+			const entryPath = join(root, entry.name);
+			if (entry.isFile() && isDiscoveredExtensionEntry(entry.name)) {
+				discovered.add(entryPath);
+				continue;
+			}
+			if (!entry.isDirectory()) {
+				continue;
+			}
+			for (const candidate of DISCOVERED_EXTENSION_INDEX_CANDIDATES) {
+				const candidatePath = join(entryPath, candidate);
+				if (existsSync(candidatePath)) {
+					discovered.add(candidatePath);
+					break;
+				}
+			}
+		}
+	}
+
+	return [...discovered].sort();
+}
+
+function readCommonJsExtensionFactory(
+	extensionPath: string,
+): ExtensionFactoryLike | undefined {
+	const required = require(extensionPath);
+	if (typeof required === "function") {
+		return required as ExtensionFactoryLike;
+	}
+	if (typeof required?.default === "function") {
+		return required.default as ExtensionFactoryLike;
+	}
+	return undefined;
+}
+
+// Temporary workaround: the V8 module loader currently fails dynamic
+// import() of ESM `.js` extension files, so this evaluates a transformed
+// copy of bare `export default` extensions. It cannot handle `import`
+// statements or named exports. Delete this once the loader supports ESM
+// `.js` dynamic import.
+function readInlineDefaultExportFactory(
+	extensionPath: string,
+): ExtensionFactoryLike | undefined {
+	const source = readFileSync(extensionPath, "utf8");
+	if (!/\bexport\s+default\b/.test(source)) {
+		return undefined;
+	}
+
+	const module = { exports: {} as { default?: unknown } };
+	const transformed = source.replace(
+		/\bexport\s+default\b/,
+		"module.exports.default =",
+	);
+	new Function("module", "exports", "require", transformed)(
+		module,
+		module.exports,
+		require,
+	);
+
+	return typeof module.exports.default === "function"
+		? (module.exports.default as ExtensionFactoryLike)
+		: undefined;
+}
+
+async function loadExtensionFactoryFromPath(
+	extensionPath: string,
+): Promise<ExtensionFactoryLike | undefined> {
+	if (extensionPath.endsWith(".cjs")) {
+		return readCommonJsExtensionFactory(extensionPath);
+	}
+
+	if (extensionPath.endsWith(".mjs")) {
+		const module = await import(extensionPath);
+		return typeof module.default === "function"
+			? (module.default as ExtensionFactoryLike)
+			: undefined;
+	}
+
+	try {
+		return readCommonJsExtensionFactory(extensionPath);
+	} catch (error) {
+		let inlineFactory: ExtensionFactoryLike | undefined;
+		try {
+			inlineFactory = readInlineDefaultExportFactory(extensionPath);
+		} catch (inlineError) {
+			const inlineMessage =
+				inlineError instanceof Error ? inlineError.message : String(inlineError);
+			if (error instanceof Error) {
+				error.message = `${error.message} (inline default-export fallback also failed: ${inlineMessage})`;
+			}
+			throw error;
+		}
+		if (inlineFactory) {
+			return inlineFactory;
+		}
+		throw error;
+	}
+}
+
+async function loadDiscoveredExtensionFactories(
+	cwd: string,
+	agentDir: string,
+): Promise<{
+	extensionFactories: ExtensionFactoryLike[];
+	errors: Array<{ path: string; error: string }>;
+}> {
+	const extensionFactories: ExtensionFactoryLike[] = [];
+	const errors: Array<{ path: string; error: string }> = [];
+
+	for (const extensionPath of discoverAutoExtensionPaths(cwd, agentDir)) {
+		try {
+			const factory = await loadExtensionFactoryFromPath(extensionPath);
+			if (!factory) {
+				errors.push({
+					path: extensionPath,
+					error: "Extension does not export a valid factory function",
+				});
+				continue;
+			}
+			extensionFactories.push(factory);
+		} catch (error) {
+			errors.push({
+				path: extensionPath,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	return { extensionFactories, errors };
+}
+
+class MinimalResourceLoader implements MinimalResourceLoaderLike {
+	private readonly runtime = {
+		flagValues: new Map<string, unknown>(),
+		pendingProviderRegistrations: [] as Array<{
+			name: string;
+			config: unknown;
+		}>,
+	};
+
+	constructor(private readonly options: { appendSystemPrompt?: string }) {}
+
+	async reload(): Promise<void> {}
+
+	getExtensions() {
+		return {
+			extensions: [],
+			errors: [],
+			runtime: this.runtime,
+		};
+	}
+
+	getSkills() {
+		return { skills: [], diagnostics: [] };
+	}
+
+	getPrompts() {
+		return { prompts: [], diagnostics: [] };
+	}
+
+	getThemes() {
+		return { themes: [], diagnostics: [] };
+	}
+
+	getAgentsFiles() {
+		return { agentsFiles: [] };
+	}
+
+	getSystemPrompt(): string {
+		return "";
+	}
+
+	getAppendSystemPrompt(): string[] {
+		return this.options.appendSystemPrompt ? [this.options.appendSystemPrompt] : [];
+	}
+
+	getPathMetadata(): Map<string, unknown> {
+		return new Map();
+	}
+
+	extendResources(_paths: string[]): void {}
+}
+
+function findInstalledPackageRoot(packageName: string): string | null {
+	const searchPaths = require.resolve.paths(packageName) ?? [];
+	for (const basePath of searchPaths) {
+		const candidateRoot = join(basePath, packageName);
+		if (existsSync(join(candidateRoot, "package.json"))) {
+			return candidateRoot;
+		}
+	}
+	return null;
+}
+
+function findProjectedPackageRoot(packageName: string): string {
+	const installedRoot = findInstalledPackageRoot(packageName);
+	if (installedRoot) {
+		return installedRoot;
+	}
+
+	const directRoot = `${MODULE_ACCESS_NODE_MODULES}/${packageName}`;
+	const pnpmRoot = `${MODULE_ACCESS_NODE_MODULES}/.pnpm`;
+	const pnpmPrefix = `${packageName.replace("/", "+")}@`;
+
+	if (existsSync(pnpmRoot)) {
+		for (const entry of readdirSync(pnpmRoot)) {
+			if (!entry.startsWith(pnpmPrefix)) continue;
+			const candidateRoot = join(pnpmRoot, entry, "node_modules", packageName);
+			if (existsSync(join(candidateRoot, "package.json"))) {
+				return candidateRoot;
+			}
+		}
+	}
+
+	return directRoot;
+}
+
+// When the agent SDK has been evaluated into the V8 startup snapshot (built once
+// per sidecar), its runtime API is already present on this global — published by
+// the snapshot build-entry (snapshot-entry.ts). Reading it skips the per-session
+// dynamic-import + evaluate of the whole SDK graph entirely.
+const PI_SDK_RUNTIME_GLOBAL = "__PI_SDK_RUNTIME__";
+
+function readSnapshotRuntime(): PiSdkRuntime | undefined {
+	const candidate = (globalThis as Record<string, unknown>)[
+		PI_SDK_RUNTIME_GLOBAL
+	];
+	if (
+		candidate &&
+		typeof candidate === "object" &&
+		typeof (candidate as PiSdkRuntime).createAgentSession === "function"
+	) {
+		return candidate as PiSdkRuntime;
+	}
+	return undefined;
+}
+
+async function loadPiSdkRuntime(): Promise<PiSdkRuntime> {
+	if (!piSdkRuntimePromise) {
+		// Snapshot fast path: the SDK runtime is already on the global (evaluated
+		// into the snapshot at sidecar startup). No I/O, no module resolution.
+		const snapshotRuntime = readSnapshotRuntime();
+		if (snapshotRuntime) {
+			piSdkRuntimePromise = Promise.resolve(snapshotRuntime);
+			return piSdkRuntimePromise;
+		}
+		// Fallback: load the SDK from the guest VFS via dynamic import (the path
+		// used when no snapshot is present, e.g. a cold/unsupported runtime).
+		piSdkRuntimePromise = (async () => {
+			const packageRoot = findProjectedPackageRoot(PI_SDK_PACKAGE);
+			const agentCoreRoot = findProjectedPackageRoot("@mariozechner/pi-agent-core");
+			const [
+				agentCoreModule,
+				authStorageModule,
+				configModule,
+				defaultsModule,
+				messagesModule,
+				modelRegistryModule,
+				resourceLoaderModule,
+				sdkModule,
+				sessionManagerModule,
+				settingsManagerModule,
+				toolsModule,
+			] =
+				await Promise.all([
+					import(`${agentCoreRoot}/dist/index.js`),
+					import(`${packageRoot}/dist/core/auth-storage.js`),
+					import(`${packageRoot}/dist/config.js`),
+					import(`${packageRoot}/dist/core/defaults.js`),
+					import(`${packageRoot}/dist/core/messages.js`),
+					import(`${packageRoot}/dist/core/model-registry.js`),
+					import(`${packageRoot}/dist/core/resource-loader.js`),
+					import(`${packageRoot}/dist/core/sdk.js`),
+					import(`${packageRoot}/dist/core/session-manager.js`),
+					import(`${packageRoot}/dist/core/settings-manager.js`),
+					import(`${packageRoot}/dist/core/tools/index.js`),
+				]);
+
+			return {
+				Agent: agentCoreModule.Agent as PiAgentCoreLike,
+				AuthStorage: authStorageModule.AuthStorage as PiSdkRuntime["AuthStorage"],
+				DefaultResourceLoader:
+					resourceLoaderModule.DefaultResourceLoader as PiSdkRuntime["DefaultResourceLoader"],
+				DEFAULT_THINKING_LEVEL:
+					defaultsModule.DEFAULT_THINKING_LEVEL as string,
+				ModelRegistry:
+					modelRegistryModule.ModelRegistry as PiSdkRuntime["ModelRegistry"],
+				SettingsManager:
+					settingsManagerModule.SettingsManager as PiSdkRuntime["SettingsManager"],
+				SessionManager: sessionManagerModule.SessionManager as SessionManagerLike,
+				convertToLlm:
+					messagesModule.convertToLlm as PiSdkRuntime["convertToLlm"],
+				getAgentDir: configModule.getAgentDir as PiSdkRuntime["getAgentDir"],
+				getDocsPath: configModule.getDocsPath as PiSdkRuntime["getDocsPath"],
+				createAgentSession:
+					sdkModule.createAgentSession as PiSdkRuntime["createAgentSession"],
+				createCodingTools:
+					sdkModule.createCodingTools as PiSdkRuntime["createCodingTools"],
+				createAllTools:
+					toolsModule.createAllTools as PiSdkRuntime["createAllTools"],
+			};
+		})();
+	}
+
+	return piSdkRuntimePromise;
+}
+
+async function createAgentSession(options: {
+	cwd: string;
+	sessionManager: unknown;
+	resourceLoader: MinimalResourceLoaderLike;
+	tools?: PiToolLike[];
+}): Promise<{ session: PiSessionLike; modelFallbackMessage?: string }> {
+	const { createAgentSession: createPiAgentSession, SettingsManager } =
+		await loadPiSdkRuntime();
+
+	const cwd = options.cwd;
+	const homeDir = process.env.HOME || "/home/agentos";
+	const agentDir = join(homeDir, ".pi", "agent");
+	const settingsManager = SettingsManager.create(cwd, agentDir);
+	const result = await createPiAgentSession({
+		cwd,
+		agentDir,
+		sessionManager: options.sessionManager,
+		resourceLoader: options.resourceLoader,
+		settingsManager,
+		tools: options.tools,
+		customTools: options.tools,
+	});
+	applyAnthropicBaseUrlOverride(result.session);
+	return result;
+}
+
+function applyAnthropicBaseUrlOverride(session: PiSessionLike): void {
+	const baseUrl = process.env.ANTHROPIC_BASE_URL;
+	if (!baseUrl) return;
+	const agent = (session as { agent?: { state?: { model?: ModelLike } } }).agent;
+	const model = agent?.state?.model;
+	if (model?.provider !== "anthropic") return;
+	if (!agent?.state) return;
+	agent.state.model = { ...model, baseUrl };
+}
+
+// ── CLI argument parsing ────────────────────────────────────────────
+
+let appendSystemPrompt: string | undefined;
+const argv = process.argv.slice(2);
+for (let i = 0; i < argv.length; i++) {
+	if (argv[i] === "--append-system-prompt" && i + 1 < argv.length) {
+		appendSystemPrompt = argv[i + 1];
+		i++;
+	}
+}
+
+// ── Agent implementation ────────────────────────────────────────────
+
+class PiSdkAgent implements Agent {
+	private conn: AgentSideConnection;
+	private session: PiSessionLike | null = null;
+	private sessionId = "";
+	private cwd = "/workspace";
+	private cancelRequested = false;
+	private currentToolCalls = new Map<string, string>();
+	private emittedAssistantText = false;
+	private bufferingUpdates = false;
+	private pendingUpdates: SessionNotification["update"][] = [];
+	private streamedTextContent = new Set<string>();
+	private editSnapshots = new Map<
+		string,
+		{ path: string; oldText: string }
+	>();
+	private lastEmit: Promise<void> = Promise.resolve();
+
+	constructor(conn: AgentSideConnection) {
+		this.conn = conn;
+	}
+
+	async initialize(
+		_params: InitializeRequest,
+	): Promise<InitializeResponse> {
+		return {
+			protocolVersion: 1,
+			agentInfo: {
+				name: "pi-sdk-acp",
+				title: "Pi SDK ACP adapter",
+				version: "0.1.0",
+			},
+			agentCapabilities: {
+				promptCapabilities: {
+					image: true,
+					audio: false,
+					embeddedContext: false,
+				},
+			},
+		};
+	}
+
+	async newSession(
+		params: NewSessionRequest,
+	): Promise<NewSessionResponse> {
+		const __trace = startPhaseTrace();
+		this.cwd = params.cwd;
+		process.chdir(params.cwd);
+		const agentDir = join(process.env.HOME || "/home/agentos", ".pi", "agent");
+		const {
+			DefaultResourceLoader,
+			SessionManager,
+			SettingsManager,
+			createCodingTools,
+		} = await __trace.span("loadPiSdkRuntime", () => loadPiSdkRuntime());
+		const { extensionFactories, errors: extensionLoadErrors } =
+			await __trace.span("loadExtensions", () =>
+				loadDiscoveredExtensionFactories(params.cwd, agentDir),
+			);
+		// Step 3: when no workspace extensions were discovered (the common case),
+		// skip DefaultResourceLoader entirely — it eagerly loads skills/themes/
+		// prompts/agentsFiles (~250ms) the headless ACP adapter doesn't use. The
+		// MinimalResourceLoader's reload() is a no-op. Only the full loader (with its
+		// extension runtime) is constructed when extensions are actually present.
+		const resourceLoader: MinimalResourceLoaderLike =
+			extensionFactories.length > 0
+				? new DefaultResourceLoader({
+						cwd: params.cwd,
+						agentDir,
+						noExtensions: true,
+						extensionFactories,
+						...(appendSystemPrompt ? { appendSystemPrompt } : {}),
+					})
+				: new MinimalResourceLoader({
+						...(appendSystemPrompt ? { appendSystemPrompt } : {}),
+					});
+		await __trace.span("resourceLoader.reload", () => resourceLoader.reload());
+		for (const { path, error } of extensionLoadErrors) {
+			console.warn(`[pi-sdk-acp] Failed to load extension ${path}: ${error}`);
+		}
+		const settingsManager = SettingsManager.create(
+			params.cwd,
+			agentDir,
+		);
+
+		const { session } = await __trace.span("createAgentSession", () =>
+			createAgentSession({
+				cwd: params.cwd,
+				sessionManager: SessionManager.inMemory(params.cwd),
+				resourceLoader,
+				tools: this.wrapTools(
+					createCodingTools(params.cwd, {
+						read: {
+							autoResizeImages: settingsManager.getImageAutoResize(),
+						},
+						bash: {
+							commandPrefix: settingsManager.getShellCommandPrefix(),
+						},
+					}),
+				),
+			}),
+		);
+		__trace.flush();
+
+		this.session = session;
+		this.sessionId = session.sessionId;
+
+		// Subscribe to Pi SDK events and translate to ACP notifications
+		session.subscribe((event) => this.handlePiEvent(event));
+
+		// Build thinking modes
+		const thinkingLevels = session.getAvailableThinkingLevels();
+		const modes = {
+			currentModeId: session.thinkingLevel,
+			availableModes: thinkingLevels.map((id) => ({
+				id,
+				name: `Thinking: ${id}`,
+			})),
+		};
+
+		return {
+			sessionId: this.sessionId,
+			modes,
+		};
+	}
+
+	async prompt(params: PromptRequest): Promise<PromptResponse> {
+		const session = this.session;
+		if (!session) {
+			throw new Error("No session created");
+		}
+
+		this.cancelRequested = false;
+		this.currentToolCalls.clear();
+		this.emittedAssistantText = false;
+		this.pendingUpdates = [];
+		this.streamedTextContent.clear();
+
+		// Extract text from prompt parts
+		const promptParts = params.prompt ?? [];
+		const text = promptParts
+			.map((p: { type?: string; text?: string }) =>
+				p.type === "text" ? (p.text ?? "") : "",
+			)
+			.join("");
+
+		// session.prompt() resolves when the agent loop completes.
+		// Events fire via subscribe() during execution and are translated
+		// to ACP notifications in handlePiEvent().
+		try {
+			await session.prompt(text);
+		} catch (error) {
+			if (!this.cancelRequested) {
+				throw error;
+			}
+		}
+
+		if (!this.emittedAssistantText) {
+			const latestText = this.latestAssistantText();
+			await this.emitAssistantText(latestText);
+		}
+
+		// The SDK resolves prompt() before its queued session event pipeline
+		// has necessarily drained through subscribe() listeners.
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+		await this.flushPendingUpdates();
+		await this.lastEmit;
+
+		const stopReason = this.cancelRequested ? "cancelled" : "end_turn";
+		return {
+			stopReason: stopReason as PromptResponse["stopReason"],
+		};
+	}
+
+	async cancel(_params: CancelNotification): Promise<void> {
+		this.cancelRequested = true;
+		await this.session?.abort();
+	}
+
+	async setSessionMode(
+		params: SetSessionModeRequest,
+	): Promise<SetSessionModeResponse | void> {
+		if (!this.session) return;
+
+		this.session.setThinkingLevel(
+			params.modeId as Parameters<PiSessionLike["setThinkingLevel"]>[0],
+		);
+
+		await this.emit({
+			sessionUpdate: "current_mode_update" as const,
+			currentModeId: params.modeId,
+		});
+	}
+
+	async authenticate(
+		_params: AuthenticateRequest,
+	): Promise<AuthenticateResponse | void> {
+		// Auth handled via env vars (ANTHROPIC_API_KEY)
+	}
+
+	// ── Event translation ───────────────────────────────────────────
+
+	private emit(update: SessionNotification["update"]): Promise<void> {
+		if (this.bufferingUpdates) {
+			this.pendingUpdates.push(update);
+			return Promise.resolve();
+		}
+		return this.sendUpdate(update);
+	}
+
+	private sendUpdate(update: SessionNotification["update"]): Promise<void> {
+		this.lastEmit = this.lastEmit
+			.then(() =>
+				this.conn.sessionUpdate({
+					sessionId: this.sessionId,
+					update,
+				}),
+			)
+			.catch(() => {});
+		return this.lastEmit;
+	}
+
+	private async flushPendingUpdates(): Promise<void> {
+		const updates = this.pendingUpdates;
+		this.pendingUpdates = [];
+		for (const update of updates) {
+			await this.sendUpdate(update);
+		}
+	}
+
+	private emitAssistantText(text: string): Promise<void> {
+		if (!text) {
+			return Promise.resolve();
+		}
+		this.emittedAssistantText = true;
+		return this.emit({
+			sessionUpdate: "agent_message_chunk",
+			content: {
+				type: "text",
+				text,
+			},
+		});
+	}
+
+	private handlePiEvent(event: AgentSessionEvent): void {
+		switch (event.type) {
+			case "message_update": {
+				const ame = event.assistantMessageEvent;
+				if (!ame) break;
+
+				if (ame.type === "text_delta" && "delta" in ame) {
+					this.streamedTextContent.add(this.textContentKey(ame));
+					this.emitAssistantText(String((ame as { delta: string }).delta));
+				} else if (ame.type === "text_end" && "content" in ame) {
+					const textKey = this.textContentKey(ame);
+					if (!this.streamedTextContent.has(textKey)) {
+						this.emitAssistantText(String((ame as { content: string }).content));
+					}
+				} else if (ame.type === "thinking_delta" && "delta" in ame) {
+					this.emit({
+						sessionUpdate: "agent_thought_chunk",
+						content: {
+							type: "text",
+							text: String((ame as { delta: string }).delta),
+						},
+					});
+				} else if (
+					ame.type === "toolcall_start" ||
+					ame.type === "toolcall_delta" ||
+					ame.type === "toolcall_end"
+				) {
+					this.handleToolCallMessage(ame);
+				}
+				break;
+			}
+
+			case "tool_execution_start":
+				this.handleToolExecutionStart(event);
+				break;
+
+			case "tool_execution_update":
+				this.handleToolExecutionUpdate(event);
+				break;
+
+			case "tool_execution_end":
+				this.handleToolExecutionEnd(event);
+				break;
+
+			case "agent_end":
+				// Agent loop finished. Notifications are flushed in prompt().
+				break;
+		}
+	}
+
+	private handleToolCallMessage(ame: Record<string, unknown>): void {
+		const toolCall =
+			(ame.toolCall as Record<string, unknown>) ??
+			(
+				(ame.partial as Record<string, unknown>)
+					?.content as Array<Record<string, unknown>>
+			)?.[(ame.contentIndex as number) ?? 0];
+
+		if (!toolCall) return;
+
+		const toolCallId = String(toolCall.id ?? "");
+		const toolName = String(toolCall.name ?? "tool");
+
+		if (!toolCallId) return;
+
+		const rawInput = this.parseToolArgs(toolCall);
+		const locations = this.toToolCallLocations(rawInput);
+		const existingStatus = this.currentToolCalls.get(toolCallId);
+		const status = existingStatus ?? "pending";
+
+		if (!existingStatus) {
+			this.currentToolCalls.set(toolCallId, "pending");
+			this.emit({
+				sessionUpdate: "tool_call",
+				toolCallId,
+				title: toolName,
+				kind: toToolKind(toolName),
+				status: status as "pending",
+				locations,
+				rawInput,
+			});
+		} else {
+			this.emit({
+				sessionUpdate: "tool_call_update",
+				toolCallId,
+				status: status as "pending",
+				locations,
+				rawInput,
+			});
+		}
+	}
+
+	private handleToolExecutionStart(event: {
+		toolCallId: string;
+		toolName: string;
+		args: unknown;
+	}): void {
+		const { toolCallId, toolName, args } = event;
+		const rawInput = args as Record<string, unknown> | undefined;
+
+		// Snapshot for edit diff support
+		if (toolName === "edit" && rawInput) {
+			const p =
+				typeof rawInput.path === "string" ? rawInput.path : undefined;
+			if (p) {
+				try {
+					const abs = isAbsolute(p)
+						? p
+						: resolvePath(this.cwd, p);
+					const oldText = readFileSync(abs, "utf8");
+					this.editSnapshots.set(toolCallId, {
+						path: p,
+						oldText,
+					});
+				} catch {
+					// File may not exist
+				}
+			}
+		}
+
+		const locations = this.toToolCallLocations(rawInput);
+
+		if (!this.currentToolCalls.has(toolCallId)) {
+			this.currentToolCalls.set(toolCallId, "in_progress");
+			this.emit({
+				sessionUpdate: "tool_call",
+				toolCallId,
+				title: toolName,
+				kind: toToolKind(toolName),
+				status: "in_progress",
+				locations,
+				rawInput,
+			});
+		} else {
+			this.currentToolCalls.set(toolCallId, "in_progress");
+			this.emit({
+				sessionUpdate: "tool_call_update",
+				toolCallId,
+				status: "in_progress",
+				locations,
+				rawInput,
+			});
+		}
+	}
+
+	private handleToolExecutionUpdate(event: {
+		toolCallId: string;
+		partialResult: unknown;
+	}): void {
+		const { toolCallId, partialResult } = event;
+		const text = toolResultToText(partialResult);
+
+		this.emit({
+			sessionUpdate: "tool_call_update",
+			toolCallId,
+			status: "in_progress",
+			content: text
+				? [{ type: "content", content: { type: "text", text } }]
+				: undefined,
+			rawOutput: partialResult as Record<string, unknown>,
+		});
+	}
+
+	private handleToolExecutionEnd(event: {
+		toolCallId: string;
+		result: unknown;
+		isError: boolean;
+	}): void {
+		const { toolCallId, result, isError } = event;
+		const text = toolResultToText(result);
+		const snapshot = this.editSnapshots.get(toolCallId);
+
+		let content:
+			| Array<
+					| { type: "diff"; path: string; oldText: string; newText: string }
+					| { type: "content"; content: { type: "text"; text: string } }
+				>
+			| undefined;
+
+		// Generate diff for edit tool
+		if (!isError && snapshot) {
+			try {
+				const abs = isAbsolute(snapshot.path)
+					? snapshot.path
+					: resolvePath(this.cwd, snapshot.path);
+				const newText = readFileSync(abs, "utf8");
+				if (newText !== snapshot.oldText) {
+					content = [
+						{
+							type: "diff" as const,
+							path: snapshot.path,
+							oldText: snapshot.oldText,
+							newText,
+						},
+						...(text
+							? [
+									{
+										type: "content" as const,
+										content: { type: "text" as const, text },
+									},
+								]
+							: []),
+					];
+				}
+			} catch {
+				// File may have been deleted
+			}
+		}
+
+		if (!content && text) {
+			content = [
+				{ type: "content" as const, content: { type: "text" as const, text } },
+			];
+		}
+
+		this.emit({
+			sessionUpdate: "tool_call_update",
+			toolCallId,
+			status: isError ? "failed" : "completed",
+			content,
+			rawOutput: result as Record<string, unknown>,
+		});
+
+		this.currentToolCalls.delete(toolCallId);
+		this.editSnapshots.delete(toolCallId);
+	}
+
+	// ── Helpers ──────────────────────────────────────────────────────
+
+	private parseToolArgs(
+		toolCall: Record<string, unknown>,
+	): Record<string, unknown> | undefined {
+		if (
+			toolCall.arguments &&
+			typeof toolCall.arguments === "object"
+		) {
+			return toolCall.arguments as Record<string, unknown>;
+		}
+		const s = String(toolCall.partialArgs ?? "");
+		if (!s) return undefined;
+		try {
+			return JSON.parse(s);
+		} catch {
+			return { partialArgs: s };
+		}
+	}
+
+	private toToolCallLocations(
+		args: Record<string, unknown> | undefined,
+	): Array<{ path: string; line?: number }> | undefined {
+		const path =
+			typeof args?.path === "string" ? args.path : undefined;
+		if (!path) return undefined;
+		const resolvedPath = isAbsolute(path)
+			? path
+			: resolvePath(this.cwd, path);
+		return [{ path: resolvedPath }];
+	}
+
+	private textContentKey(ame: Record<string, unknown>): string {
+		const contentIndex =
+			typeof ame.contentIndex === "number" ? ame.contentIndex : -1;
+		return String(contentIndex);
+	}
+
+	private latestAssistantText(): string {
+		if (!this.session) {
+			return "";
+		}
+
+		for (let index = this.session.messages.length - 1; index >= 0; index--) {
+			const message = this.session.messages[index] as {
+				role?: string;
+				content?: unknown;
+			};
+			if (message.role !== "assistant") {
+				continue;
+			}
+
+			const content = message.content;
+			if (typeof content === "string") {
+				return content;
+			}
+			if (!Array.isArray(content)) {
+				const errorMessage =
+					typeof (message as { errorMessage?: unknown }).errorMessage === "string"
+						? (message as { errorMessage: string }).errorMessage
+						: "";
+				return errorMessage;
+			}
+
+			const text = content
+				.map((part) => {
+					const block = part as { type?: string; text?: string };
+					return block.type === "text" && typeof block.text === "string"
+						? block.text
+						: "";
+				})
+				.filter(Boolean)
+				.join("");
+			if (text) {
+				return text;
+			}
+
+			const errorMessage =
+				typeof (message as { errorMessage?: unknown }).errorMessage === "string"
+					? (message as { errorMessage: string }).errorMessage
+					: "";
+			return errorMessage;
+		}
+
+		return "";
+	}
+
+	private wrapTools(tools: PiToolLike[]): PiToolLike[] {
+		return tools.map((tool) => ({
+			...tool,
+			execute: async (toolCallId, args, signal, onUpdate) => {
+				const rawInput =
+					args && typeof args === "object"
+						? (args as Record<string, unknown>)
+						: undefined;
+				const locations = this.toToolCallLocations(rawInput);
+
+				this.currentToolCalls.set(toolCallId, "in_progress");
+				await this.emit({
+					sessionUpdate: "tool_call",
+					toolCallId,
+					title: tool.name,
+					kind: toToolKind(tool.name),
+					status: "in_progress",
+					locations,
+					rawInput,
+				});
+
+				try {
+					const result = await tool.execute(
+						toolCallId,
+						args,
+						signal,
+						(partialResult) => {
+							void this.emit({
+								sessionUpdate: "tool_call_update",
+								toolCallId,
+								status: "in_progress",
+								content: toTextContent(toolResultToText(partialResult)),
+								rawOutput:
+									partialResult && typeof partialResult === "object"
+										? (partialResult as Record<string, unknown>)
+										: undefined,
+							});
+							onUpdate?.(partialResult);
+						},
+					);
+
+					await this.emit({
+						sessionUpdate: "tool_call_update",
+						toolCallId,
+						status: "completed",
+						content: toTextContent(toolResultToText(result)),
+						rawOutput:
+							result && typeof result === "object"
+								? (result as Record<string, unknown>)
+								: undefined,
+					});
+					return result;
+				} catch (error) {
+					await this.emit({
+						sessionUpdate: "tool_call_update",
+						toolCallId,
+						status: "failed",
+						content:
+							error instanceof Error
+								? toTextContent(error.message)
+								: undefined,
+					});
+					throw error;
+				} finally {
+					this.currentToolCalls.delete(toolCallId);
+				}
+			},
+		}));
+	}
+}
+
+// ── Standalone helpers ──────────────────────────────────────────────
+
+function toToolKind(
+	toolName: string,
+): "read" | "edit" | "other" {
+	if (toolName === "read") return "read";
+	if (toolName === "write" || toolName === "edit") return "edit";
+	return "other";
+}
+
+function toTextContent(text: string):
+	| Array<{ type: "content"; content: { type: "text"; text: string } }>
+	| undefined {
+	if (!text) {
+		return undefined;
+	}
+	return [
+		{
+			type: "content",
+			content: {
+				type: "text",
+				text,
+			},
+		},
+	];
+}
+
+function toolResultToText(result: unknown): string {
+	if (!result) return "";
+	const r = result as Record<string, unknown>;
+	const content = r.content;
+	if (Array.isArray(content)) {
+		const texts = content
+			.map((c: Record<string, unknown>) =>
+				c?.type === "text" && typeof c.text === "string"
+					? c.text
+					: "",
+			)
+			.filter(Boolean);
+		if (texts.length) return texts.join("");
+	}
+	const details = r.details as Record<string, unknown> | undefined;
+	const stdout =
+		(typeof details?.stdout === "string" ? details.stdout : undefined) ??
+		(typeof r.stdout === "string" ? r.stdout : undefined) ??
+		(typeof details?.output === "string" ? details.output : undefined) ??
+		(typeof r.output === "string" ? r.output : undefined);
+	const stderr =
+		(typeof details?.stderr === "string" ? details.stderr : undefined) ??
+		(typeof r.stderr === "string" ? r.stderr : undefined);
+	const exitCode =
+		(typeof details?.exitCode === "number"
+			? details.exitCode
+			: undefined) ??
+		(typeof r.exitCode === "number" ? r.exitCode : undefined) ??
+		(typeof details?.code === "number" ? details.code : undefined) ??
+		(typeof r.code === "number" ? r.code : undefined);
+
+	if (
+		(typeof stdout === "string" && stdout.trim()) ||
+		(typeof stderr === "string" && stderr.trim())
+	) {
+		const parts: string[] = [];
+		if (typeof stdout === "string" && stdout.trim()) parts.push(stdout);
+		if (typeof stderr === "string" && stderr.trim())
+			parts.push(`stderr:\n${stderr}`);
+		if (typeof exitCode === "number")
+			parts.push(`exit code: ${exitCode}`);
+		return parts.join("\n\n").trimEnd();
+	}
+
+	try {
+		return JSON.stringify(result, null, 2);
+	} catch {
+		return String(result);
+	}
+}
+
+// ── Entry point ─────────────────────────────────────────────────────
+
+const input = new WritableStream<Uint8Array>({
+	write(chunk) {
+		return new Promise<void>((resolve) => {
+			process.stdout.write(chunk, () => resolve());
+		});
+	},
+});
+
+const output = new ReadableStream<Uint8Array>({
+	start(controller) {
+		realStdin.on("data", (chunk: Buffer) => {
+			controller.enqueue(new Uint8Array(chunk));
+		});
+		realStdin.on("end", () => controller.close());
+		realStdin.on("error", (error: Error) => controller.error(error));
+	},
+});
+
+const stream = ndJsonStream(input, output);
+const _connection = new AgentSideConnection(
+	(conn) => new PiSdkAgent(conn),
+	stream,
+);
+
+// Keep process alive
+realStdin.resume();
+
+// Shutdown on stdin close
+realStdin.on("end", () => {
+	process.exit(0);
+});

--- a/registry/agent/pi/src/index.ts
+++ b/registry/agent/pi/src/index.ts
@@ -1,0 +1,24 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageDir = resolve(__dirname, "..");
+
+const pi = {
+	name: "pi",
+	type: "agent" as const,
+	packageDir,
+	requires: ["@agentos-software/pi", "@mariozechner/pi-coding-agent"],
+	agent: {
+		id: "pi",
+		acpAdapter: "@agentos-software/pi",
+		agentPackage: "@mariozechner/pi-coding-agent",
+		// Evaluate the bundled Pi SDK into the per-sidecar V8 snapshot
+		// (dist/sdk-snapshot.js) so it loads once per sidecar and is reused
+		// across sessions. Falls back to per-session dynamic import if the
+		// snapshot can't be built.
+		snapshot: true,
+	},
+};
+
+export default pi;

--- a/registry/agent/pi/src/snapshot-entry.ts
+++ b/registry/agent/pi/src/snapshot-entry.ts
@@ -1,0 +1,63 @@
+/**
+ * Pi SDK snapshot entry (Step 2a/2c — eval/entry split).
+ *
+ * This module is bundled by esbuild into a single IIFE (`dist/pi-sdk-snapshot.js`)
+ * whose ONLY job is to evaluate the Pi SDK module graph and publish its exports on
+ * a well-known global, `globalThis.__PI_SDK_RUNTIME__`. The bundle is run once at V8
+ * snapshot-creation time; the evaluated SDK heap is captured into the startup blob
+ * and reused to seed every fresh per-session isolate. After restore the adapter
+ * reads the global instead of dynamically importing the SDK from the guest VFS,
+ * collapsing the ~830ms per-session module-load/eval tax.
+ *
+ * INVARIANTS (enforced by the C0 snapshot-safety scan — see
+ * ~/.agents/research/pi-snapshot-safety-scan.md):
+ *  - This entry performs NO per-session work: it must not read cwd, model,
+ *    ANTHROPIC env vars, HOME, argv, open fds/sockets, or start timers. It only
+ *    binds the SDK's static exports. All per-session configuration is injected
+ *    post-restore by the adapter (newSession), exactly as before.
+ *  - Heavy provider SDKs (@anthropic-ai/sdk, openai, …) are loaded by the SDK via
+ *    dynamic import() and are intentionally NOT part of this static graph; they
+ *    stay lazy and load post-restore from the VFS on first prompt.
+ *  - The bundle is keyed by the sha256 of its own (fully inlined) bytes, so any SDK
+ *    dependency change invalidates the snapshot.
+ */
+
+import { Agent } from "@mariozechner/pi-agent-core";
+import { AuthStorage } from "@mariozechner/pi-coding-agent/dist/core/auth-storage.js";
+import {
+	getAgentDir,
+	getDocsPath,
+} from "@mariozechner/pi-coding-agent/dist/config.js";
+import { DEFAULT_THINKING_LEVEL } from "@mariozechner/pi-coding-agent/dist/core/defaults.js";
+import { convertToLlm } from "@mariozechner/pi-coding-agent/dist/core/messages.js";
+import { ModelRegistry } from "@mariozechner/pi-coding-agent/dist/core/model-registry.js";
+import { DefaultResourceLoader } from "@mariozechner/pi-coding-agent/dist/core/resource-loader.js";
+import {
+	createAgentSession,
+	createCodingTools,
+} from "@mariozechner/pi-coding-agent/dist/core/sdk.js";
+import { SessionManager } from "@mariozechner/pi-coding-agent/dist/core/session-manager.js";
+import { SettingsManager } from "@mariozechner/pi-coding-agent/dist/core/settings-manager.js";
+import { createAllTools } from "@mariozechner/pi-coding-agent/dist/core/tools/index.js";
+
+// The shape mirrors `PiSdkRuntime` in adapter.ts so the adapter can read the
+// global with no behavioral difference from the dynamic-import path.
+const runtime = {
+	Agent,
+	AuthStorage,
+	DefaultResourceLoader,
+	DEFAULT_THINKING_LEVEL,
+	ModelRegistry,
+	SettingsManager,
+	SessionManager,
+	convertToLlm,
+	getAgentDir,
+	getDocsPath,
+	createAgentSession,
+	createCodingTools,
+	createAllTools,
+};
+
+// Publish on the global so it survives into every fresh context cloned from the
+// snapshotted default context.
+(globalThis as Record<string, unknown>).__PI_SDK_RUNTIME__ = runtime;

--- a/registry/agent/pi/tsconfig.json
+++ b/registry/agent/pi/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"declaration": true,
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "src/snapshot-entry.ts"]
+}

--- a/scripts/check-registry-software-split.mjs
+++ b/scripts/check-registry-software-split.mjs
@@ -1,0 +1,150 @@
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	statSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const defaultRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const agentOsPackagePattern = /^@rivet-dev\/agent-os(?:-|$)/;
+const dependencySections = [
+	"dependencies",
+	"devDependencies",
+	"peerDependencies",
+	"optionalDependencies",
+];
+
+function formatPath(root, path) {
+	return relative(root, path).replaceAll("\\", "/") || ".";
+}
+
+function readJson(path) {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function collectSoftwareDirs(root) {
+	const softwareRoot = join(root, "registry", "software");
+	if (!existsSync(softwareRoot)) {
+		return [];
+	}
+
+	return readdirSync(softwareRoot, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory() && !entry.name.startsWith("_"))
+		.map((entry) => join(softwareRoot, entry.name))
+		.filter((packageDir) => {
+			const manifestPath = join(packageDir, "package.json");
+			return existsSync(manifestPath) && statSync(manifestPath).isFile();
+		})
+		.sort((left, right) => left.localeCompare(right));
+}
+
+function checkDependencies(packageName, manifest, errors) {
+	for (const section of dependencySections) {
+		const dependencies = manifest[section];
+		if (!dependencies || typeof dependencies !== "object") {
+			continue;
+		}
+		for (const dependencyName of Object.keys(dependencies)) {
+			if (agentOsPackagePattern.test(dependencyName)) {
+				errors.push(
+					`${packageName} must not depend on Agent OS package ${dependencyName} in registry software ${section}`,
+				);
+			}
+		}
+	}
+}
+
+export function checkRegistrySoftwareSplit(options = {}) {
+	const root = resolve(options.root ?? defaultRoot);
+	const errors = [];
+
+	for (const packageDir of collectSoftwareDirs(root)) {
+		const dirName = packageDir.split(/[\\/]/).at(-1);
+		const manifestPath = join(packageDir, "package.json");
+		const metadataPath = join(packageDir, "secure-exec-package.json");
+		const staleMetadataPath = join(packageDir, "agentos-package.json");
+		const staleArtifactMetadataPath = join(
+			packageDir,
+			"agentos-package.meta.json",
+		);
+
+		const manifest = readJson(manifestPath);
+		const expectedName = `@agentos-software/${dirName}`;
+		if (manifest.name !== expectedName) {
+			errors.push(
+				`${formatPath(root, manifestPath)} must be named ${expectedName}, found ${manifest.name}`,
+			);
+		}
+
+		if (existsSync(staleMetadataPath)) {
+			errors.push(
+				`${formatPath(root, staleMetadataPath)} must be renamed to secure-exec-package.json`,
+			);
+		}
+		if (existsSync(staleArtifactMetadataPath)) {
+			errors.push(
+				`${formatPath(root, staleArtifactMetadataPath)} must be renamed to secure-exec-package.meta.json`,
+			);
+		}
+		if (!existsSync(metadataPath)) {
+			errors.push(`${formatPath(root, metadataPath)} is required`);
+		} else {
+			const metadata = readJson(metadataPath);
+			if (metadata.name !== manifest.name) {
+				errors.push(
+					`${formatPath(root, metadataPath)} name must match package.json (${manifest.name}), found ${metadata.name}`,
+				);
+			}
+		}
+
+		checkDependencies(manifest.name ?? expectedName, manifest, errors);
+	}
+
+	return errors;
+}
+
+function parseArgs(argv) {
+	let root = defaultRoot;
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--root") {
+			const value = argv[++i];
+			if (!value) {
+				throw new Error("--root requires a path");
+			}
+			root = value;
+			continue;
+		}
+		if (arg.startsWith("--root=")) {
+			root = arg.slice("--root=".length);
+			continue;
+		}
+		throw new Error(`unknown argument: ${arg}`);
+	}
+	return { root };
+}
+
+export function main(argv = process.argv.slice(2)) {
+	const { root } = parseArgs(argv);
+	const resolvedRoot = resolve(root);
+	if (!existsSync(resolvedRoot) || !statSync(resolvedRoot).isDirectory()) {
+		throw new Error(`root is not a directory: ${resolvedRoot}`);
+	}
+
+	const errors = checkRegistrySoftwareSplit({ root: resolvedRoot });
+	if (errors.length > 0) {
+		for (const error of errors) {
+			console.error(error);
+		}
+		process.exitCode = 1;
+		return;
+	}
+
+	console.log("registry software split check ok");
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+	main();
+}

--- a/scripts/check-registry-software-split.test.mjs
+++ b/scripts/check-registry-software-split.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { checkRegistrySoftwareSplit } from "./check-registry-software-split.mjs";
+
+function withFixture(fn) {
+	const root = mkdtempSync(join(tmpdir(), "registry-software-split-"));
+	try {
+		return fn(root);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+function writeJson(root, rel, value) {
+	const path = join(root, rel);
+	mkdirSync(join(path, ".."), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(value, null, "\t")}\n`);
+}
+
+test("accepts agentos-software registry software package metadata", () => {
+	withFixture((root) => {
+		writeJson(root, "registry/software/coreutils/package.json", {
+			name: "@agentos-software/coreutils",
+			dependencies: {
+				"@secure-exec/registry-types": "workspace:*",
+			},
+		});
+		writeJson(root, "registry/software/coreutils/secure-exec-package.json", {
+			name: "@agentos-software/coreutils",
+		});
+
+		assert.deepEqual(checkRegistrySoftwareSplit({ root }), []);
+	});
+});
+
+test("rejects stale Agent OS package names and metadata files", () => {
+	withFixture((root) => {
+		writeJson(root, "registry/software/grep/package.json", {
+			name: "@rivet-dev/agent-os-pkg-grep",
+		});
+		writeJson(root, "registry/software/grep/agentos-package.json", {
+			name: "@rivet-dev/agent-os-pkg-grep",
+		});
+
+		assert.deepEqual(checkRegistrySoftwareSplit({ root }), [
+			"registry/software/grep/package.json must be named @agentos-software/grep, found @rivet-dev/agent-os-pkg-grep",
+			"registry/software/grep/agentos-package.json must be renamed to secure-exec-package.json",
+			"registry/software/grep/secure-exec-package.json is required",
+		]);
+	});
+});
+
+test("rejects metadata name drift", () => {
+	withFixture((root) => {
+		writeJson(root, "registry/software/sed/package.json", {
+			name: "@agentos-software/sed",
+		});
+		writeJson(root, "registry/software/sed/secure-exec-package.json", {
+			name: "@agentos-software/grep",
+		});
+
+		assert.deepEqual(checkRegistrySoftwareSplit({ root }), [
+			"registry/software/sed/secure-exec-package.json name must match package.json (@agentos-software/sed), found @agentos-software/grep",
+		]);
+	});
+});
+
+test("rejects Agent OS dependencies inside software manifests", () => {
+	withFixture((root) => {
+		writeJson(root, "registry/software/common/package.json", {
+			name: "@agentos-software/common",
+			dependencies: {
+				"@rivet-dev/agent-os-core": "workspace:*",
+			},
+		});
+		writeJson(root, "registry/software/common/secure-exec-package.json", {
+			name: "@agentos-software/common",
+		});
+
+		assert.deepEqual(checkRegistrySoftwareSplit({ root }), [
+			"@agentos-software/common must not depend on Agent OS package @rivet-dev/agent-os-core in registry software dependencies",
+		]);
+	});
+});

--- a/scripts/check-registry-test-runtime-boundary.mjs
+++ b/scripts/check-registry-test-runtime-boundary.mjs
@@ -1,0 +1,155 @@
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	statSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const defaultRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const forbiddenSpecifiers = new Set([
+	"@rivet-dev/agentos-core/test/runtime",
+	"@rivet-dev/agentos-core/internal/runtime-compat",
+	"@secure-exec/core/test-runtime",
+]);
+const allowedRegistryHelper = "registry/tests/helpers.ts";
+const scannedExtensions = new Set([
+	".js",
+	".jsx",
+	".mjs",
+	".cjs",
+	".ts",
+	".tsx",
+	".mts",
+	".cts",
+]);
+const ignoredDirectories = new Set([
+	"dist",
+	"node_modules",
+	"coverage",
+	".turbo",
+	".vitest",
+]);
+const importSpecifierPatterns = [
+	/\bimport\s+(?:type\s+)?(?:[^"'()]*?\s+from\s+)?["']([^"']+)["']/g,
+	/\bexport\s+(?:type\s+)?[^"'()]*?\s+from\s+["']([^"']+)["']/g,
+	/\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+	/\brequire\s*\(\s*["']([^"']+)["']\s*\)/g,
+];
+
+function formatPath(root, path) {
+	return relative(root, path).replaceAll("\\", "/") || ".";
+}
+
+function shouldScanFile(path) {
+	for (const extension of scannedExtensions) {
+		if (path.endsWith(extension)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function collectFiles(root, dir) {
+	if (!existsSync(dir)) {
+		return [];
+	}
+
+	const files = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+		a.name.localeCompare(b.name),
+	)) {
+		const path = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (!ignoredDirectories.has(entry.name)) {
+				files.push(...collectFiles(root, path));
+			}
+			continue;
+		}
+		if (entry.isFile() && shouldScanFile(path)) {
+			files.push(path);
+		}
+	}
+	return files;
+}
+
+function collectImportSpecifiers(source) {
+	const specifiers = [];
+	for (const pattern of importSpecifierPatterns) {
+		pattern.lastIndex = 0;
+		for (const match of source.matchAll(pattern)) {
+			specifiers.push(match[1]);
+		}
+	}
+	return specifiers;
+}
+
+export function checkRegistryTestRuntimeBoundary(options = {}) {
+	const root = resolve(options.root ?? defaultRoot);
+	const registryTestsDir = join(root, "registry", "tests");
+	const files = (options.files ?? collectFiles(root, registryTestsDir)).toSorted();
+	const errors = [];
+
+	for (const filePath of files) {
+		const rel = formatPath(root, filePath);
+		if (rel === allowedRegistryHelper) {
+			continue;
+		}
+		const source = readFileSync(filePath, "utf8");
+		const forbiddenImport = collectImportSpecifiers(source).find((specifier) =>
+			forbiddenSpecifiers.has(specifier),
+		);
+		if (forbiddenImport) {
+			errors.push(
+				`${rel} must import registry test runtime helpers from ../helpers.js instead of ${forbiddenImport}`,
+			);
+		}
+	}
+
+	return errors;
+}
+
+function parseArgs(argv) {
+	let root = defaultRoot;
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--root") {
+			const value = argv[++i];
+			if (!value) {
+				throw new Error("--root requires a path");
+			}
+			root = value;
+			continue;
+		}
+		if (arg.startsWith("--root=")) {
+			root = arg.slice("--root=".length);
+			continue;
+		}
+		throw new Error(`unknown argument: ${arg}`);
+	}
+	return { root };
+}
+
+export function main(argv = process.argv.slice(2)) {
+	const { root } = parseArgs(argv);
+	const resolvedRoot = resolve(root);
+	if (!existsSync(resolvedRoot) || !statSync(resolvedRoot).isDirectory()) {
+		throw new Error(`root is not a directory: ${resolvedRoot}`);
+	}
+
+	const errors = checkRegistryTestRuntimeBoundary({ root: resolvedRoot });
+	if (errors.length > 0) {
+		for (const error of errors) {
+			console.error(error);
+		}
+		process.exitCode = 1;
+		return;
+	}
+
+	console.log("registry test runtime boundary ok");
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+	main();
+}

--- a/scripts/check-registry-test-runtime-boundary.test.mjs
+++ b/scripts/check-registry-test-runtime-boundary.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { checkRegistryTestRuntimeBoundary } from "./check-registry-test-runtime-boundary.mjs";
+
+function withFixture(fn) {
+	const root = mkdtempSync(join(tmpdir(), "registry-test-runtime-boundary-"));
+	try {
+		return fn(root);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+function write(root, rel, contents) {
+	const path = join(root, rel);
+	mkdirSync(join(path, ".."), { recursive: true });
+	writeFileSync(path, contents);
+}
+
+test("accepts the central registry test runtime helper", () => {
+	withFixture((root) => {
+		write(
+			root,
+			"registry/tests/helpers.ts",
+			'export { createWasmVmRuntime } from "@secure-exec/core/test-runtime";\n',
+		);
+		write(
+			root,
+			"registry/tests/wasmvm/example.test.ts",
+			'import { createWasmVmRuntime } from "../helpers.js";\n',
+		);
+
+		assert.deepEqual(checkRegistryTestRuntimeBoundary({ root }), []);
+	});
+});
+
+test("rejects direct Agent OS test runtime imports in registry tests", () => {
+	withFixture((root) => {
+		write(
+			root,
+			"registry/tests/wasmvm/example.test.ts",
+			'import { createWasmVmRuntime } from "@rivet-dev/agentos-core/test/runtime";\n',
+		);
+
+		assert.deepEqual(checkRegistryTestRuntimeBoundary({ root }), [
+			"registry/tests/wasmvm/example.test.ts must import registry test runtime helpers from ../helpers.js instead of @rivet-dev/agentos-core/test/runtime",
+		]);
+	});
+});
+
+test("rejects direct re-exports and requires", () => {
+	withFixture((root) => {
+		write(
+			root,
+			"registry/tests/kernel/example.test.ts",
+			'export { createKernel } from "@rivet-dev/agentos-core/test/runtime";\nconst rt = require("@rivet-dev/agentos-core/test/runtime");\n',
+		);
+
+		assert.deepEqual(checkRegistryTestRuntimeBoundary({ root }), [
+			"registry/tests/kernel/example.test.ts must import registry test runtime helpers from ../helpers.js instead of @rivet-dev/agentos-core/test/runtime",
+		]);
+	});
+});
+
+test("rejects direct Agent OS runtime compat imports in registry tests", () => {
+	withFixture((root) => {
+		write(
+			root,
+			"registry/tests/wasmvm/example.test.ts",
+			'import { createWasmVmRuntime } from "@rivet-dev/agentos-core/internal/runtime-compat";\n',
+		);
+
+		assert.deepEqual(checkRegistryTestRuntimeBoundary({ root }), [
+			"registry/tests/wasmvm/example.test.ts must import registry test runtime helpers from ../helpers.js instead of @rivet-dev/agentos-core/internal/runtime-compat",
+		]);
+	});
+});
+
+test("rejects direct secure-exec test runtime imports in registry tests", () => {
+	withFixture((root) => {
+		write(
+			root,
+			"registry/tests/wasmvm/example.test.ts",
+			'import { createWasmVmRuntime } from "@secure-exec/core/test-runtime";\n',
+		);
+
+		assert.deepEqual(checkRegistryTestRuntimeBoundary({ root }), [
+			"registry/tests/wasmvm/example.test.ts must import registry test runtime helpers from ../helpers.js instead of @secure-exec/core/test-runtime",
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

- Adds live sidecar extension event delivery so extension code can emit events while a request is still in flight.
- Wires the stdio frame transport into the sidecar event sink path.
- Carries the moved agent registry, including the Pi adapter change that stops buffering prompt-time updates until prompt completion.

## Validation

- `cargo test -p secure-exec-sidecar --lib live_event_tests`
- `pnpm --dir registry/agent/pi build`
- packed `@agentos-software/pi@0.2.0-rc.3` and verified it in the zid repro with agent-os sidecar

## Notes

Pairs with the agent-os `zid-agentos` branch for the ACP extension polling/regression test side of the fix.
