### PR TITLE
fix(sidecar): release kernel socket slots when guest sockets close

### DIFF
--- a/crates/execution/src/node_import_cache.rs
+++ b/crates/execution/src/node_import_cache.rs
@@ -17,7 +17,7 @@ const NODE_IMPORT_CACHE_MATERIALIZE_TIMEOUT_MS_ENV: &str =
     "AGENTOS_NODE_IMPORT_CACHE_MATERIALIZE_TIMEOUT_MS";
 const NODE_IMPORT_CACHE_SCHEMA_VERSION: &str = "1";
 const NODE_IMPORT_CACHE_LOADER_VERSION: &str = "8";
-const NODE_IMPORT_CACHE_ASSET_VERSION: &str = "81";
+const NODE_IMPORT_CACHE_ASSET_VERSION: &str = "82";
 const NODE_IMPORT_CACHE_DIR_PREFIX: &str = "agentos-node-import-cache";
 const DEFAULT_NODE_IMPORT_CACHE_MATERIALIZE_TIMEOUT: Duration = Duration::from_secs(30);
 const PYODIDE_DIST_DIR: &str = "pyodide-dist";
@@ -4758,10 +4758,20 @@ function createRpcBackedNetModule(netModule, fromGuestDir = '/') {
   const callDestroy = (socketId) => bridge().call('net.destroy', [socketId]);
   const callServerClose = (serverId) => bridge().call('net.server_close', [serverId]);
 
+  const releaseSocketBridge = (socket) => {
+    if (socket._agentOSBridgeReleased || socket._agentOSSocketId == null) {
+      return Promise.resolve();
+    }
+    const socketId = socket._agentOSSocketId;
+    socket._agentOSBridgeReleased = true;
+    return callDestroy(socketId).catch(() => {});
+  };
+
   const finalizeSocketClose = (socket, hadError = false) => {
     if (socket._agentOSClosed) {
       return;
     }
+    void releaseSocketBridge(socket);
     socket._agentOSClosed = true;
     socket._agentOSCloseHadError = hadError === true;
     socket._agentOSSocketId = null;
@@ -4773,6 +4783,16 @@ function createRpcBackedNetModule(netModule, fromGuestDir = '/') {
       socket.push(null);
     }
     queueMicrotask(() => socket.emit('close', hadError));
+  };
+  const finalizeSocketCloseAfterReadableEnd = (socket, hadError = false) => {
+    if (socket._agentOSClosed) {
+      return;
+    }
+    if (socket.readableEnded) {
+      finalizeSocketClose(socket, hadError);
+      return;
+    }
+    socket.once('end', () => finalizeSocketClose(socket, hadError));
   };
 
   const scheduleSocketPoll = (socket, delayMs) => {
@@ -4808,6 +4828,8 @@ function createRpcBackedNetModule(netModule, fromGuestDir = '/') {
       }
 
       if (event.type === 'end') {
+        socket._agentOSRemoteEnded = true;
+        finalizeSocketCloseAfterReadableEnd(socket, false);
         socket.push(null);
         if (!socket._agentOSAllowHalfOpen && !socket.writableEnded) {
           socket.end();
@@ -4868,6 +4890,8 @@ function createRpcBackedNetModule(netModule, fromGuestDir = '/') {
     socket.connecting = false;
     socket.pending = false;
     socket._agentOSClosed = false;
+    socket._agentOSRemoteEnded = false;
+    socket._agentOSBridgeReleased = false;
     if (emitConnect) {
       queueMicrotask(() => {
         if (socket._agentOSClosed) {
@@ -4887,6 +4911,8 @@ function createRpcBackedNetModule(netModule, fromGuestDir = '/') {
       this._agentOSClosed = false;
       this._agentOSCloseHadError = false;
       this._agentOSExplicitDestroy = false;
+      this._agentOSRemoteEnded = false;
+      this._agentOSBridgeReleased = false;
       this._agentOSRefed = true;
       this._agentOSSocketId = null;
       this._pollTimer = null;
@@ -4941,7 +4967,12 @@ function createRpcBackedNetModule(netModule, fromGuestDir = '/') {
         return;
       }
       callShutdown(this._agentOSSocketId).then(
-        () => callback(),
+        () => {
+          if (this._agentOSRemoteEnded) {
+            finalizeSocketCloseAfterReadableEnd(this, false);
+          }
+          callback();
+        },
         (error) => callback(error),
       );
     }
@@ -4955,13 +4986,13 @@ function createRpcBackedNetModule(netModule, fromGuestDir = '/') {
       };
       if (
         socketId == null ||
-        this._agentOSClosed ||
-        (error == null && !this._agentOSExplicitDestroy)
+        this._agentOSClosed
       ) {
         finishDestroy();
         return;
       }
-      callDestroy(socketId).then(finishDestroy, () => finishDestroy());
+      this._agentOSSocketId = socketId;
+      releaseSocketBridge(this).then(finishDestroy, () => finishDestroy());
     }
 
     address() {

--- a/crates/sidecar/src/execution.rs
+++ b/crates/sidecar/src/execution.rs
@@ -1717,6 +1717,7 @@ impl ActiveTcpSocket {
                                 .socket_read_end_events
                                 .fetch_add(1, Ordering::Relaxed);
                         }
+                        self.saw_remote_end.store(true, Ordering::SeqCst);
                         Ok(Some(JavascriptTcpSocketEvent::End))
                     }
                     Err(error) if error.code() == "EAGAIN" => {
@@ -1741,6 +1742,7 @@ impl ActiveTcpSocket {
                 };
             }
             if revents.intersects(POLLHUP) {
+                self.saw_remote_end.store(true, Ordering::SeqCst);
                 return Ok(Some(JavascriptTcpSocketEvent::End));
             }
             if revents.intersects(POLLERR) {
@@ -2182,14 +2184,18 @@ impl ActiveTcpSocket {
             }
         }
         if let Some(socket_id) = self.kernel_socket_id {
-            return kernel
-                .socket_shutdown(
-                    EXECUTION_DRIVER_NAME,
-                    kernel_pid,
-                    socket_id,
-                    KernelSocketShutdown::Write,
-                )
-                .map_err(kernel_error);
+            self.saw_local_shutdown.store(true, Ordering::SeqCst);
+            match kernel.socket_shutdown(
+                EXECUTION_DRIVER_NAME,
+                kernel_pid,
+                socket_id,
+                KernelSocketShutdown::Write,
+            ) {
+                Ok(()) => {}
+                Err(error) if error.code() == "ENOENT" => {}
+                Err(error) => return Err(kernel_error(error)),
+            }
+            return Ok(());
         }
         let stream = self
             .stream
@@ -2241,14 +2247,9 @@ impl ActiveTcpSocket {
                 let _ = stream.send_close_notify();
                 let _ = stream.close();
             }
-            if self.kernel_socket_id.is_some() {
-                return Ok(());
-            }
         }
         if let Some(socket_id) = self.kernel_socket_id {
-            return kernel
-                .socket_close(EXECUTION_DRIVER_NAME, kernel_pid, socket_id)
-                .map_err(kernel_error);
+            return close_kernel_socket_idempotent(kernel, kernel_pid, socket_id);
         }
         let stream = self
             .stream
@@ -2258,6 +2259,45 @@ impl ActiveTcpSocket {
             .map_err(|_| SidecarError::InvalidState(String::from("TCP socket lock poisoned")))?;
         stream.shutdown(Shutdown::Both).map_err(sidecar_net_error)
     }
+}
+
+fn close_kernel_socket_idempotent(
+    kernel: &mut SidecarKernel,
+    kernel_pid: u32,
+    socket_id: SocketId,
+) -> Result<(), SidecarError> {
+    match kernel.socket_close(EXECUTION_DRIVER_NAME, kernel_pid, socket_id) {
+        Ok(()) => Ok(()),
+        Err(error) if error.code() == "ENOENT" => Ok(()),
+        Err(error) => Err(kernel_error(error)),
+    }
+}
+
+fn release_tcp_socket_handle(
+    process: &mut ActiveProcess,
+    socket_id: &str,
+    socket: ActiveTcpSocket,
+    kernel: &mut SidecarKernel,
+) {
+    if let Some(listener_id) = socket.listener_id.as_deref() {
+        if let Some(listener) = process.tcp_listeners.get_mut(listener_id) {
+            listener.release_connection(socket_id);
+        }
+    }
+    let _ = socket.close(kernel, process.kernel_pid);
+}
+
+fn release_unix_socket_handle(
+    process: &mut ActiveProcess,
+    socket_id: &str,
+    socket: ActiveUnixSocket,
+) {
+    if let Some(listener_id) = socket.listener_id.as_deref() {
+        if let Some(listener) = process.unix_listeners.get_mut(listener_id) {
+            listener.release_connection(socket_id);
+        }
+    }
+    let _ = socket.close();
 }
 
 impl ActiveTlsStream {
@@ -2786,9 +2826,7 @@ impl ActiveTcpListener {
 
     fn close(&self, kernel: &mut SidecarKernel, kernel_pid: u32) -> Result<(), SidecarError> {
         if let Some(socket_id) = self.kernel_socket_id {
-            kernel
-                .socket_close(EXECUTION_DRIVER_NAME, kernel_pid, socket_id)
-                .map_err(kernel_error)?;
+            close_kernel_socket_idempotent(kernel, kernel_pid, socket_id)?;
         }
         Ok(())
     }
@@ -3041,7 +3079,7 @@ impl ActiveUdpSocket {
 
     fn close(&mut self, kernel: &mut SidecarKernel, kernel_pid: u32) {
         if let Some(socket_id) = self.kernel_socket_id {
-            let _ = kernel.socket_close(EXECUTION_DRIVER_NAME, kernel_pid, socket_id);
+            let _ = close_kernel_socket_idempotent(kernel, kernel_pid, socket_id);
         }
         self.socket.take();
         self.guest_local_addr = None;
@@ -22659,17 +22697,9 @@ where
                 })),
                 Some(JavascriptTcpSocketEvent::Close { had_error }) => {
                     if let Some(socket) = process.tcp_sockets.remove(socket_id) {
-                        if let Some(listener_id) = socket.listener_id.as_deref() {
-                            if let Some(listener) = process.tcp_listeners.get_mut(listener_id) {
-                                listener.release_connection(socket_id);
-                            }
-                        }
+                        release_tcp_socket_handle(process, socket_id, socket, kernel);
                     } else if let Some(socket) = process.unix_sockets.remove(socket_id) {
-                        if let Some(listener_id) = socket.listener_id.as_deref() {
-                            if let Some(listener) = process.unix_listeners.get_mut(listener_id) {
-                                listener.release_connection(socket_id);
-                            }
-                        }
+                        release_unix_socket_handle(process, socket_id, socket);
                     }
                     Ok(json!({
                         "type": "close",
@@ -23129,12 +23159,7 @@ where
             let socket = process.tcp_sockets.remove(socket_id).ok_or_else(|| {
                 SidecarError::InvalidState(format!("unknown TCP socket {socket_id}"))
             })?;
-            if let Some(listener_id) = socket.listener_id.as_deref() {
-                if let Some(listener) = process.tcp_listeners.get_mut(listener_id) {
-                    listener.release_connection(socket_id);
-                }
-            }
-            let _ = socket.close(kernel, process.kernel_pid);
+            release_tcp_socket_handle(process, socket_id, socket, kernel);
             Ok(Value::Null)
         }
         "net.write" => {
@@ -23196,23 +23221,12 @@ where
         "net.destroy" => {
             let socket_id = javascript_sync_rpc_arg_str(&request.args, 0, "net.destroy socket id")?;
             if let Some(socket) = process.tcp_sockets.remove(socket_id) {
-                if let Some(listener_id) = socket.listener_id.as_deref() {
-                    if let Some(listener) = process.tcp_listeners.get_mut(listener_id) {
-                        listener.release_connection(socket_id);
-                    }
-                }
-                let _ = socket.close(kernel, process.kernel_pid);
+                release_tcp_socket_handle(process, socket_id, socket, kernel);
+                Ok(Value::Null)
+            } else if let Some(socket) = process.unix_sockets.remove(socket_id) {
+                release_unix_socket_handle(process, socket_id, socket);
                 Ok(Value::Null)
             } else {
-                let socket = process.unix_sockets.remove(socket_id).ok_or_else(|| {
-                    SidecarError::InvalidState(format!("unknown net socket {socket_id}"))
-                })?;
-                if let Some(listener_id) = socket.listener_id.as_deref() {
-                    if let Some(listener) = process.unix_listeners.get_mut(listener_id) {
-                        listener.release_connection(socket_id);
-                    }
-                }
-                let _ = socket.close();
                 Ok(Value::Null)
             }
         }

--- a/crates/sidecar/tests/service.rs
+++ b/crates/sidecar/tests/service.rs
@@ -13371,6 +13371,115 @@ console.log(JSON.stringify(summary));
             );
             assert!(stdout.contains("\"listenerPort\":"), "stdout: {stdout}");
         }
+        fn javascript_net_loopback_socket_churn_releases_kernel_slots() {
+            assert_node_available();
+
+            let mut sidecar = create_test_sidecar();
+            let (connection_id, session_id) =
+                authenticate_and_open_session(&mut sidecar).expect("authenticate and open session");
+            let vm_id = create_vm_with_metadata(
+                &mut sidecar,
+                &connection_id,
+                &session_id,
+                PermissionsPolicy::allow_all(),
+                BTreeMap::from([(String::from("resource.max_sockets"), String::from("8"))]),
+            )
+            .expect("create vm");
+            let cwd = temp_dir("secure-exec-sidecar-js-net-churn-cwd");
+            write_fixture(
+                &cwd.join("entry.mjs"),
+                r#"
+import net from "node:net";
+
+const iterations = 24;
+let accepted = 0;
+let acceptedClosed = 0;
+
+const server = net.createServer((socket) => {
+  accepted += 1;
+  socket.setEncoding("utf8");
+  let payload = "";
+  socket.on("data", (chunk) => {
+    payload += chunk;
+  });
+  socket.on("end", () => {
+    socket.end(payload);
+  });
+  socket.on("close", () => {
+    acceptedClosed += 1;
+  });
+});
+
+await new Promise((resolve, reject) => {
+  server.once("error", reject);
+  server.listen(0, "127.0.0.1", resolve);
+});
+
+const address = server.address();
+if (!address || typeof address === "string") {
+  throw new Error(`unexpected listener address: ${String(address)}`);
+}
+
+const waitForAcceptedClose = async (count) => {
+  const deadline = Date.now() + 5000;
+  while (acceptedClosed < count) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for accepted close ${count}, got ${acceptedClosed}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+};
+
+for (let index = 0; index < iterations; index += 1) {
+  const message = `x${index}`;
+  const response = await new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port: address.port });
+    let data = "";
+    socket.setEncoding("utf8");
+    socket.on("connect", () => {
+      socket.end(message);
+    });
+    socket.on("data", (chunk) => {
+      data += chunk;
+    });
+    socket.on("error", reject);
+    socket.on("close", (hadError) => {
+      if (hadError) {
+        reject(new Error(`client close reported error at ${index}`));
+        return;
+      }
+      resolve(data);
+    });
+  });
+  if (response !== message) {
+    throw new Error(`unexpected response at ${index}: ${response}`);
+  }
+  await waitForAcceptedClose(index + 1);
+}
+
+await new Promise((resolve, reject) => {
+  server.close((error) => {
+    if (error) {
+      reject(error);
+    } else {
+      resolve();
+    }
+  });
+});
+
+console.log(JSON.stringify({ iterations, accepted, acceptedClosed }));
+"#,
+            );
+
+            let (stdout, stderr, exit_code) =
+                run_javascript_entry(&mut sidecar, &vm_id, &cwd, "proc-js-net-churn");
+
+            assert_eq!(exit_code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+            let parsed: Value = serde_json::from_str(stdout.trim()).expect("parse churn JSON");
+            assert_eq!(parsed["iterations"], Value::from(24));
+            assert_eq!(parsed["accepted"], Value::from(24));
+            assert_eq!(parsed["acceptedClosed"], Value::from(24));
+        }
         fn javascript_dgram_rpc_sends_and_receives_vm_loopback_packets() {
             assert_node_available();
 
@@ -19168,6 +19277,11 @@ console.log(JSON.stringify({
         #[test]
         fn aad_javascript_network_dns_javascript_net_poll_suite() {
             run_service_suite();
+        }
+
+        #[test]
+        fn javascript_net_loopback_socket_churn_releases_kernel_slots_regression() {
+            javascript_net_loopback_socket_churn_releases_kernel_slots();
         }
 
         #[test]

--- a/packages/build-tools/bridge-src/builtins/fetch.ts
+++ b/packages/build-tools/bridge-src/builtins/fetch.ts
@@ -1,4 +1,4 @@
-import { getSecureExecUndiciDispatcher, undiciFetch } from "./undici.js";
+import { createSecureExecUndiciDispatcher, undiciFetch } from "./undici.js";
 import { exposeCustomGlobal } from "../global-exposure.js";
 import { undiciHeadersModule, undiciRequestModule, undiciResponseModule } from "../prelude.js";
 import { isFlatHeaderList, onUpgradeSocketEnd } from "./http.js";
@@ -106,7 +106,7 @@ async function fetch(input, options = {}) {
   if (handleId) {
     _registerHandle?.(handleId, `fetch ${requestLabel}`);
   }
-  const fetchDispatcher = normalizedOptions.dispatcher == null && typeof getSecureExecUndiciDispatcher === "function" ? getSecureExecUndiciDispatcher() : null;
+  const fetchDispatcher = normalizedOptions.dispatcher == null && typeof createSecureExecUndiciDispatcher === "function" ? createSecureExecUndiciDispatcher() : null;
   try {
     return await undiciFetch(
       resolvedInput,

--- a/packages/build-tools/bridge-src/builtins/net.ts
+++ b/packages/build-tools/bridge-src/builtins/net.ts
@@ -1497,6 +1497,7 @@ var NetSocket = class _NetSocket {
   _remoteEnded = false;
   _writableEnded = false;
   _closeEmitted = false;
+  _bridgeReleased = false;
   _connected = false;
   connecting = false;
   destroyed = false;
@@ -1711,11 +1712,7 @@ var NetSocket = class _NetSocket {
       this._emitSocketClose(Boolean(error));
       return this;
     }
-    if (typeof _netSocketDestroyRaw !== "undefined" && this._socketId) {
-      _netSocketDestroyRaw.applySync(void 0, [this._socketId]);
-      countNetBridgeMetric("peerWakeOnDestroy");
-      wakePeerBridgeReads(this);
-    }
+    this._releaseBridgeSocket();
     if (error) {
       this._emitNet("error", error);
     }
@@ -1832,7 +1829,31 @@ var NetSocket = class _NetSocket {
     if (this._socketId) {
       unregisterNetSocket(this._socketId);
     }
+    if (this.readableLength > 0) {
+      this._deferBridgeReleaseUntilReadDrained = true;
+    } else {
+      this._releaseBridgeSocket();
+    }
     this._emitNet("close", hadError);
+  }
+  _releaseDeferredBridgeSocket() {
+    if (!this._deferBridgeReleaseUntilReadDrained || this.readableLength > 0) {
+      return;
+    }
+    this._deferBridgeReleaseUntilReadDrained = false;
+    this._releaseBridgeSocket();
+  }
+  _releaseBridgeSocket() {
+    if (this._bridgeReleased || !this._socketId || typeof _netSocketDestroyRaw === "undefined") {
+      return;
+    }
+    this._bridgeReleased = true;
+    try {
+      _netSocketDestroyRaw.applySync(void 0, [this._socketId]);
+    } catch {
+    }
+    countNetBridgeMetric("peerWakeOnDestroy");
+    wakePeerBridgeReads(this);
   }
   _handleRemoteReadableEnd() {
     if (this.destroyed || this._remoteEnded) {
@@ -1966,25 +1987,30 @@ var NetSocket = class _NetSocket {
     if (this._readQueue.length === 0) {
       return null;
     }
+    let chunk;
     if (size == null || size <= 0) {
-      const chunk = this._readQueue.shift() ?? null;
+      chunk = this._readQueue.shift() ?? null;
       if (chunk) {
         this.readableLength = Math.max(0, this.readableLength - chunk.length);
       }
-      return chunk;
+    } else {
+      const head = this._readQueue[0];
+      if (!head) {
+        return null;
+      }
+      if (head.length <= size) {
+        this._readQueue.shift();
+        this.readableLength = Math.max(0, this.readableLength - head.length);
+        chunk = head;
+      } else {
+        chunk = head.subarray(0, size);
+        this._readQueue[0] = head.subarray(size);
+        this.readableLength = Math.max(0, this.readableLength - chunk.length);
+      }
     }
-    const head = this._readQueue[0];
-    if (!head) {
-      return null;
+    if (this.readableLength === 0) {
+      this._releaseDeferredBridgeSocket();
     }
-    if (head.length <= size) {
-      this._readQueue.shift();
-      this.readableLength = Math.max(0, this.readableLength - head.length);
-      return head;
-    }
-    const chunk = head.subarray(0, size);
-    this._readQueue[0] = head.subarray(size);
-    this.readableLength = Math.max(0, this.readableLength - chunk.length);
     return chunk;
   }
   unshift(chunk) {


### PR DESCRIPTION
Closed guest loopback sockets never released their kernel socket-table slots
until process exit (measured: vm_sockets highWater 81 for a workload whose
true concurrency is ~9), so connection-churning guests hit EAGAIN 'maximum
socket count reached' at ~250 cumulative sockets.

- Bridge: natural FIN close finalization now releases the sidecar/kernel
  handle (idempotent, once), deferred until JS readable buffers drain so
  buffered data is never dropped.
- Sidecar: net.poll close handling closes the underlying TCP/Unix handle when
  removing map entries; explicit close paths funnel through an idempotent
  kernel close (ENOENT tolerated); the TLS-mode close path no longer skips
  kernel close for kernel-backed sockets.
- Guest fetch() now uses a bounded per-call undici dispatcher instead of the
  process singleton whose pooled clients went stale against released sockets
  and hung (also fixes a pre-existing hang: repeated fetch over a kept-alive
  loopback connection). Revisit pooling when host->guest socket event push
  (#178) lands.
- Regression test: guest churns 3x max_sockets connections with closes.

Full net family at 30 iterations passes (previously EAGAIN at tcp_concurrent_4):
fetch 2.59ms, tcp_echo 3.57ms, tcp_concurrent_4 4.91ms guest p50; leak probe
highWater 81 -> 17 with depth returning to 0.