### PR TITLE
fix(agent): mount @agentclientprotocol/sdk for pi and claude adapters

### DIFF
--- a/registry/agent/claude/src/index.ts
+++ b/registry/agent/claude/src/index.ts
@@ -8,7 +8,7 @@ const claude = {
 	name: "claude",
 	type: "agent" as const,
 	packageDir,
-	requires: ["@anthropic-ai/claude-agent-sdk"],
+	requires: ["@agentclientprotocol/sdk", "@anthropic-ai/claude-agent-sdk"],
 	agent: {
 		id: "claude",
 		acpAdapter: "@agentos-software/claude-code",

--- a/registry/agent/pi/src/index.ts
+++ b/registry/agent/pi/src/index.ts
@@ -8,7 +8,11 @@ const pi = {
 	name: "pi",
 	type: "agent" as const,
 	packageDir,
-	requires: ["@agentos-software/pi", "@mariozechner/pi-coding-agent"],
+	requires: [
+		"@agentclientprotocol/sdk",
+		"@agentos-software/pi",
+		"@mariozechner/pi-coding-agent",
+	],
 	agent: {
 		id: "pi",
 		acpAdapter: "@agentos-software/pi",


### PR DESCRIPTION
- **Problem:** the pi and claude ACP adapters import `@agentclientprotocol/sdk`, but it is missing from each agent descriptor's `requires`, so it is never projected into the VM at `/root/node_modules`. On runtimes whose module resolver does not fall back to the host tree, the adapter exits code 1 with `Cannot resolve module '@agentclientprotocol/sdk'` — the failure reported against `@agentos-software/claude-code@0.2.0`.
- **Fix:** add `@agentclientprotocol/sdk` to `requires` for both `registry/agent/claude` and `registry/agent/pi`. Both packages already declare it as a dependency, so it resolves on the host and gets mounted into the VM.
- **Verified (against the published 0.2.x agents):** with the SDK in `requires`, the VM probe shows `/root/node_modules/@agentclientprotocol/sdk` is now present (was MISSING); the claude session runs end-to-end on current `@rivet-dev/agentos-core`, across npm/pnpm/yarn/bun.
- **Scope:** touches only `index.ts` (the descriptor `requires`). It does **not** overlap the in-flight adapter-robustness work on `stack/fix-agent-adapters-robustness-fixes-to-pi-claude-acp-adapters`, which modifies `adapter.ts`/`package.json`/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
