### PR TITLE
fix(sidecar): classify new limit constants + tolerate stale sidecar callback responses

### DIFF
--- a/crates/sidecar/src/service.rs
+++ b/crates/sidecar/src/service.rs
@@ -2721,9 +2721,26 @@ where
         &mut self,
         response: SidecarResponseFrame,
     ) -> Result<(), SidecarError> {
-        self.pending_sidecar_responses
-            .accept_response(&response)
-            .map_err(sidecar_response_tracker_error)?;
+        match self.pending_sidecar_responses.accept_response(&response) {
+            Ok(()) => {}
+            // A response for a request that is no longer pending (its owning VM
+            // was disposed, abandoning the in-flight callback) or already
+            // completed is a benign late/stale reply on the shared sidecar — a
+            // per-VM `sidecar_request` can be answered by the host after that VM
+            // has been torn down (multiple VMs share one sidecar process). Drop
+            // it instead of failing the whole sidecar over a harmless straggler.
+            Err(
+                error @ (SidecarResponseTrackerError::UnmatchedResponse { .. }
+                | SidecarResponseTrackerError::DuplicateResponse { .. }),
+            ) => {
+                tracing::warn!(
+                    request_id = response.request_id,
+                    "dropping stale sidecar response with no matching pending request: {error}"
+                );
+                return Ok(());
+            }
+            Err(error) => return Err(sidecar_response_tracker_error(error)),
+        }
         self.pending_sidecar_responses_gauge
             .observe_depth(self.pending_sidecar_responses.pending_count());
         self.completed_sidecar_response_order

--- a/crates/sidecar/tests/fixtures/limits-inventory.json
+++ b/crates/sidecar/tests/fixtures/limits-inventory.json
@@ -25,6 +25,12 @@
 		"wired": "VmLimits.js_runtime.captured_output_limit_bytes"
 	},
 	{
+		"name": "MAX_TIMER_DELAY_MS",
+		"path": "crates/execution/src/javascript.rs",
+		"class": "invariant",
+		"rationale": "Clamps a guest timer delay to the JS setTimeout ceiling (2^31-1 ms); a leak guard so a timer thread cannot outlive its session by pinning the session Arc, mirroring the standard setTimeout max rather than operator policy."
+	},
+	{
 		"name": "JAVASCRIPT_EVENT_CHANNEL_CAPACITY",
 		"path": "crates/execution/src/javascript.rs",
 		"class": "invariant",
@@ -102,6 +108,12 @@
 		"path": "crates/execution/src/wasm.rs",
 		"class": "policy-deferred",
 		"rationale": "WASM wall-clock backstop applied when no fuel budget is set; safety default to stop infinite-loop core-pinning, fold into a wasm execution-timeout field later."
+	},
+	{
+		"name": "DEFAULT_WASM_RUNNER_HEAP_LIMIT_MB",
+		"path": "crates/execution/src/wasm.rs",
+		"class": "policy-deferred",
+		"rationale": "Wasm runner V8 heap default (2 GiB, intentionally above the 128 MiB per-guest budget so warmup stops OOMing); per-isolate near-heap guard contains it, operator-tunable via the WASM_RUNNER_HEAP_LIMIT_MB env override rather than VmLimits."
 	},
 	{
 		"name": "DEFAULT_WASM_PREWARM_TIMEOUT_MS",

--- a/crates/sidecar/tests/service.rs
+++ b/crates/sidecar/tests/service.rs
@@ -63,7 +63,7 @@ use extension::{
     ExtensionInterruptResponse, ExtensionResponse,
 };
 use service::NativeSidecarConfig;
-use state::SidecarRequestTransport;
+use state::{EventSinkTransport, SidecarRequestTransport};
 
 #[allow(dead_code)]
 #[path = "../src/stdio.rs"]


### PR DESCRIPTION
## Summary
Two fixes surfaced while syncing agent-os against latest secure-exec main.

1. **limits_audit (red on main):** #129 and #131 added `DEFAULT_WASM_RUNNER_HEAP_LIMIT_MB` and `MAX_TIMER_DELAY_MS` without inventory entries, so `cargo test -p secure-exec-sidecar --test limits_audit` fails on main. Classify them:
   - `DEFAULT_WASM_RUNNER_HEAP_LIMIT_MB` → policy-deferred (wasm runner V8 heap default; operator-tunable via the `WASM_RUNNER_HEAP_LIMIT_MB` env override, contained by the per-isolate near-heap guard).
   - `MAX_TIMER_DELAY_MS` → invariant (clamps a guest timer delay to the JS `setTimeout` 2^31-1 ms ceiling; a leak guard so a timer thread can't outlive its session).
2. **Stale sidecar callback responses:** `accept_sidecar_response` now drops a `sidecar_response` with no matching pending request (`UnmatchedResponse`) or whose request already completed (`DuplicateResponse`) instead of failing the whole sidecar. Multiple VMs share one sidecar process; a per-VM `sidecar_request` callback can be answered by the host *after* that VM is disposed, and the straggler reply must not crash an unrelated VM's startup. Real protocol violations (ownership / response-kind mismatch) stay fatal.

## Testing
- `limits_audit` 2/2 ✅, `cargo fmt --check` ✅, `cargo clippy -p secure-exec-sidecar -- -D warnings` ✅, `vm_fetch_kernel_tcp` socket tests ✅
- Downstream (agent-os against this build): full core suite **264 passed / 0 failed** — fixed the mount/codex shared-sidecar correlation failures.