### PR TITLE
fix(agent-adapters): robustness fixes to pi + claude ACP adapters

### DIFF
--- a/registry/agent/claude/package.json
+++ b/registry/agent/claude/package.json
@@ -18,7 +18,7 @@
 	"scripts": {
 		"build": "tsc && node ./scripts/build-patched-cli.mjs",
 		"check-types": "tsc --noEmit",
-		"test": "pnpm build && node --test tests/*.test.mjs"
+		"test": "pnpm build && node --test --test-force-exit tests/*.test.mjs"
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^0.16.1",

--- a/registry/agent/claude/src/adapter.ts
+++ b/registry/agent/claude/src/adapter.ts
@@ -326,7 +326,9 @@ type PendingTurn = {
 	sawToolCall: boolean;
 };
 
-class ClaudeQuerySession {
+// Exported for unit tests (the constructor takes an injectable `queryFactory`,
+// so the SDK can be faked). Not part of the package's public API.
+export class ClaudeQuerySession {
 	private promptQueue = new AsyncQueue<SDKUserMessage>();
 	private query: Query;
 	private readyPromise: Promise<void>;
@@ -338,6 +340,11 @@ class ClaudeQuerySession {
 		string,
 		{ toolName: string; rawInput?: Record<string, unknown> }
 	>();
+	// Maps a streaming content-block `index` -> toolUseId for the current turn.
+	// `content_block_delta` (input_json_delta) events reference the tool call by
+	// its content-block index, NOT by tool-call ordinal — any text/thinking block
+	// before a tool_use shifts that index. Cleared on each turn terminus.
+	private toolUseBlockIndex = new Map<number, string>();
 	private reader: Promise<void>;
 	private closed = false;
 	private cancelled = false;
@@ -688,9 +695,15 @@ class ClaudeQuerySession {
 			}
 		} finally {
 			traceAdapter(`consume_finally session=${this.sessionId}`);
+			// The reader loop has exited — the SDK query stream is done (cleanly or
+			// via error), so this session can never produce another result. Mark it
+			// closed so a subsequent prompt() fails fast via the guard in prompt()
+			// instead of queueing onto a dead reader and hanging to the ACP method
+			// timeout (a zombie session).
+			this.closed = true;
 			if (this.pendingTurn) {
 				this.pendingTurn.reject(
-					new Error("Claude query ended before producing a result"),
+					new Error("Claude session ended before producing a result"),
 				);
 				this.pendingTurn = null;
 			}
@@ -793,6 +806,12 @@ class ClaudeQuerySession {
 			const toolName = String(block.name ?? "tool");
 			const rawInput = isRecord(block.input) ? block.input : undefined;
 			this.activeToolCalls.set(toolUseId, { toolName, rawInput });
+			// Remember this tool_use block's content-block index so subsequent
+			// input_json_delta events (which reference the block by index) are
+			// attributed to the right tool call.
+			if (typeof event.index === "number") {
+				this.toolUseBlockIndex.set(Number(event.index), toolUseId);
+			}
 			if (this.pendingTurn) this.pendingTurn.sawToolCall = true;
 
 			await this.emit({
@@ -892,6 +911,7 @@ class ClaudeQuerySession {
 			});
 		}
 		this.activeToolCalls.clear();
+		this.toolUseBlockIndex.clear();
 
 		await this.lastEmit;
 
@@ -921,7 +941,16 @@ class ClaudeQuerySession {
 					update,
 				}),
 			)
-			.catch(() => {});
+			// The catch is load-bearing: lastEmit is awaited at turn end and a
+			// rejected chain would halt all later updates and surface as a spurious
+			// prompt failure. But never swallow silently — a dropped session/update
+			// (host disconnect / broken pipe) must be host-visible, so write it to
+			// stderr (the onAgentStderr channel).
+			.catch((error) => {
+				process.stderr.write(
+					`[claude-acp] failed to deliver session/update: ${formatError(error)}\n`,
+				);
+			});
 		return this.lastEmit;
 	}
 
@@ -960,26 +989,13 @@ class ClaudeQuerySession {
 					toolCallId: options.toolUseID,
 				},
 			};
-			const permissionFallbackMs = Number.parseInt(
-				process.env.CLAUDE_CODE_PERMISSION_FALLBACK_MS ?? "2000",
-				10,
-			);
-			const response = await Promise.race([
-				this.conn.requestPermission(request),
-				new Promise<RequestPermissionResponse>((resolve) => {
-					setTimeout(() => {
-						traceAdapter(
-							`permission_request_fallback session=${this.sessionId} tool=${toolName} toolUseId=${options.toolUseID}`,
-						);
-						resolve({
-							outcome: {
-								outcome: "selected",
-								optionId: "allow_once",
-							},
-						});
-					}, Number.isFinite(permissionFallbackMs) ? permissionFallbackMs : 2000);
-				}),
-			]);
+			// The host's permission handler is authoritative: never auto-resolve
+			// the request on a timer. A timer-based fallback here would either
+			// fail OPEN (auto-allow — the untrusted guest's tool runs without host
+			// consent) or fail closed early (deny a legitimate slow approval). If
+			// the host never answers, the request fails via the bounded ACP method
+			// timeout, which surfaces to the host rather than silently granting.
+			const response = await this.conn.requestPermission(request);
 			traceAdapter(
 				`permission_request_done session=${this.sessionId} tool=${toolName} toolUseId=${options.toolUseID}`,
 			);
@@ -997,9 +1013,14 @@ class ClaudeQuerySession {
 		toolName: string;
 		rawInput?: Record<string, unknown>;
 	} | null {
-		const entry = [...this.activeToolCalls.entries()][index];
-		if (!entry) return null;
-		const [toolUseId, value] = entry;
+		// `index` is the streaming content-block index, not a tool-call ordinal —
+		// resolve it through the per-turn block-index map so the partial input is
+		// attributed to the correct tool call even when text/thinking blocks
+		// precede the tool_use block.
+		const toolUseId = this.toolUseBlockIndex.get(index);
+		if (!toolUseId) return null;
+		const value = this.activeToolCalls.get(toolUseId);
+		if (!value) return null;
 		return { toolUseId, toolName: value.toolName, rawInput: value.rawInput };
 	}
 }

--- a/registry/agent/claude/tests/adapter.test.mjs
+++ b/registry/agent/claude/tests/adapter.test.mjs
@@ -1,0 +1,203 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import { resolve as resolvePath } from "node:path";
+
+// Stop fns for every "open" fake query, drained after the run so the dangling
+// consume() loops (and the process) can exit.
+const cleanups = [];
+after(() => {
+	for (const stop of cleanups) stop();
+});
+
+// Unit tests for the ClaudeQuerySession adapter fixes. The class is exported
+// for testing and its constructor takes an injectable `queryFactory`, so these
+// drive the translation/permission/teardown logic with a fake Claude SDK query
+// and a mock ACP connection — no real SDK, no VM.
+const packageDir = resolvePath(import.meta.dirname, "..");
+const { ClaudeQuerySession } = await import(
+	resolvePath(packageDir, "dist", "adapter.js")
+);
+
+function makeConn(overrides = {}) {
+	let closeConn;
+	const closed = new Promise((r) => {
+		closeConn = r;
+	});
+	const updates = [];
+	return {
+		updates,
+		closeConn: () => closeConn(),
+		sessionUpdate: async (u) => {
+			updates.push(u);
+		},
+		requestPermission: async () => ({
+			outcome: { outcome: "selected", optionId: "allow_once" },
+		}),
+		closed,
+		...overrides,
+	};
+}
+
+function makeQuery({ endImmediately = false } = {}) {
+	let stop;
+	const stopped = new Promise((r) => {
+		stop = r;
+	});
+	if (!endImmediately) cleanups.push(stop);
+	return {
+		setMcpServers: async () => {},
+		interrupt: async () => {},
+		setPermissionMode: async () => {},
+		async *[Symbol.asyncIterator]() {
+			if (endImmediately) return;
+			await stopped; // ends consume() when drained in `after`
+		},
+	};
+}
+
+function makeSession({ endImmediately = false, conn } = {}) {
+	const c = conn ?? makeConn();
+	let capturedOptions;
+	const queryFactory = (arg) => {
+		capturedOptions = arg.options;
+		return makeQuery({ endImmediately });
+	};
+	const sess = new ClaudeQuerySession(
+		c,
+		"sess-1",
+		"/workspace",
+		"default",
+		{ cwd: "/workspace", mcpServers: undefined },
+		"/usr/bin/claude",
+		queryFactory,
+	);
+	return { sess, conn: c, getOptions: () => capturedOptions };
+}
+
+// ── Fix #5: input_json_delta maps to the correct tool by content-block index ──
+test("claude #5: partial tool input is attributed by content-block index, not insertion order", async () => {
+	const { sess, conn } = makeSession();
+	sess.pendingTurn = {
+		sawAssistantText: false,
+		sawToolCall: false,
+		resolve() {},
+		reject() {},
+	};
+	// A text block occupies content-block index 0; the tool_use block is index 1.
+	await sess.handleStreamEvent({
+		event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "thinking..." } },
+	});
+	await sess.handleStreamEvent({
+		event: {
+			type: "content_block_start",
+			index: 1,
+			content_block: { type: "tool_use", id: "tool-A", name: "Bash", input: {} },
+		},
+	});
+	await sess.handleStreamEvent({
+		event: { type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: '{"command":"ls"}' } },
+	});
+	await sess.lastEmit;
+
+	const toolUpdates = conn.updates
+		.map((u) => u.update)
+		.filter((u) => u?.sessionUpdate === "tool_call_update");
+	// With the old insertion-order lookup, findToolCallByIndex(1) on a 1-entry
+	// map returns null and the partial input is silently dropped (no update).
+	assert.equal(toolUpdates.length, 1, "expected exactly one tool_call_update for the partial input");
+	assert.equal(toolUpdates[0].toolCallId, "tool-A", "partial input must target the tool at block index 1");
+	assert.equal(toolUpdates[0].rawInput.partial_json, '{"command":"ls"}');
+});
+
+test("claude #5: two tool_use blocks at different indices each get their own partial input", async () => {
+	const { sess, conn } = makeSession();
+	sess.pendingTurn = { sawAssistantText: false, sawToolCall: false, resolve() {}, reject() {} };
+	// index 0 = text, index 1 = toolA, index 2 = toolB
+	await sess.handleStreamEvent({ event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "x" } } });
+	await sess.handleStreamEvent({ event: { type: "content_block_start", index: 1, content_block: { type: "tool_use", id: "tool-A", name: "Bash", input: {} } } });
+	await sess.handleStreamEvent({ event: { type: "content_block_start", index: 2, content_block: { type: "tool_use", id: "tool-B", name: "Read", input: {} } } });
+	await sess.handleStreamEvent({ event: { type: "content_block_delta", index: 2, delta: { type: "input_json_delta", partial_json: '{"path":"/a"}' } } });
+	await sess.handleStreamEvent({ event: { type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: '{"command":"echo"}' } } });
+	await sess.lastEmit;
+
+	const updates = conn.updates.map((u) => u.update).filter((u) => u?.sessionUpdate === "tool_call_update");
+	const byTool = Object.fromEntries(updates.map((u) => [u.toolCallId, u.rawInput.partial_json]));
+	assert.equal(byTool["tool-B"], '{"path":"/a"}', "block index 2 → tool-B");
+	assert.equal(byTool["tool-A"], '{"command":"echo"}', "block index 1 → tool-A");
+});
+
+// ── Fix #1: permission handler is host-authoritative; no timer auto-resolve ──
+test("claude #1: permission handler returns the host's deny decision", async () => {
+	const conn = makeConn({
+		requestPermission: async () => ({ outcome: { outcome: "selected", optionId: "reject_once" } }),
+	});
+	const { getOptions } = makeSession({ conn });
+	const canUseTool = getOptions().canUseTool;
+	const result = await canUseTool("Bash", { command: "rm -rf /" }, { toolUseID: "t1", title: "Bash", suggestions: [] });
+	assert.equal(result.behavior, "deny", "host reject must produce a deny");
+});
+
+test("claude #1: permission handler does NOT auto-resolve on a timer when the host is silent", async () => {
+	let pendingResolve;
+	const conn = makeConn({
+		// Never settles — simulates a host that hasn't answered yet.
+		requestPermission: () => new Promise((r) => {
+			pendingResolve = r;
+		}),
+	});
+	const { getOptions } = makeSession({ conn });
+	const canUseTool = getOptions().canUseTool;
+	const handlerPromise = canUseTool("Bash", {}, { toolUseID: "t1", title: "Bash", suggestions: [] });
+	const timer = new Promise((r) => setTimeout(() => r("TIMER_WON"), 300));
+	const winner = await Promise.race([handlerPromise.then(() => "HANDLER_WON"), timer]);
+	assert.equal(winner, "TIMER_WON", "handler must not auto-resolve before the host answers (no fail-open timer)");
+	// settle the pending request so the handler promise doesn't dangle
+	pendingResolve({ outcome: { outcome: "selected", optionId: "reject_once" } });
+	await handlerPromise;
+});
+
+// ── Fix #2: emit logs delivery failures (host-visible) and keeps the chain alive ──
+test("claude #2: a failed sessionUpdate is logged to stderr and the emit chain survives", async () => {
+	let failNext = true;
+	const delivered = [];
+	const conn = makeConn({
+		sessionUpdate: async (u) => {
+			if (failNext) {
+				failNext = false;
+				throw new Error("broken pipe");
+			}
+			delivered.push(u);
+		},
+	});
+	const { sess } = makeSession({ conn });
+
+	const writes = [];
+	const orig = process.stderr.write;
+	process.stderr.write = (s) => {
+		writes.push(String(s));
+		return true;
+	};
+	try {
+		await sess.emit({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "a" } });
+		await sess.emit({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "b" } });
+		await sess.lastEmit;
+	} finally {
+		process.stderr.write = orig;
+	}
+	assert.ok(
+		writes.some((w) => w.includes("failed to deliver session/update")),
+		"a delivery failure must be written to stderr, not swallowed",
+	);
+	assert.equal(delivered.length, 1, "the chain must survive the failure and deliver the next update");
+});
+
+// ── Fix #4: a dead reader marks the session closed so prompt() fails fast ──
+test("claude #4: once the query stream ends, prompt() fails fast instead of hanging", async () => {
+	const { sess } = makeSession({ endImmediately: true });
+	await sess.reader; // wait for consume() to finish on the now-ended query
+	await assert.rejects(
+		sess.prompt({ prompt: [{ type: "text", text: "hi" }] }),
+		/Session is closed/,
+		"a prompt on a dead session must reject promptly, not hang",
+	);
+});

--- a/registry/agent/pi/package.json
+++ b/registry/agent/pi/package.json
@@ -18,7 +18,8 @@
 	"scripts": {
 		"build": "tsc && node scripts/build-snapshot-bundle.mjs",
 		"build:snapshot": "node scripts/build-snapshot-bundle.mjs",
-		"check-types": "tsc --noEmit"
+		"check-types": "tsc --noEmit",
+		"test": "pnpm build && node --test --test-force-exit tests/*.test.mjs"
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^0.16.1",

--- a/registry/agent/pi/src/adapter.ts
+++ b/registry/agent/pi/src/adapter.ts
@@ -763,7 +763,9 @@ for (let i = 0; i < argv.length; i++) {
 
 // ── Agent implementation ────────────────────────────────────────────
 
-class PiSdkAgent implements Agent {
+// Exported for unit tests (drive the translation handlers with a mock
+// connection + a fake session). Not part of the package's public API.
+export class PiSdkAgent implements Agent {
 	private conn: AgentSideConnection;
 	private session: PiSessionLike | null = null;
 	private sessionId = "";
@@ -779,9 +781,30 @@ class PiSdkAgent implements Agent {
 		{ path: string; oldText: string }
 	>();
 	private lastEmit: Promise<void> = Promise.resolve();
+	private unsubscribe: (() => void) | null = null;
+	private disposed = false;
 
 	constructor(conn: AgentSideConnection) {
 		this.conn = conn;
+		// The ACP connection ending is the only unconditional teardown signal for
+		// this adapter (there is no SDK-invoked close hook). Drop the live Pi event
+		// subscription on connection close so a closed connection doesn't leave a
+		// listener — and the session it closes over — alive. Defer to the next tick:
+		// AgentSideConnection invokes this agent factory mid-construction, so
+		// `conn.closed` is not yet readable synchronously here (matches the claude
+		// adapter's pattern).
+		setTimeout(() => {
+			void this.conn.closed.then(() => this.dispose());
+		}, 0);
+	}
+
+	private dispose(): void {
+		this.disposed = true;
+		if (this.unsubscribe) {
+			this.unsubscribe();
+			this.unsubscribe = null;
+		}
+		this.session = null;
 	}
 
 	async initialize(
@@ -866,11 +889,20 @@ class PiSdkAgent implements Agent {
 		);
 		__trace.flush();
 
+		// Replacing the session: drop the previous session's subscription so its
+		// listener (and the session it closes over) doesn't leak or fire against
+		// stale state.
+		if (this.unsubscribe) {
+			this.unsubscribe();
+			this.unsubscribe = null;
+		}
 		this.session = session;
 		this.sessionId = session.sessionId;
 
-		// Subscribe to Pi SDK events and translate to ACP notifications
-		session.subscribe((event) => this.handlePiEvent(event));
+		// Subscribe to Pi SDK events and translate to ACP notifications. Keep the
+		// disposer so the subscription is torn down on session replace / connection
+		// close (`subscribe` returns an unsubscribe function).
+		this.unsubscribe = session.subscribe((event) => this.handlePiEvent(event));
 
 		// Build thinking modes
 		const thinkingLevels = session.getAvailableThinkingLevels();
@@ -899,6 +931,11 @@ class PiSdkAgent implements Agent {
 		this.emittedAssistantText = false;
 		this.pendingUpdates = [];
 		this.streamedTextContent.clear();
+		// Pre-edit snapshots are per-tool-call, captured at tool_execution_start and
+		// consumed at tool_execution_end. If a tool never reaches `end` (cancel /
+		// crash / abort) the entry would otherwise leak across turns — reset here so
+		// the map can't grow unbounded.
+		this.editSnapshots.clear();
 
 		// Extract text from prompt parts
 		const promptParts = params.prompt ?? [];
@@ -939,6 +976,11 @@ class PiSdkAgent implements Agent {
 
 	async cancel(_params: CancelNotification): Promise<void> {
 		this.cancelRequested = true;
+		// A cancelled turn may abort tools mid-execution before their
+		// tool_execution_end fires; clear the per-tool maps so their entries don't
+		// leak (prompt() also resets these at the next turn's start).
+		this.currentToolCalls.clear();
+		this.editSnapshots.clear();
 		await this.session?.abort();
 	}
 
@@ -981,7 +1023,19 @@ class PiSdkAgent implements Agent {
 					update,
 				}),
 			)
-			.catch(() => {});
+			// The catch is load-bearing: `lastEmit` is awaited at turn end and a
+			// rejected chain would halt all later updates and surface as a spurious
+			// prompt failure (plus an unhandled rejection on detached emit callers).
+			// But never swallow silently — a dropped session/update (host disconnect
+			// / broken pipe) must be host-visible, so log it to stderr (the
+			// onAgentStderr channel).
+			.catch((error) => {
+				console.warn(
+					`[pi-sdk-acp] failed to deliver session/update: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+			});
 		return this.lastEmit;
 	}
 

--- a/registry/agent/pi/tests/adapter.test.mjs
+++ b/registry/agent/pi/tests/adapter.test.mjs
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolve as resolvePath } from "node:path";
+
+// Unit tests for the PiSdkAgent adapter fixes. The class is exported for
+// testing; newSession needs the real Pi SDK, so these drive the translation /
+// lifecycle logic directly with a mock ACP connection + a fake session.
+const packageDir = resolvePath(import.meta.dirname, "..");
+const { PiSdkAgent } = await import(resolvePath(packageDir, "dist", "adapter.js"));
+
+function makeConn(overrides = {}) {
+	return {
+		closed: new Promise(() => {}), // never closes unless a test overrides
+		sessionUpdate: async () => {},
+		...overrides,
+	};
+}
+
+function fakeSession(overrides = {}) {
+	return {
+		messages: [],
+		prompt: async () => {},
+		abort: async () => {},
+		subscribe: () => () => {},
+		...overrides,
+	};
+}
+
+// ── Fix #3: editSnapshots is cleared each turn (no unbounded leak) ──
+test("pi #3: prompt() clears leaked edit snapshots from a prior aborted turn", async () => {
+	const agent = new PiSdkAgent(makeConn());
+	agent.session = fakeSession();
+	agent.sessionId = "s1";
+	// Simulate a tool that started an edit but never reached tool_execution_end.
+	agent.editSnapshots.set("tool-1", { path: "/workspace/a.txt", oldText: "before" });
+	assert.equal(agent.editSnapshots.size, 1);
+
+	await agent.prompt({ prompt: [{ type: "text", text: "hi" }] });
+	assert.equal(agent.editSnapshots.size, 0, "editSnapshots must be reset at prompt start");
+});
+
+test("pi #3: cancel() clears the per-turn tool maps", async () => {
+	const agent = new PiSdkAgent(makeConn());
+	agent.session = fakeSession();
+	agent.editSnapshots.set("tool-1", { path: "/a", oldText: "x" });
+	agent.currentToolCalls.set("tool-1", "call-1");
+	await agent.cancel({});
+	assert.equal(agent.editSnapshots.size, 0);
+	assert.equal(agent.currentToolCalls.size, 0);
+});
+
+// ── Fix #4: the live subscription is disposed when the connection closes ──
+test("pi #4: connection close disposes the session subscription", async () => {
+	let closeConn;
+	const conn = makeConn({ closed: new Promise((r) => (closeConn = r)) });
+	const agent = new PiSdkAgent(conn);
+	let unsubscribed = false;
+	agent.unsubscribe = () => {
+		unsubscribed = true;
+	};
+	agent.session = fakeSession();
+
+	closeConn();
+	await new Promise((r) => setTimeout(r, 10)); // let conn.closed.then(dispose) run
+
+	assert.ok(unsubscribed, "conn.closed must call the subscription disposer");
+	assert.equal(agent.session, null, "the session reference must be dropped on dispose");
+});
+
+// ── Fix #2: emit logs delivery failures (host-visible) and survives them ──
+test("pi #2: a failed sessionUpdate is logged and the emit chain survives", async () => {
+	let failNext = true;
+	const delivered = [];
+	const conn = makeConn({
+		sessionUpdate: async (u) => {
+			if (failNext) {
+				failNext = false;
+				throw new Error("broken pipe");
+			}
+			delivered.push(u);
+		},
+	});
+	const agent = new PiSdkAgent(conn);
+	agent.sessionId = "s1";
+
+	const warns = [];
+	const origWarn = console.warn;
+	console.warn = (...a) => warns.push(a.join(" "));
+	try {
+		await agent.sendUpdate({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "a" } });
+		await agent.sendUpdate({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "b" } });
+		await agent.lastEmit;
+	} finally {
+		console.warn = origWarn;
+	}
+
+	assert.ok(
+		warns.some((w) => w.includes("failed to deliver session/update")),
+		"a delivery failure must be logged, not swallowed",
+	);
+	assert.equal(delivered.length, 1, "the chain must survive the failure and deliver the next update");
+});


### PR DESCRIPTION
Five verified fixes to the Pi and Claude ACP agent adapters (each with a unit
test), found via a multi-agent review:
- claude: tool-permission handler no longer auto-resolves on a 2s timer (was
  fail-open: ran the guest's tool without host consent); host is authoritative.
- claude: partial tool input attributed by streaming content-block index, not
  Map insertion order.
- claude: a dead query reader marks the session closed so the next prompt()
  fails fast instead of hanging to the ACP timeout.
- pi: live session subscription is torn down on replace + conn.closed;
  editSnapshots cleared per turn + on cancel.
- pi + claude: failed session/update writes are logged to stderr instead of
  silently swallowed (emit chain kept alive).

Tests: registry/agent/{claude,pi}/tests/adapter.test.mjs. No auto-resolve on
timeout remains in any adapter.