### PR TITLE
fix(runtime): native poll(2) for guest stdio + event-driven kernel waits

### DIFF
--- a/crates/execution/assets/runners/wasm-runner.mjs
+++ b/crates/execution/assets/runners/wasm-runner.mjs
@@ -668,17 +668,26 @@ function stdioFdIsKernelTty(fd) {
   return isTty;
 }
 
+// Long event-driven in-RPC waits: the sidecar services __kernel_stdin_read /
+// __kernel_poll by parking the RPC and replying when kernel poll state changes
+// (reply-by-token), so a long wait costs no dispatch-loop time and near-zero
+// CPU (the guest thread blocks in Atomics.wait inside callSync). Keep each
+// slice under the 30s guest sync-RPC deadline.
+const KERNEL_WAIT_SLICE_MS = 10_000;
+
 function readKernelStdinChunk(maxBytes) {
   const requestedLength = Math.max(1, Number(maxBytes) >>> 0);
   while (true) {
-    const response = callSyncRpc('__kernel_stdin_read', [requestedLength, 10]);
+    const response = callSyncRpc('__kernel_stdin_read', [
+      requestedLength,
+      KERNEL_WAIT_SLICE_MS,
+    ]);
     if (response && typeof response.dataBase64 === 'string') {
       return Buffer.from(response.dataBase64, 'base64');
     }
     if (response && response.done === true) {
       return null;
     }
-    Atomics.wait(syntheticWaitArray, 0, 0, 10);
   }
 }
 
@@ -2804,18 +2813,30 @@ const hostNetImport = {
     // these, so net_poll must match or POLLOUT readiness is never reported and writers block.
     const POLLIN = 0x001;
     const POLLOUT = 0x002;
+    const POLLERR = 0x008;
+    const POLLHUP = 0x010;
+    const POLLNVAL = 0x020;
     const t = Number(timeoutMs) | 0;
     const deadline = t < 0 ? null : Date.now() + Math.max(0, t);
+    const kernelManagedStdio =
+      KERNEL_STDIO_SYNC_RPC ||
+      (typeof process?.env?.AGENTOS_SANDBOX_ROOT === 'string' &&
+        process.env.AGENTOS_SANDBOX_ROOT.length > 0);
     try {
       while (true) {
         const view = new DataView(instanceMemory.buffer);
         let ready = 0;
+        // fds the kernel owns (PTY/pipe stdio in sidecar-managed mode): their readiness
+        // comes from a batched __kernel_poll below, which doubles as the wait slice.
+        const kernelTargets = [];
+        const kernelEntries = [];
         for (let i = 0; i < n; i++) {
           const base = base0 + i * 8;
           const fd = view.getInt32(base, true);
           const events = view.getUint16(base + 4, true);
           let revents = 0;
           const socket = getHostNetSocket(fd);
+          const handle = fd >= 0 ? lookupFdHandle(fd >>> 0) : undefined;
           if (socket && !socket.closed) {
             if (socket.serverId) {
               if (events & POLLIN) {
@@ -2833,19 +2854,97 @@ const hostNetImport = {
               }
               if (events & POLLOUT) revents |= POLLOUT;
             }
+          } else if (handle?.kind === 'pipe-read') {
+            if (events & POLLIN) {
+              pumpPipeProducers(handle.pipe, 0);
+              if (handle.pipe.chunks.length > 0) {
+                revents |= POLLIN;
+              } else if (
+                handle.pipe.writeHandleCount === 0 &&
+                handle.pipe.producers.size === 0
+              ) {
+                revents |= POLLHUP;
+              }
+            }
+          } else if (handle?.kind === 'pipe-write') {
+            if (events & POLLOUT) revents |= POLLOUT;
+          } else if (
+            fd >= 0 &&
+            fd <= 2 &&
+            kernelManagedStdio &&
+            (!handle || (handle.kind === 'passthrough' && handle.targetFd === fd))
+          ) {
+            // Kernel-managed stdio (PTY slave / stdio pipes): ask the kernel, like a
+            // native poll(2) on the terminal fd.
+            kernelTargets.push({
+              fd,
+              events:
+                ((events & POLLIN) !== 0 ? KERNEL_POLLIN : 0) |
+                ((events & POLLOUT) !== 0 ? KERNEL_POLLOUT : 0),
+            });
+            kernelEntries.push({ base, fd, events });
+          } else if (handle) {
+            // Regular files / other VFS-backed fds: always ready, as on Linux.
+            revents |= events & (POLLIN | POLLOUT);
+          } else if (fd >= 0 && fd <= 2) {
+            // Non-kernel-managed stdio (plain runner stdio): report requested
+            // readiness rather than blocking a guest forever on fds we cannot wait on.
+            revents |= events & (POLLIN | POLLOUT);
+          } else if (fd >= 0) {
+            revents |= POLLNVAL;
           }
           view.setUint16(base + 6, revents, true);
           if (revents) ready++;
         }
+
+        if (kernelTargets.length > 0) {
+          // If something is already ready (or this is a non-blocking poll), probe the
+          // kernel without waiting; otherwise let the kernel wait one slice for us.
+          const remaining = deadline == null ? Infinity : deadline - Date.now();
+          const sliceMs =
+            ready > 0 || t === 0
+              ? 0
+              : Math.max(0, Math.min(KERNEL_WAIT_SLICE_MS, remaining));
+          let response = null;
+          try {
+            response = callSyncRpc('__kernel_poll', [kernelTargets, sliceMs]);
+          } catch {
+            response = null;
+          }
+          const responseEntries = Array.isArray(response?.fds) ? response.fds : [];
+          for (const entry of kernelEntries) {
+            const responseEntry = responseEntries.find(
+              (item) => (Number(item?.fd) >>> 0) === (entry.fd >>> 0),
+            );
+            const kernelRevents = Number(responseEntry?.revents) >>> 0;
+            let revents = 0;
+            if (kernelRevents & KERNEL_POLLIN) revents |= POLLIN & entry.events;
+            if (kernelRevents & KERNEL_POLLOUT) revents |= POLLOUT & entry.events;
+            if (kernelRevents & KERNEL_POLLERR) revents |= POLLERR;
+            if (kernelRevents & KERNEL_POLLHUP) revents |= POLLHUP;
+            new DataView(instanceMemory.buffer).setUint16(entry.base + 6, revents, true);
+            if (revents) ready++;
+          }
+        }
+
         if (ready > 0 || t === 0 || (deadline != null && Date.now() >= deadline)) {
           new DataView(instanceMemory.buffer).setUint32(Number(retReadyPtr) >>> 0, ready >>> 0, true);
           return 0;
         }
+        let pumpedSocket = false;
         const v2 = new DataView(instanceMemory.buffer);
         for (let i = 0; i < n; i++) {
           const fd = v2.getInt32(base0 + i * 8, true);
           const s = getHostNetSocket(fd);
-          if (s && s.socketId && !s.serverId) pollHostNetSocket(s, 10);
+          if (s && s.socketId && !s.serverId) {
+            pollHostNetSocket(s, 10);
+            pumpedSocket = true;
+          }
+        }
+        if (kernelTargets.length === 0 && !pumpedSocket) {
+          // Nothing to wait on except time: sleep a slice instead of hot-spinning.
+          const remaining = deadline == null ? Infinity : deadline - Date.now();
+          Atomics.wait(syntheticWaitArray, 0, 0, Math.max(1, Math.min(10, remaining)));
         }
       }
     } catch (_e) {
@@ -4950,6 +5049,12 @@ wasiImport.poll_oneoff = (inPtr, outPtr, nsubscriptions, neventsPtr) => {
       ) {
         hasRemappedPassthroughSubscription = true;
       }
+    } else if (!handle && fd <= 2 && (sidecarManagedProcess || KERNEL_STDIO_SYNC_RPC)) {
+      // Kernel-managed stdio with no local handle: fd 0/1/2 map straight to
+      // the kernel PTY/pipes, so readiness must come from __kernel_poll — the
+      // delegate's fds are the runner process's own stdio and never fire for
+      // guest terminal input (vim's RealWaitForChar polls fd 0 this way).
+      hasRemappedPassthroughSubscription = true;
     }
     subscriptions.push({
       kind: tag === 1 ? 'fd_read' : 'fd_write',
@@ -4973,19 +5078,27 @@ wasiImport.poll_oneoff = (inPtr, outPtr, nsubscriptions, neventsPtr) => {
       return [];
     }
 
+    const kernelPollFdFor = (subscription) => {
+      if (subscription.kind !== 'fd_read' && subscription.kind !== 'fd_write') {
+        return null;
+      }
+      const fd = Number(subscription.fd) >>> 0;
+      if (subscription.handle?.kind === 'passthrough') {
+        const targetFd = Number(subscription.handle.targetFd) >>> 0;
+        if (targetFd !== fd || (fd === 0 && (sidecarManagedProcess || KERNEL_STDIO_SYNC_RPC))) {
+          return targetFd;
+        }
+        return null;
+      }
+      if (!subscription.handle && fd <= 2 && (sidecarManagedProcess || KERNEL_STDIO_SYNC_RPC)) {
+        return fd;
+      }
+      return null;
+    };
     const pollTargets = subscriptions
-      .filter(
-        (subscription) =>
-          (subscription.kind === 'fd_read' || subscription.kind === 'fd_write') &&
-          subscription.handle?.kind === 'passthrough' &&
-          (
-            (Number(subscription.handle.targetFd) >>> 0) !== (Number(subscription.fd) >>> 0) ||
-            ((Number(subscription.fd) >>> 0) === 0 &&
-              (sidecarManagedProcess || KERNEL_STDIO_SYNC_RPC))
-          )
-      )
+      .filter((subscription) => kernelPollFdFor(subscription) != null)
       .map((subscription) => ({
-        fd: Number(subscription.handle.targetFd) >>> 0,
+        fd: kernelPollFdFor(subscription),
         events: subscription.kind === 'fd_read' ? KERNEL_POLLIN : KERNEL_POLLOUT,
       }));
     if (pollTargets.length === 0) {
@@ -5005,21 +5118,12 @@ wasiImport.poll_oneoff = (inPtr, outPtr, nsubscriptions, neventsPtr) => {
     const responseEntries = Array.isArray(response?.fds) ? response.fds : [];
     const ready = [];
     for (const subscription of subscriptions) {
-      if (
-        (subscription.kind !== 'fd_read' && subscription.kind !== 'fd_write') ||
-        subscription.handle?.kind !== 'passthrough' ||
-        (
-          (Number(subscription.handle.targetFd) >>> 0) === (Number(subscription.fd) >>> 0) &&
-          !(
-            (Number(subscription.fd) >>> 0) === 0 &&
-            (sidecarManagedProcess || KERNEL_STDIO_SYNC_RPC)
-          )
-        )
-      ) {
+      const kernelFd = kernelPollFdFor(subscription);
+      if (kernelFd == null) {
         continue;
       }
 
-      const targetFd = Number(subscription.handle.targetFd) >>> 0;
+      const targetFd = kernelFd;
       const responseEntry = responseEntries.find(
         (entry) => (Number(entry?.fd) >>> 0) === targetFd
       );
@@ -5087,8 +5191,17 @@ wasiImport.poll_oneoff = (inPtr, outPtr, nsubscriptions, neventsPtr) => {
     }
 
     if (hasRemappedPassthroughSubscription) {
-      const kernelWaitMs =
-        deadline == null ? 10 : Math.max(0, Math.min(10, deadline - Date.now()));
+      // Kernel fds wait event-driven in the sidecar (parked RPC), so the slice
+      // can be long. Synthetic (pipe) subscriptions still need short local
+      // pumping, so only use the long slice when every subscription is
+      // kernel-backed.
+      const kernelWaitMs = hasSyntheticSubscription
+        ? deadline == null
+          ? 10
+          : Math.max(0, Math.min(10, deadline - Date.now()))
+        : deadline == null
+          ? KERNEL_WAIT_SLICE_MS
+          : Math.max(0, Math.min(KERNEL_WAIT_SLICE_MS, deadline - Date.now()));
       readyEvents.push(...collectKernelReadyEvents(kernelWaitMs));
       if (readyEvents.length > 0) {
         break;
@@ -5150,18 +5263,22 @@ wasiImport.poll_oneoff = (inPtr, outPtr, nsubscriptions, neventsPtr) => {
 // (-1 as i32) means block until input. Backed by the same __kernel_stdin_read RPC
 // the wasi fd_read path uses, so it works identically under native and browser.
 const hostTtyImport = {
-  // Short-poll slices (like readKernelStdinChunk), never one long blocking
-  // read: a long `__kernel_stdin_read` occupies the sidecar service loop, so
-  // the very host->guest stdin write the caller is waiting for (e.g. the CPR
-  // reply to crossterm's cursor-position query) queues behind it and cannot
-  // land until the read times out — a self-deadlock.
+  // Long event-driven waits: the sidecar parks __kernel_stdin_read and replies
+  // when the PTY becomes readable (reply-by-token), so a host->guest write the
+  // caller is waiting for (e.g. the CPR reply to crossterm's cursor-position
+  // query) lands immediately — no polling slices, no self-deadlock.
   read(ptr, len, timeoutMs) {
     const cap = Number(len) >>> 0;
     if (cap === 0) return 0;
     const blocking = (timeoutMs >>> 0) === 0xffffffff;
     const deadline = blocking ? Infinity : Date.now() + (Number(timeoutMs) >>> 0);
     while (true) {
-      const response = callSyncRpc('__kernel_stdin_read', [cap, 10]);
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) return 0;
+      const response = callSyncRpc('__kernel_stdin_read', [
+        cap,
+        Math.min(remaining, KERNEL_WAIT_SLICE_MS),
+      ]);
       if (response && typeof response.dataBase64 === 'string') {
         const bytes = Buffer.from(response.dataBase64, 'base64');
         const n = Math.min(bytes.length, cap);
@@ -5171,8 +5288,6 @@ const hostTtyImport = {
         }
       }
       if (response && response.done === true) return 0;
-      if (Date.now() >= deadline) return 0;
-      Atomics.wait(syntheticWaitArray, 0, 0, 5);
     }
   },
   // `host_tty.isatty(fd)` -> 1 if the guest fd is a kernel PTY, else 0.

--- a/crates/execution/src/wasm.rs
+++ b/crates/execution/src/wasm.rs
@@ -65,7 +65,6 @@ const DEFAULT_WASM_PREWARM_TIMEOUT_MS: u64 = 30_000;
 /// `Some(limit)` in [`WasmExecution::wait`] and pin a host CPU core forever,
 /// starving every other tenant on the shared process. Operators that need a
 /// tighter (or looser) bound can still set `AGENTOS_WASM_MAX_FUEL` explicitly.
-const DEFAULT_WASM_EXECUTION_TIMEOUT_MS: u64 = 30_000;
 /// Default V8 heap cap (MB) for the wasm *runner* isolate.
 ///
 /// The runner is trusted sidecar infrastructure: it compiles the WASI runtime +
@@ -3042,20 +3041,19 @@ fn warmup_metrics_line(
 fn resolve_wasm_execution_timeout(
     request: &StartWasmExecutionRequest,
 ) -> Result<Option<Duration>, WasmExecutionError> {
-    // Node's WASI runtime does not expose per-instruction fuel metering, so the
-    // configured "fuel" budget is currently enforced as a tight wall-clock
+    // Node's WASI runtime does not expose per-instruction fuel metering, so an
+    // EXPLICITLY configured "fuel" budget is enforced as a tight wall-clock
     // timeout. The value rides the typed `limits.max_fuel` (from the BARE-wire
     // resource limits), not an `AGENTOS_WASM_MAX_FUEL` env var.
     //
-    // When no explicit fuel budget is configured we still apply a default
-    // wall-clock timeout: otherwise `wait()` gates termination behind
-    // `Some(limit)` and a never-returning guest (e.g. an infinite loop) pins a
-    // host CPU core indefinitely, starving other tenants on the shared process.
-    let budget_ms = request
-        .limits
-        .max_fuel
-        .unwrap_or(DEFAULT_WASM_EXECUTION_TIMEOUT_MS);
-    Ok(Some(Duration::from_millis(budget_ms)))
+    // With no explicit fuel budget there is NO default wall-clock timeout —
+    // matching the JS execution philosophy (wall-clock backstop is opt-in).
+    // The guest stays bounded by default anyway: the wasm module executes on
+    // the runner isolate's thread, whose TRUE-CPU budget (the V8 CPU-time
+    // watchdog, default 30s ACTIVE CPU) terminates an infinite-loop module
+    // while letting an idle interactive guest (vim blocked in a kernel input
+    // wait) live indefinitely, exactly like native Linux.
+    Ok(request.limits.max_fuel.map(Duration::from_millis))
 }
 
 /// Resolve and validate the per-execution WASM stack cap from the typed wire
@@ -3560,8 +3558,7 @@ mod tests {
         wasm_sandbox_root, wasm_sync_read_length, wasm_sync_rpc_error_code,
         wasm_sync_rpc_method_routes_through_sidecar_kernel, GuestRuntimeConfig,
         JavascriptSyncRpcRequest, StartWasmExecutionRequest, Value, WasmExecutionError,
-        WasmExecutionLimits, WasmInternalSyncRpc, WasmPermissionTier,
-        DEFAULT_WASM_EXECUTION_TIMEOUT_MS, NODE_WASI_MODULE_SOURCE,
+        WasmExecutionLimits, WasmInternalSyncRpc, WasmPermissionTier, NODE_WASI_MODULE_SOURCE,
         WASM_CAPTURED_OUTPUT_LIMIT_BYTES, WASM_MAX_FUEL_ENV, WASM_MAX_MEMORY_BYTES_ENV,
         WASM_MAX_STACK_BYTES_ENV, WASM_PAGE_BYTES, WASM_PREWARM_TIMEOUT_MS_ENV,
         WASM_SANDBOX_ROOT_ENV, WASM_SIDECAR_ROUTED_FS_SYNC_METHODS, WASM_SYNC_READ_LIMIT_BYTES,
@@ -3680,13 +3677,14 @@ mod tests {
 
     #[test]
     fn wasm_limits_default_to_bounded_timeout_when_unset_even_with_env_present() {
-        // Same misleading env, but no typed limits: execution gets the default
-        // bounded timeout, while memory and stack limits remain absent.
+        // Same misleading env, but no typed limits: no wall-clock fuel timeout
+        // (the runner's V8 TRUE-CPU budget bounds runaways), and memory and
+        // stack limits remain absent.
         let request = request_with_typed_limits_and_misleading_env(WasmExecutionLimits::default());
 
         assert_eq!(
             resolve_wasm_execution_timeout(&request).expect("fuel"),
-            Some(Duration::from_millis(DEFAULT_WASM_EXECUTION_TIMEOUT_MS))
+            None
         );
         assert_eq!(wasm_memory_limit_bytes(&request).expect("memory"), None);
         assert_eq!(
@@ -3763,10 +3761,11 @@ mod tests {
             .expect("execution timeout resolves without fuel env");
 
         assert_eq!(
-            timeout,
-            Some(Duration::from_millis(DEFAULT_WASM_EXECUTION_TIMEOUT_MS)),
-            "a no-fuel guest must still be bounded by a default wall-clock timeout, \
-             otherwise wait() never terminates an infinite-loop module (F-004)"
+            timeout, None,
+            "no explicit fuel budget means no wall-clock timeout; the runner \
+             isolate's TRUE-CPU budget (default 30s active CPU) is the bound \
+             that terminates an infinite-loop module (F-004), so an idle \
+             interactive guest is not killed on wall time"
         );
     }
 

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -2268,6 +2268,13 @@ impl<F: VirtualFileSystem + 'static> KernelVm<F> {
         })
     }
 
+    /// A cloneable, Send handle for waiting on kernel poll-state changes off
+    /// the kernel owner's thread. Pair with a zero-timeout `poll_fds` /
+    /// `fd_read_with_timeout_result` re-check on the owning thread.
+    pub fn poll_wait_handle(&self) -> crate::poll::PollWaitHandle {
+        crate::poll::PollWaitHandle::new(self.poll_notifier.clone())
+    }
+
     pub fn poll_targets(
         &self,
         requester_driver: &str,

--- a/crates/kernel/src/poll.rs
+++ b/crates/kernel/src/poll.rs
@@ -113,6 +113,34 @@ pub struct PollTargetResult {
     pub targets: Vec<PollTargetEntry>,
 }
 
+/// Cloneable, Send handle onto the kernel's poll notifier so a caller can wait
+/// for "some poll-visible state changed" OFF the thread that owns the kernel
+/// (deferred readiness servicing), then re-check readiness with a zero-timeout
+/// poll on the owning thread. Take `snapshot()` BEFORE the readiness check it
+/// guards so a change landing between the check and the wait wakes immediately
+/// instead of being lost.
+#[derive(Debug, Clone)]
+pub struct PollWaitHandle {
+    notifier: PollNotifier,
+}
+
+impl PollWaitHandle {
+    pub(crate) fn new(notifier: PollNotifier) -> Self {
+        Self { notifier }
+    }
+
+    /// Snapshot the current change generation.
+    pub fn snapshot(&self) -> u64 {
+        self.notifier.snapshot()
+    }
+
+    /// Block until the generation moves past `observed` or `timeout` elapses
+    /// (`None` = wait forever). Returns true when a change was observed.
+    pub fn wait_for_change(&self, observed: u64, timeout: Option<Duration>) -> bool {
+        self.notifier.wait_for_change(observed, timeout)
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct PollNotifier {
     inner: Arc<PollNotifierInner>,

--- a/crates/sidecar/src/execution.rs
+++ b/crates/sidecar/src/execution.rs
@@ -498,6 +498,7 @@ impl ActiveProcess {
             next_sqlite_database_id: 0,
             sqlite_statements: BTreeMap::new(),
             next_sqlite_statement_id: 0,
+            deferred_kernel_wait_rpc: None,
             module_resolution_cache: secure_exec_execution::LocalModuleResolutionCache::default(),
         }
     }
@@ -4187,6 +4188,12 @@ where
             SidecarError::InvalidState(format!("VM {vm_id} has no active process {process_id}"))
         })?;
         let kernel_pid = process.kernel_pid;
+        if !matches!(signal, 0 | libc::SIGCONT) {
+            // A guest parked in a deferred kernel-wait sync RPC is blocked in a
+            // native bridge wait the kill cannot interrupt; answer the parked
+            // RPC first so the termination can take effect.
+            flush_parked_kernel_wait_rpc(process);
+        }
 
         enum KillBehavior {
             Tool,
@@ -7258,6 +7265,137 @@ where
         }
     }
 
+    /// Deferred servicing for a CHILD's `__kernel_stdin_read` / `__kernel_poll`
+    /// inside the child-event pump: probe readiness with a zero timeout, reply
+    /// when ready / expired / non-blocking, otherwise park the RPC on the child
+    /// (reply-by-token). The pump loop re-checks the parked RPC every
+    /// iteration, so the dispatch loop never blocks in a kernel wait on the
+    /// child's behalf. Returns false when the RPC must be serviced inline
+    /// (non-TTY JavaScript local stdin bridge).
+    fn service_child_kernel_wait_rpc(
+        &mut self,
+        vm_id: &str,
+        process_id: &str,
+        current_process_path: &[&str],
+        child_process_id: &str,
+        request: &JavascriptSyncRpcRequest,
+    ) -> Result<bool, SidecarError> {
+        let Some(vm) = self.vms.get_mut(vm_id) else {
+            return Ok(true);
+        };
+        let kernel = &mut vm.kernel;
+        let Some(root) = vm.active_processes.get_mut(process_id) else {
+            return Ok(true);
+        };
+        let Some(parent) = Self::active_process_by_path_mut(root, current_process_path) else {
+            return Ok(true);
+        };
+        let Some(child) = parent.child_processes.get_mut(child_process_id) else {
+            return Ok(true);
+        };
+        if request.method == "__kernel_stdin_read"
+            && matches!(child.execution, ActiveExecution::Javascript(_))
+            && child.tty_master_fd.is_none()
+        {
+            return Ok(false);
+        }
+        let now = Instant::now();
+        let requested_timeout_ms = match request.method.as_str() {
+            "__kernel_stdin_read" => parse_kernel_stdin_read_args(request)?.1,
+            _ => u64::try_from(parse_kernel_poll_args(request)?.1).unwrap_or(0),
+        };
+        let deadline = match &child.deferred_kernel_wait_rpc {
+            Some((parked, parked_deadline)) if parked.id == request.id => *parked_deadline,
+            _ => now + Duration::from_millis(requested_timeout_ms),
+        };
+        let kernel_pid = child.kernel_pid;
+        let probe = match request.method.as_str() {
+            "__kernel_stdin_read" => {
+                let (max_bytes, _) = parse_kernel_stdin_read_args(request)?;
+                kernel_stdin_read_response(kernel, kernel_pid, max_bytes, Duration::ZERO)
+            }
+            _ => {
+                let (fd_requests, _) = parse_kernel_poll_args(request)?;
+                kernel_poll_response(kernel, kernel_pid, &fd_requests, 0)
+            }
+        };
+        let probe = match probe {
+            Ok(value) => value,
+            Err(error) => {
+                child.deferred_kernel_wait_rpc = None;
+                child
+                    .execution
+                    .respond_javascript_sync_rpc_error(
+                        request.id,
+                        javascript_sync_rpc_error_code(&error),
+                        error.to_string(),
+                    )
+                    .or_else(ignore_stale_javascript_sync_rpc_response)?;
+                return Ok(true);
+            }
+        };
+        let ready = match request.method.as_str() {
+            "__kernel_stdin_read" => !probe.is_null(),
+            _ => {
+                probe
+                    .get("readyCount")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0)
+                    > 0
+            }
+        };
+        if ready || requested_timeout_ms == 0 || now >= deadline {
+            child.deferred_kernel_wait_rpc = None;
+            child
+                .execution
+                .respond_javascript_sync_rpc_response(request.id, probe.into())
+                .or_else(ignore_stale_javascript_sync_rpc_response)?;
+            return Ok(true);
+        }
+        child.deferred_kernel_wait_rpc = Some((request.clone(), deadline));
+        Ok(true)
+    }
+
+    /// Re-check a child's parked kernel-wait RPC (see
+    /// `service_child_kernel_wait_rpc`); called once per pump-loop iteration.
+    fn recheck_child_deferred_kernel_wait_rpc(
+        &mut self,
+        vm_id: &str,
+        process_id: &str,
+        current_process_path: &[&str],
+        child_process_id: &str,
+    ) -> Result<(), SidecarError> {
+        let parked = {
+            let Some(vm) = self.vms.get_mut(vm_id) else {
+                return Ok(());
+            };
+            let Some(root) = vm.active_processes.get_mut(process_id) else {
+                return Ok(());
+            };
+            let Some(parent) = Self::active_process_by_path_mut(root, current_process_path)
+            else {
+                return Ok(());
+            };
+            let Some(child) = parent.child_processes.get_mut(child_process_id) else {
+                return Ok(());
+            };
+            child
+                .deferred_kernel_wait_rpc
+                .as_ref()
+                .map(|(request, _)| request.clone())
+        };
+        if let Some(request) = parked {
+            let _ = self.service_child_kernel_wait_rpc(
+                vm_id,
+                process_id,
+                current_process_path,
+                child_process_id,
+                &request,
+            )?;
+        }
+        Ok(())
+    }
+
     fn poll_descendant_javascript_child_process(
         &mut self,
         vm_id: &str,
@@ -7277,6 +7415,12 @@ where
                 vm_id,
                 process_id,
                 &child_path,
+            )?;
+            self.recheck_child_deferred_kernel_wait_rpc(
+                vm_id,
+                process_id,
+                current_process_path,
+                child_process_id,
             )?;
             enum ChildPollResult {
                 Event(Box<Option<ActiveExecutionEvent>>),
@@ -7484,6 +7628,20 @@ where
                 ActiveExecutionEvent::JavascriptSyncRpcRequest(request) => {
                     let mut current_child_path = current_process_path.to_vec();
                     current_child_path.push(child_process_id);
+                    if matches!(
+                        request.method.as_str(),
+                        "__kernel_stdin_read" | "__kernel_poll"
+                    ) && self.service_child_kernel_wait_rpc(
+                        vm_id,
+                        process_id,
+                        current_process_path,
+                        child_process_id,
+                        &request,
+                    )? {
+                        // Replied immediately or parked on the child; the pump
+                        // loop re-checks parked RPCs every iteration.
+                        continue;
+                    }
                     let response = if request.method == "process.signal_state" {
                         let (signal, registration) =
                             parse_process_signal_state_request(&request.args)
@@ -13656,7 +13814,21 @@ fn spawn_unix_socket_reader(
     });
 }
 
+/// Unblock a guest thread parked in a deferred `__kernel_stdin_read` /
+/// `__kernel_poll` sync RPC. Isolate termination cannot interrupt the native
+/// bridge wait, so teardown must answer the parked RPC BEFORE dropping the
+/// execution (drop joins the guest thread) or cleanup deadlocks against it.
+fn flush_parked_kernel_wait_rpc(process: &mut ActiveProcess) {
+    if let Some((request, _)) = process.deferred_kernel_wait_rpc.take() {
+        let _ = process
+            .execution
+            .respond_javascript_sync_rpc_error(request.id, "EINTR", "process teardown")
+            .or_else(ignore_stale_javascript_sync_rpc_response);
+    }
+}
+
 fn terminate_child_process_tree(kernel: &mut SidecarKernel, process: &mut ActiveProcess) {
+    flush_parked_kernel_wait_rpc(process);
     let sqlite_database_ids = process.sqlite_databases.keys().copied().collect::<Vec<_>>();
     for database_id in sqlite_database_ids {
         let _ = close_sqlite_database(kernel, process, database_id);
@@ -14745,7 +14917,7 @@ pub(crate) fn javascript_sync_rpc_bytes_value(bytes: &[u8]) -> Value {
 }
 
 #[derive(Debug, Deserialize)]
-struct KernelPollFdRequest {
+pub(crate) struct KernelPollFdRequest {
     fd: u32,
     events: u16,
 }
@@ -17640,6 +17812,19 @@ fn service_javascript_kernel_stdin_sync_rpc(
     process: &mut ActiveProcess,
     request: &JavascriptSyncRpcRequest,
 ) -> Result<Value, SidecarError> {
+    let (max_bytes, timeout_ms) = parse_kernel_stdin_read_args(request)?;
+    kernel_stdin_read_response(
+        kernel,
+        process.kernel_pid,
+        max_bytes,
+        Duration::from_millis(timeout_ms),
+    )
+}
+
+/// Parse `__kernel_stdin_read` args: (max bytes, requested timeout ms).
+pub(crate) fn parse_kernel_stdin_read_args(
+    request: &JavascriptSyncRpcRequest,
+) -> Result<(usize, u64), SidecarError> {
     let max_bytes =
         javascript_sync_rpc_arg_u64_optional(&request.args, 0, "__kernel_stdin_read max bytes")?
             .map(|value| value.clamp(1, DEFAULT_KERNEL_STDIN_READ_MAX_BYTES as u64) as usize)
@@ -17647,15 +17832,19 @@ fn service_javascript_kernel_stdin_sync_rpc(
     let timeout_ms =
         javascript_sync_rpc_arg_u64_optional(&request.args, 1, "__kernel_stdin_read timeout ms")?
             .unwrap_or(DEFAULT_KERNEL_STDIN_READ_TIMEOUT_MS);
+    Ok((max_bytes, timeout_ms))
+}
 
+/// One bounded stdin read against the kernel. `Duration::ZERO` = non-blocking
+/// probe (deferred servicing re-checks readiness with this before replying).
+pub(crate) fn kernel_stdin_read_response(
+    kernel: &mut SidecarKernel,
+    kernel_pid: u32,
+    max_bytes: usize,
+    timeout: Duration,
+) -> Result<Value, SidecarError> {
     match kernel
-        .fd_read_with_timeout_result(
-            EXECUTION_DRIVER_NAME,
-            process.kernel_pid,
-            0,
-            max_bytes,
-            Some(Duration::from_millis(timeout_ms)),
-        )
+        .fd_read_with_timeout_result(EXECUTION_DRIVER_NAME, kernel_pid, 0, max_bytes, Some(timeout))
         .map_err(kernel_error)
     {
         Ok(Some(chunk)) if !chunk.is_empty() => Ok(json!({
@@ -17861,6 +18050,14 @@ fn service_javascript_kernel_poll_sync_rpc(
     process: &ActiveProcess,
     request: &JavascriptSyncRpcRequest,
 ) -> Result<Value, SidecarError> {
+    let (fd_requests, timeout_ms) = parse_kernel_poll_args(request)?;
+    kernel_poll_response(kernel, process.kernel_pid, &fd_requests, timeout_ms)
+}
+
+/// Parse `__kernel_poll` args: (fd list, requested timeout ms).
+pub(crate) fn parse_kernel_poll_args(
+    request: &JavascriptSyncRpcRequest,
+) -> Result<(Vec<KernelPollFdRequest>, i32), SidecarError> {
     let fd_requests: Vec<KernelPollFdRequest> = serde_json::from_value(
         request
             .args
@@ -17879,7 +18076,17 @@ fn service_javascript_kernel_poll_sync_rpc(
     let timeout_ms = i32::try_from(timeout_ms).map_err(|_| {
         SidecarError::InvalidState(String::from("__kernel_poll timeout ms must fit within i32"))
     })?;
+    Ok((fd_requests, timeout_ms))
+}
 
+/// One bounded kernel poll. Timeout `0` = non-blocking probe (deferred
+/// servicing re-checks readiness with this before replying).
+pub(crate) fn kernel_poll_response(
+    kernel: &SidecarKernel,
+    kernel_pid: u32,
+    fd_requests: &[KernelPollFdRequest],
+    timeout_ms: i32,
+) -> Result<Value, SidecarError> {
     let poll_fds = fd_requests
         .iter()
         .map(|entry| PollFd {
@@ -17889,12 +18096,7 @@ fn service_javascript_kernel_poll_sync_rpc(
         })
         .collect::<Vec<_>>();
     let result = kernel
-        .poll_fds(
-            EXECUTION_DRIVER_NAME,
-            process.kernel_pid,
-            poll_fds,
-            timeout_ms,
-        )
+        .poll_fds(EXECUTION_DRIVER_NAME, kernel_pid, poll_fds, timeout_ms)
         .map_err(kernel_error)?;
     Ok(json!({
         "readyCount": result.ready_count,

--- a/crates/sidecar/src/service.rs
+++ b/crates/sidecar/src/service.rs
@@ -9,8 +9,9 @@ pub(crate) use crate::execution::{
     javascript_sync_rpc_option_bool, javascript_sync_rpc_option_u32,
     mark_execute_exit_event_queued, parse_signal, record_execute_exit_event_queue_wait,
     record_execute_phase, sanitize_javascript_child_process_internal_bootstrap_env,
-    service_javascript_sync_rpc, vm_network_resource_counts, JavascriptSyncRpcServiceRequest,
-    LoopbackHttpDispatchRequest,
+    kernel_poll_response, kernel_stdin_read_response, parse_kernel_poll_args,
+    parse_kernel_stdin_read_args, service_javascript_sync_rpc, vm_network_resource_counts,
+    JavascriptSyncRpcServiceRequest, LoopbackHttpDispatchRequest,
 };
 use crate::extension::{
     Extension, ExtensionBufferedProcessOutput, ExtensionContext, ExtensionFuture, ExtensionHost,
@@ -1723,6 +1724,152 @@ where
     // poll_javascript_child_process, write_javascript_child_process_stdin,
     // close_javascript_child_process_stdin, kill_javascript_child_process moved to crate::execution
 
+    /// Whether a `__kernel_stdin_read` / `__kernel_poll` RPC may be serviced
+    /// via the non-blocking deferral path. Non-TTY JavaScript keeps its
+    /// in-process local stdin bridge (serviced inline by the fallback arm).
+    fn kernel_wait_rpc_is_deferrable(
+        &self,
+        vm_id: &str,
+        process_id: &str,
+        request: &JavascriptSyncRpcRequest,
+    ) -> bool {
+        let Some(vm) = self.vms.get(vm_id) else {
+            return false;
+        };
+        let Some(process) = vm.active_processes.get(process_id) else {
+            return false;
+        };
+        if request.method == "__kernel_stdin_read"
+            && matches!(process.execution, crate::state::ActiveExecution::Javascript(_))
+            && process.tty_master_fd.is_none()
+        {
+            return false;
+        }
+        true
+    }
+
+    /// Service `__kernel_stdin_read` / `__kernel_poll` without blocking the
+    /// dispatch loop. Probes readiness with a zero timeout; when not ready and
+    /// the requested timeout has not expired, parks the RPC on the process
+    /// (reply-by-token) and spawns a waiter that re-enqueues it as a process
+    /// event when kernel poll state changes or the deadline passes. The kernel
+    /// waits stay event-driven (PollNotifier), so a host stdin write wakes the
+    /// guest immediately instead of after a polling slice.
+    ///
+    /// Returns `Ok(Some(response))` to reply now, `Ok(None)` when parked.
+    fn service_deferrable_kernel_wait_rpc(
+        &mut self,
+        vm_id: &str,
+        process_id: &str,
+        request: &JavascriptSyncRpcRequest,
+    ) -> Result<Option<crate::execution::JavascriptSyncRpcServiceResponse>, SidecarError> {
+        let requested_timeout_ms = match request.method.as_str() {
+            "__kernel_stdin_read" => parse_kernel_stdin_read_args(request)?.1,
+            _ => u64::try_from(parse_kernel_poll_args(request)?.1).unwrap_or(0),
+        };
+        let now = Instant::now();
+
+        let Some(vm) = self.vms.get_mut(vm_id) else {
+            log_stale_process_event(
+                &self.bridge,
+                vm_id,
+                process_id,
+                "deferred kernel wait RPC",
+            );
+            return Ok(None);
+        };
+        let wait_handle = vm.kernel.poll_wait_handle();
+        // Snapshot BEFORE the readiness probe: a write landing between the
+        // probe and the waiter's wait bumps the generation, so the wait
+        // returns immediately instead of losing the wakeup.
+        let generation = wait_handle.snapshot();
+        let Some(process) = vm.active_processes.get_mut(process_id) else {
+            log_stale_process_event(
+                &self.bridge,
+                vm_id,
+                process_id,
+                "deferred kernel wait RPC",
+            );
+            return Ok(None);
+        };
+        let kernel_pid = process.kernel_pid;
+        let deadline = match &process.deferred_kernel_wait_rpc {
+            Some((parked, parked_deadline)) if parked.id == request.id => *parked_deadline,
+            _ => now + Duration::from_millis(requested_timeout_ms),
+        };
+        let probe = match request.method.as_str() {
+            "__kernel_stdin_read" => {
+                let (max_bytes, _) = parse_kernel_stdin_read_args(request)?;
+                kernel_stdin_read_response(&mut vm.kernel, kernel_pid, max_bytes, Duration::ZERO)
+            }
+            _ => {
+                let (fd_requests, _) = parse_kernel_poll_args(request)?;
+                kernel_poll_response(&vm.kernel, kernel_pid, &fd_requests, 0)
+            }
+        };
+        let Some(process) = vm.active_processes.get_mut(process_id) else {
+            return Ok(None);
+        };
+        let probe = match probe {
+            Ok(value) => value,
+            Err(error) => {
+                process.deferred_kernel_wait_rpc = None;
+                return Err(error);
+            }
+        };
+        let ready = match request.method.as_str() {
+            "__kernel_stdin_read" => !probe.is_null(),
+            _ => {
+                probe
+                    .get("readyCount")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0)
+                    > 0
+            }
+        };
+        if ready || requested_timeout_ms == 0 || now >= deadline {
+            process.deferred_kernel_wait_rpc = None;
+            return Ok(Some(probe.into()));
+        }
+
+        let connection_id = vm.connection_id.clone();
+        let session_id = vm.session_id.clone();
+        let remaining = deadline.saturating_duration_since(now);
+        let sender = self.process_event_sender.clone();
+        let waiter_request = request.clone();
+        let envelope_vm_id = vm_id.to_owned();
+        let envelope_process_id = process_id.to_owned();
+        let spawned = std::thread::Builder::new()
+            .name(String::from("kernel-wait-rpc"))
+            .spawn(move || {
+                // Wake on any kernel poll-state change or the deadline; either
+                // way requeue exactly once — the handler re-probes and either
+                // replies or re-parks.
+                let _ = wait_handle.wait_for_change(generation, Some(remaining));
+                let _ = sender.blocking_send(ProcessEventEnvelope {
+                    connection_id,
+                    session_id,
+                    vm_id: envelope_vm_id,
+                    process_id: envelope_process_id,
+                    event: ActiveExecutionEvent::JavascriptSyncRpcRequest(waiter_request),
+                });
+            });
+        let Some(vm) = self.vms.get_mut(vm_id) else {
+            return Ok(None);
+        };
+        let Some(process) = vm.active_processes.get_mut(process_id) else {
+            return Ok(None);
+        };
+        if spawned.is_err() {
+            // Degrade to pre-deferral behavior: reply not-ready now and let the
+            // guest re-issue its bounded wait.
+            process.deferred_kernel_wait_rpc = None;
+            return Ok(Some(probe.into()));
+        }
+        process.deferred_kernel_wait_rpc = Some((request.clone(), deadline));
+        Ok(None)
+    }
+
     pub(crate) fn handle_javascript_sync_rpc_request(
         &mut self,
         vm_id: &str,
@@ -2067,6 +2214,17 @@ where
                     })
                     .map(Value::String)
                     .map(Into::into)
+                }
+                "__kernel_stdin_read" | "__kernel_poll"
+                    if self.kernel_wait_rpc_is_deferrable(vm_id, process_id, &request) =>
+                {
+                    match self.service_deferrable_kernel_wait_rpc(vm_id, process_id, &request) {
+                        Ok(Some(response)) => Ok(response),
+                        // Parked: an off-loop waiter re-enqueues this request as a
+                        // process event when kernel poll state changes.
+                        Ok(None) => return Ok(()),
+                        Err(error) => Err(error),
+                    }
                 }
                 _ => {
                     let Some(vm) = self.vms.get_mut(vm_id) else {

--- a/crates/sidecar/src/state.rs
+++ b/crates/sidecar/src/state.rs
@@ -477,6 +477,11 @@ pub(crate) struct ActiveProcess {
     pub(crate) next_sqlite_database_id: u64,
     pub(crate) sqlite_statements: BTreeMap<u64, ActiveSqliteStatement>,
     pub(crate) next_sqlite_statement_id: u64,
+    /// A parked `__kernel_stdin_read` / `__kernel_poll` sync RPC awaiting
+    /// kernel readiness (reply-by-token deferral so servicing never blocks the
+    /// dispatch loop). At most one per process: the guest thread is blocked in
+    /// this RPC, so it cannot issue another. `(request, absolute deadline)`.
+    pub(crate) deferred_kernel_wait_rpc: Option<(JavascriptSyncRpcRequest, Instant)>,
     /// Per-process module resolution cache, persisted across module sync-RPCs
     /// (`__resolve_module` / `__load_file` / `__module_format` /
     /// `__batch_resolve_modules`) for the lifetime of this process so cold-start

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/nathan/.herdr/workspaces/agent-os/secure-exec-provides/node_modules

--- a/packages/build-tools/node_modules
+++ b/packages/build-tools/node_modules
@@ -1,0 +1,1 @@
+/home/nathan/.herdr/workspaces/agent-os/secure-exec-provides/packages/build-tools/node_modules


### PR DESCRIPTION
- The wasm runner's `net_poll` (the patched libc's poll(2) backend) now reports readiness for every fd type — kernel-managed stdio/PTY fds via `__kernel_poll`, pipes, regular files, and POLLNVAL for closed fds — instead of host_net sockets only, and sleeps between iterations instead of hot-spinning. select()-based guests (vim) now see stdin readiness and no longer burn CPU while idle.
- The sidecar services `__kernel_stdin_read` / `__kernel_poll` without blocking the dispatch loop: a zero-timeout readiness probe answers immediately when possible, otherwise the RPC is parked (reply-by-token) and an off-loop waiter on the kernel's poll notifier re-enqueues it when poll state changes. Child processes park on the child-event pump with per-iteration rechecks.
- Runner input waits switched from 10ms polling slices to long event-driven waits (`host_tty.read`, `readKernelStdinChunk`, `poll_oneoff`, `net_poll`), so idle full-screen guests accrue ~zero active CPU.
- The wasm "fuel" wall-clock timeout is now opt-in (explicit `max_fuel` only). Runaway modules stay bounded by the default 30s active-CPU V8 watchdog, while idle interactive guests are no longer killed on wall time.
- The kernel exposes a cloneable `PollWaitHandle` for waiting on poll-state changes off the kernel owner's thread.
- Kill/teardown flushes a parked kernel-wait RPC (EINTR) first, since isolate termination cannot interrupt the native bridge wait — prevents teardown deadlocking against a blocked guest thread.