### PR TITLE
fix(execution): provide host_tty.isatty/get_size + real set_raw_mode for wasm-c TTY guests

### DIFF
--- a/crates/execution/assets/runners/wasm-runner.mjs
+++ b/crates/execution/assets/runners/wasm-runner.mjs
@@ -5046,9 +5046,26 @@ const hostTtyImport = {
       Atomics.wait(syntheticWaitArray, 0, 0, 10);
     }
   },
-  // Toggle terminal raw mode on the guest's PTY. crossterm calls this instead of
-  // tcsetattr; route it to the kernel so reedline gets raw \r keystrokes and submits.
-  set_raw_mode(_enabled) {
+  // `host_tty.isatty(fd)` -> 1 if the guest fd is a kernel PTY, else 0.
+  isatty(fd) {
+    return callSyncRpc('__kernel_isatty', [fd >>> 0]) === true ? 1 : 0;
+  },
+  // `host_tty.get_size(fd, colsPtr, rowsPtr)` -> writes the PTY window size as two
+  // little-endian u16s and returns 0; non-zero (ENOTTY) if fd is not a PTY.
+  get_size(fd, colsPtr, rowsPtr) {
+    const size = callSyncRpc('__kernel_tty_size', [fd >>> 0]);
+    if (!size || typeof size.cols !== 'number' || typeof size.rows !== 'number') {
+      return 25; // ENOTTY
+    }
+    const view = new DataView(instanceMemory.buffer);
+    view.setUint16(colsPtr >>> 0, size.cols & 0xffff, true);
+    view.setUint16(rowsPtr >>> 0, size.rows & 0xffff, true);
+    return 0;
+  },
+  // Toggle terminal raw mode on the guest's PTY. crossterm/pty_probe/vim call this
+  // instead of tcsetattr; route it to the kernel so the guest gets raw keystrokes.
+  set_raw_mode(enabled) {
+    callSyncRpc('__pty_set_raw_mode', [(enabled >>> 0) !== 0]);
     return 0;
   },
 };


### PR DESCRIPTION
Fixes wasm-c TTY guests (pty_probe, vim) that couldn't run under the converged runtime.

`crates/execution/assets/runners/wasm-runner.mjs`'s `host_tty` import object only provided `read()` and a **stubbed `set_raw_mode` that returned 0** — it was **missing `isatty` and `get_size`**. Any wasm-c program that imports `host_tty.{isatty,get_size}` (the "termios bridge" — used by `pty_probe`, vim, and any crossterm/termios guest) therefore **failed to instantiate with a `LinkError`** on the missing imports, produced no output, and hung.

This wires all three to the kernel sync-RPCs that already exist and are served on the same dispatch as the working `__kernel_stdin_read`:
- `isatty(fd)` → `__kernel_isatty`
- `get_size(fd, colsPtr, rowsPtr)` → `__kernel_tty_size` (writes two LE u16s)
- `set_raw_mode(enabled)` → `__pty_set_raw_mode` (was a no-op stub)

Root-caused by debugging the recovered `pty-line-discipline` integration test (agent-os), whose `wasm-c` matrix all timed out with an empty screen because the probe never instantiated. Complements secure-exec#166 (kernel line-editing): #166 made the kernel *do* echo/VKILL/VWERASE; this makes the guest *able to reach* it.
