### PR TITLE
docs: fix stale package names and feature-doc gaps

### DIFF
--- a/crates/sidecar-browser/CLAUDE.md
+++ b/crates/sidecar-browser/CLAUDE.md
@@ -1,5 +1,5 @@
 # Browser Support
 
-- Browser support is untested after the secure-exec split; only build-level validation is required during migration.
+- Browser support is untested after the secure-exec split: the scaffold's service logic (extension dispatch, VM filesystem context, worker lifecycle) is covered by smoke/bridge/service tests against a mock BrowserWorkerBridge; end-to-end browser/worker-transport integration is still unvalidated.
 - Provenance: moved from rivet-dev/agentos@87ed8e21e454.
 - Keep the browser sidecar separate from the native sidecar because worker transport and main-thread ownership differ from stdio/socket transport.

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -4,3 +4,17 @@ Browser driver primitives for secure-exec.
 
 - Package: `@secure-exec/browser`
 - Exports: `createBrowserDriver`, `createBrowserRuntimeDriverFactory`, `createOpfsFileSystem`, `BrowserWorkerAdapter`
+
+## Permissions
+
+The browser runtime gates guest I/O through a per-scope `PermissionCheck` callback
+model (`fs`, `network`, `childProcess`, `env`) rather than the node runtime's
+string-policy permissions. Each callback receives the request and returns a
+decision (`boolean`, or `{ allowed | allow, reason? }`); the default policy should
+be your own secure callbacks, not a fully-open one.
+
+For dev/test runtimes that need everything open, the package exports convenience
+presets:
+
+- `allowAll` — aggregate `Permissions` allowing every scope.
+- `allowAllFs`, `allowAllNetwork`, `allowAllChildProcess`, `allowAllEnv` — per-scope presets.

--- a/registry/README.md
+++ b/registry/README.md
@@ -46,17 +46,19 @@ Node.js agent and tool packages that are projected into the VM via the ModuleAcc
 
 | Package | apt Equivalent | Description | Source | Combined Size | Gzipped |
 |---------|---------------|-------------|--------|---------------|---------|
-| `@agentos-software/codex` | codex | OpenAI Codex integration (codex, codex-exec) | rust | 274 KiB | 118 KiB |
+| `@agentos-software/codex-cli` | codex | OpenAI Codex command package (codex, codex-exec) | rust | 274 KiB | 118 KiB |
 | `@agentos-software/coreutils` | coreutils | GNU coreutils: sh, cat, ls, cp, sort, and 80+ commands | rust | 51.4 MiB | 23.5 MiB |
 | `@agentos-software/curl` | curl | curl-compatible HTTP client | rust | - | - |
 | `@agentos-software/diffutils` | diffutils | GNU diffutils (diff) | rust | 120 KiB | 54.0 KiB |
+| `@agentos-software/duckdb` | duckdb | DuckDB command-line interface | c | - | - |
 | `@agentos-software/fd` | fd-find | fd fast file finder | rust | 901 KiB | 328 KiB |
 | `@agentos-software/file` | file | file type detection | rust | 117 KiB | 49.9 KiB |
 | `@agentos-software/findutils` | findutils | GNU findutils (find, xargs) | rust | 950 KiB | 348 KiB |
 | `@agentos-software/gawk` | gawk | GNU awk text processing | rust | 1.11 MiB | 432 KiB |
-| `@agentos-software/git` | git | git version control (planned) *(planned)* | rust | - | - |
+| `@agentos-software/git` | git | git version control | rust | - | - |
 | `@agentos-software/grep` | grep | GNU grep pattern matching (grep, egrep, fgrep) | rust | 2.59 MiB | 956 KiB |
 | `@agentos-software/gzip` | gzip | GNU gzip compression (gzip, gunzip, zcat) | rust | 391 KiB | 194 KiB |
+| `@agentos-software/http-get` | http-get | Minimal HTTP GET fetch helper | c | - | - |
 | `@agentos-software/jq` | jq | jq JSON processor | rust | 699 KiB | 298 KiB |
 | `@agentos-software/make` | make | GNU make build tool (planned) *(planned)* | rust | - | - |
 | `@agentos-software/ripgrep` | ripgrep | ripgrep fast recursive search | rust | 912 KiB | 330 KiB |
@@ -75,6 +77,7 @@ Node.js agent and tool packages that are projected into the VM via the ModuleAcc
 |---------|-------------|----------|
 | `@agentos-software/build-essential` | Build-essential WASM command set (standard + make + git + curl) | standard, make, git, curl |
 | `@agentos-software/common` | Common WASM command set (coreutils + sed + grep + gawk + findutils + diffutils + tar + gzip) | coreutils, sed, grep, gawk, findutils, diffutils, tar, gzip |
+| `@agentos-software/everything` | All available WASM command packages in a single bundle | coreutils, sed, grep, gawk, findutils, diffutils, tar, gzip, curl, zip, unzip, jq, ripgrep, fd, tree, file, yq, codex |
 <!-- END PACKAGE TABLE -->
 
 ## Building

--- a/website/src/content/docs/docs/features/filesystem.mdx
+++ b/website/src/content/docs/docs/features/filesystem.mdx
@@ -8,6 +8,7 @@ Each VM presents a normal POSIX filesystem to guest code, backed by a virtual fi
 - **Per-VM virtual filesystem**: Every VM gets its own isolated virtual filesystem. One VM cannot see or reach another VM's files.
 - **Never touches the host disk**: Guest filesystem calls are served entirely inside the kernel and never read or write the real host disk.
 - **Normal POSIX and Node APIs**: The standard `node:fs` and `node:fs/promises` APIs work as usual against the virtual filesystem, so ordinary programs run unchanged.
+- **Standard `/dev` devices**: The usual POSIX device files exist and behave as on Linux — `/dev/null`, `/dev/zero`, `/dev/urandom` (cryptographically random bytes), `/dev/stdin`, `/dev/stdout`, `/dev/stderr`, `/dev/fd/*`, and `/dev/pts/*`. Attempts to mutate these entries (unlink/rename/link) fail with `EPERM`.
 - **Mountable backends**: You can project host-backed sources into the guest filesystem, Docker-style, including host directories and S3. Mounts are confined to their root, and the guest sees only the mounted subtree.
 - **`nodeModules` is a mount**: `NodeRuntime.create({ nodeModules })` is a convenience for a read-only host-directory mount. It projects a host `node_modules` tree at guest `/tmp/node_modules` using the same mount machinery as `mounts`, placed on the package-resolution path. See [Module loading](/docs/features/module-loading).
 


### PR DESCRIPTION
Fixes documentation that drifted from the code, surfaced by a full behavior scan. Docs/README only — no product code changes.

- Correct the registry README package table: add the missing `duckdb` and `http-get` rows, fix the `codex` package name (`@agentos-software/codex` → `@agentos-software/codex-cli`).
- Document the `/dev/*` device layer in the filesystem feature docs.
- Document the browser permission presets in the browser package README.
- Correct the browser-sidecar CLAUDE.md test-coverage status (it has smoke/bridge/service tests, not build-only validation).
