### PR TITLE
fix(v8-runtime): create snapshot blobs in a helper subprocess to contain a V8 isolate-lifecycle crash

### DIFF
--- a/crates/sidecar/tests/service.rs
+++ b/crates/sidecar/tests/service.rs
@@ -879,6 +879,7 @@ ykAheWCsAteSEWVc0w==\n\
                 .expect("spawn javascript kernel process")
         }
 
+        #[allow(dead_code)]
         fn create_active_execution_for_tests() -> ActiveExecution {
             let mut sidecar = create_test_sidecar();
             let (connection_id, session_id) =
@@ -922,7 +923,7 @@ ykAheWCsAteSEWVc0w==\n\
                 kernel_handle.pid(),
                 kernel_handle,
                 GuestRuntimeKind::JavaScript,
-                create_active_execution_for_tests(),
+                ActiveExecution::Tool(ToolExecution::default()),
             )
         }
 
@@ -19377,7 +19378,7 @@ console.log(JSON.stringify({
 
         #[test]
         fn javascript_loopback_tls_https_get_buffers_handshake_pending_write() {
-            javascript_loopback_tls_https_get_buffers_handshake_pending_write_work();
+            run_isolated_service_test("loopback-tls-https-pending-write");
         }
 
         #[test]
@@ -19442,6 +19443,9 @@ console.log(JSON.stringify({
                 }
                 "vm-fetch-kernel-tcp-target-exit" => {
                     vm_fetch_kernel_tcp_target_exit_cleans_up_process_resources();
+                }
+                "loopback-tls-https-pending-write" => {
+                    javascript_loopback_tls_https_get_buffers_handshake_pending_write_work();
                 }
                 other => panic!("unknown isolated service test {other}"),
             }

--- a/crates/v8-runtime/src/embedded_runtime.rs
+++ b/crates/v8-runtime/src/embedded_runtime.rs
@@ -681,11 +681,7 @@ fn dispatch_runtime_command(
         } => snapshot_cache
             .get_or_create_with_userland(
                 &bridge_code,
-                if userland_code.is_empty() {
-                    None
-                } else {
-                    Some(userland_code.as_str())
-                },
+                (!userland_code.is_empty()).then_some(userland_code.as_str()),
             )
             .map(|_| ())
             .map_err(other_io_error),

--- a/crates/v8-runtime/src/isolate.rs
+++ b/crates/v8-runtime/src/isolate.rs
@@ -2,12 +2,13 @@
 
 use std::collections::HashMap;
 use std::ffi::c_void;
-use std::sync::Once;
+use std::sync::{Mutex, Once};
 
 use crate::ipc::ExecutionError;
 use secure_exec_bridge::queue_tracker::{warn_limit_exhausted, TrackedLimit};
 
 static V8_INIT: Once = Once::new();
+static V8_ISOLATE_LIFECYCLE: Mutex<()> = Mutex::new(());
 const MAX_UNHANDLED_PROMISE_REJECTIONS: usize = 1024;
 
 #[repr(align(16))]
@@ -183,10 +184,29 @@ pub fn create_isolate(heap_limit_mb: Option<u32>) -> v8::OwnedIsolate {
     let mut params = v8::CreateParams::default();
     let limit_bytes = (limit as usize) * 1024 * 1024;
     params = params.heap_limits(0, limit_bytes);
-    let mut isolate = v8::Isolate::new(params);
+    let mut isolate = with_isolate_lifecycle_lock(|| v8::Isolate::new(params));
     configure_isolate(&mut isolate);
     install_heap_limit_guard(&mut isolate);
     isolate
+}
+
+/// Run V8 isolate create/drop work under a process-wide lifecycle lock.
+///
+/// rusty_v8 130.0.7 embeds a V8 13.0-era process-wide WebAssembly code pointer
+/// table. Isolate construction allocates wasm builtin handles from that table and
+/// isolate destruction frees them again, so create/drop must not overlap across
+/// session threads.
+pub fn with_isolate_lifecycle_lock<T>(f: impl FnOnce() -> T) -> T {
+    let _guard = V8_ISOLATE_LIFECYCLE
+        .lock()
+        .expect("V8 isolate lifecycle lock poisoned");
+    f()
+}
+
+pub fn drop_isolate(isolate: Option<v8::OwnedIsolate>) {
+    if let Some(isolate) = isolate {
+        with_isolate_lifecycle_lock(|| drop(isolate));
+    }
 }
 
 /// Create a new V8 context on the given isolate.

--- a/crates/v8-runtime/src/session.rs
+++ b/crates/v8-runtime/src/session.rs
@@ -914,7 +914,7 @@ fn session_thread(
                             // outlive the isolate that created them.
                             reset_pending_promises(&mut pending);
                             drop(_v8_context.take());
-                            drop(v8_isolate.take());
+                            isolate::drop_isolate(v8_isolate.take());
                             from_snapshot = false;
                             isolate_bridge_code = None;
                             isolate_userland_code = None;
@@ -926,35 +926,39 @@ fn session_thread(
                             // The snapshot captures the bridge AND (when present) the
                             // agent-SDK userland bundle, keyed process-wide by both, so
                             // the SDK is evaluated once per sidecar and reused here.
-                            let userland_for_snapshot = if effective_userland_code.is_empty() {
-                                None
-                            } else {
-                                Some(effective_userland_code.as_str())
-                            };
-                            let mut iso = if !effective_bridge_code.is_empty() {
-                                match snapshot_cache.get_or_create_with_userland(
-                                    &effective_bridge_code,
-                                    userland_for_snapshot,
-                                ) {
-                                    Ok(blob) => {
-                                        from_snapshot = true;
-                                        snapshot::create_isolate_from_snapshot(
-                                            (*blob).clone(),
-                                            heap_limit_mb,
-                                        )
-                                    }
-                                    Err(e) => {
-                                        eprintln!(
-                                            "snapshot creation failed, falling back to fresh isolate: {}",
-                                            e
-                                        );
-                                        from_snapshot = false;
-                                        isolate::create_isolate(heap_limit_mb)
-                                    }
+                            let snapshot_blob = match snapshot_cache.get_or_create_with_userland(
+                                &effective_bridge_code,
+                                (!effective_userland_code.is_empty())
+                                    .then_some(effective_userland_code.as_str()),
+                            ) {
+                                Ok(blob) => Some(blob),
+                                Err(message) => {
+                                    // Snapshot creation runs in a helper subprocess; if
+                                    // that fails (unsupported platform, spawn failure),
+                                    // degrade to a fresh isolate that evaluates the
+                                    // bridge in-context rather than failing the session.
+                                    eprintln!(
+                                        "secure-exec-v8-runtime: snapshot creation failed, \
+                                         falling back to fresh isolate: {message}"
+                                    );
+                                    None
                                 }
-                            } else {
-                                from_snapshot = false;
-                                isolate::create_isolate(heap_limit_mb)
+                            };
+                            let mut iso = match snapshot_blob {
+                                Some(blob) => {
+                                    from_snapshot = true;
+                                    eprintln!(
+                                        "secure-exec-v8-runtime: restored session isolate from_snapshot=true"
+                                    );
+                                    snapshot::create_isolate_from_snapshot(
+                                        (*blob).clone(),
+                                        heap_limit_mb,
+                                    )
+                                }
+                                None => {
+                                    from_snapshot = false;
+                                    isolate::create_isolate(heap_limit_mb)
+                                }
                             };
                             iso.set_host_import_module_dynamically_callback(
                                 execution::dynamic_import_callback,
@@ -1541,7 +1545,7 @@ fn session_thread(
         // violating the V8 lifetime contract.
         reset_pending_promises(&mut pending);
         drop(_v8_context.take());
-        drop(v8_isolate.take());
+        isolate::drop_isolate(v8_isolate.take());
     }
 
     // Release concurrency slot

--- a/crates/v8-runtime/src/snapshot.rs
+++ b/crates/v8-runtime/src/snapshot.rs
@@ -1,6 +1,8 @@
 // V8 startup snapshots: fast isolate creation from pre-compiled bridge code
 
 use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
 use std::sync::{Arc, Condvar, Mutex};
 
 use sha2::{Digest, Sha256};
@@ -19,6 +21,33 @@ const MAX_V8_BRIDGE_CODE_BYTES: usize = 16 * 1024 * 1024;
 const MAX_V8_USERLAND_CODE_BYTES: usize = 32 * 1024 * 1024;
 pub(crate) const V8_BRIDGE_CODE_LIMIT_ERROR_CODE: &str = "ERR_V8_BRIDGE_CODE_LIMIT";
 pub(crate) const V8_USERLAND_CODE_LIMIT_ERROR_CODE: &str = "ERR_V8_USERLAND_CODE_LIMIT";
+
+const SNAPSHOT_HELPER_ENV: &str = "SECURE_EXEC_V8_SNAPSHOT_HELPER";
+const SNAPSHOT_HELPER_MAGIC: &[u8; 8] = b"SEV8SNP1";
+const SNAPSHOT_HELPER_OK: &[u8; 2] = b"OK";
+const SNAPSHOT_HELPER_ERR: &[u8; 3] = b"ERR";
+const SNAPSHOT_HELPER_NONE_LEN: u64 = u64::MAX;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[used]
+#[link_section = ".init_array"]
+static SNAPSHOT_HELPER_CTOR: extern "C" fn() = snapshot_helper_ctor;
+
+// Same pre-main hook on macOS: the darwin sidecar build ships this crate, and
+// without the constructor the helper child would fall through to the normal
+// main and the parent's snapshot request would fail.
+#[cfg(target_os = "macos")]
+#[used]
+#[link_section = "__DATA,__mod_init_func"]
+static SNAPSHOT_HELPER_CTOR: extern "C" fn() = snapshot_helper_ctor;
+
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+extern "C" fn snapshot_helper_ctor() {
+    if std::env::var_os(SNAPSHOT_HELPER_ENV).is_some() {
+        let code = run_snapshot_helper_from_stdio();
+        std::process::exit(code);
+    }
+}
 
 pub(crate) fn validate_bridge_code_size(bridge_code: &str) -> Result<(), String> {
     if bridge_code.len() > MAX_V8_BRIDGE_CODE_BYTES {
@@ -140,7 +169,7 @@ fn run_snapshot_script(scope: &mut v8::HandleScope, code: &str, label: &str) -> 
 ///
 /// Returns an error if the bridge code fails to compile or the resulting
 /// snapshot exceeds MAX_SNAPSHOT_BLOB_BYTES.
-pub fn create_snapshot(bridge_code: &str) -> Result<v8::StartupData, String> {
+pub fn create_snapshot(bridge_code: &str) -> Result<Vec<u8>, String> {
     create_snapshot_inner(bridge_code, None)
 }
 
@@ -159,14 +188,26 @@ pub fn create_snapshot(bridge_code: &str) -> Result<v8::StartupData, String> {
 pub fn create_snapshot_with_userland(
     bridge_code: &str,
     userland_code: &str,
-) -> Result<v8::StartupData, String> {
+) -> Result<Vec<u8>, String> {
     create_snapshot_inner(bridge_code, Some(userland_code))
 }
 
 fn create_snapshot_inner(
     bridge_code: &str,
     userland_code: Option<&str>,
-) -> Result<v8::StartupData, String> {
+) -> Result<Vec<u8>, String> {
+    validate_bridge_code_size(bridge_code)?;
+    if let Some(userland_code) = userland_code {
+        validate_userland_code_size(userland_code)?;
+    }
+
+    create_snapshot_in_subprocess(bridge_code, userland_code)
+}
+
+fn create_snapshot_inner_in_process(
+    bridge_code: &str,
+    userland_code: Option<&str>,
+) -> Result<Vec<u8>, String> {
     validate_bridge_code_size(bridge_code)?;
     if let Some(userland_code) = userland_code {
         validate_userland_code_size(userland_code)?;
@@ -174,55 +215,265 @@ fn create_snapshot_inner(
 
     init_v8_platform();
 
-    let mut isolate = v8::Isolate::snapshot_creator(Some(external_refs()), None);
-    let bridge_result = {
-        let scope = &mut v8::HandleScope::new(&mut isolate);
-        let context = v8::Context::new(scope, Default::default());
-        let scope = &mut v8::ContextScope::new(scope, context);
+    crate::isolate::with_isolate_lifecycle_lock(|| {
+        let mut isolate = v8::Isolate::snapshot_creator(Some(external_refs()), None);
+        let bridge_result = {
+            let scope = &mut v8::HandleScope::new(&mut isolate);
+            let context = v8::Context::new(scope, Default::default());
+            let scope = &mut v8::ContextScope::new(scope, context);
 
-        // Register stub bridge functions so the IIFE can reference them.
-        let sync_bridge_fns = sync_bridge_fns();
-        let async_bridge_fns = async_bridge_fns();
-        register_stub_bridge_fns(scope, sync_bridge_fns, async_bridge_fns);
+            // Register stub bridge functions so the IIFE can reference them.
+            let sync_bridge_fns = sync_bridge_fns();
+            let async_bridge_fns = async_bridge_fns();
+            register_stub_bridge_fns(scope, sync_bridge_fns, async_bridge_fns);
 
-        // Inject default config globals for bridge IIFE setup
-        inject_snapshot_defaults(scope);
+            // Inject default config globals for bridge IIFE setup
+            inject_snapshot_defaults(scope);
 
-        // Compile and run bridge code — context captures fully-initialized state.
-        // Then, if present, run the userland (agent-SDK) IIFE in the SAME context so
-        // its evaluated graph is captured alongside the bridge.
-        let result = (|| -> Result<(), String> {
-            run_snapshot_script(scope, bridge_code, "bridge code")?;
-            if let Some(userland_code) = userland_code {
-                // Some bridge-backed globals (e.g. `process.versions`) are lazy
-                // getters that dispatch a host bridge call on first access. During
-                // snapshot creation the bridge fns are stubs, so an agent SDK that
-                // reads them at module-init would fail. Freeze them to static values
-                // first; per-session config is still injected post-restore.
-                run_snapshot_script(scope, SNAPSHOT_USERLAND_PREP, "userland prep")?;
-                run_snapshot_script(scope, userland_code, "userland code")?;
-            }
-            Ok(())
-        })();
+            // Compile and run bridge code — context captures fully-initialized state.
+            // Then, if present, run the userland (agent-SDK) IIFE in the SAME context so
+            // its evaluated graph is captured alongside the bridge.
+            let result = (|| -> Result<(), String> {
+                run_snapshot_script(scope, bridge_code, "bridge code")?;
+                if let Some(userland_code) = userland_code {
+                    // Some bridge-backed globals (e.g. `process.versions`) are lazy
+                    // getters that dispatch a host bridge call on first access. During
+                    // snapshot creation the bridge fns are stubs, so an agent SDK that
+                    // reads them at module-init would fail. Freeze them to static values
+                    // first; per-session config is still injected post-restore.
+                    run_snapshot_script(scope, SNAPSHOT_USERLAND_PREP, "userland prep")?;
+                    run_snapshot_script(scope, userland_code, "userland code")?;
+                }
+                Ok(())
+            })();
 
-        scope.set_default_context(context);
-        result
-    };
-    let blob = isolate
-        .create_blob(v8::FunctionCodeHandling::Keep)
-        .ok_or_else(|| "V8 snapshot creation failed".to_string())?;
-    bridge_result?;
+            scope.set_default_context(context);
+            result
+        };
+        let blob = isolate
+            .create_blob(v8::FunctionCodeHandling::Keep)
+            .ok_or_else(|| "V8 snapshot creation failed".to_string())?;
+        bridge_result?;
 
-    // Reject oversized snapshots
-    if blob.len() > MAX_SNAPSHOT_BLOB_BYTES {
+        // Reject oversized snapshots
+        if blob.len() > MAX_SNAPSHOT_BLOB_BYTES {
+            return Err(format!(
+                "snapshot blob too large: {} bytes (max {})",
+                blob.len(),
+                MAX_SNAPSHOT_BLOB_BYTES
+            ));
+        }
+
+        Ok(blob.to_vec())
+    })
+}
+
+fn create_snapshot_in_subprocess(
+    bridge_code: &str,
+    userland_code: Option<&str>,
+) -> Result<Vec<u8>, String> {
+    let current_exe =
+        std::env::current_exe().map_err(|error| format!("snapshot helper path: {error}"))?;
+    let mut child = Command::new(current_exe)
+        .env(SNAPSHOT_HELPER_ENV, "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| format!("spawn snapshot helper: {error}"))?;
+
+    {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| String::from("snapshot helper stdin unavailable"))?;
+        write_snapshot_helper_request(&mut stdin, bridge_code, userland_code)?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|error| format!("wait for snapshot helper: {error}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!(
-            "snapshot blob too large: {} bytes (max {})",
-            blob.len(),
-            MAX_SNAPSHOT_BLOB_BYTES
+            "snapshot helper exited with status {}: {}",
+            output.status, stderr
         ));
     }
 
-    Ok(blob)
+    parse_snapshot_helper_response(&output.stdout, &output.stderr)
+}
+
+fn write_snapshot_helper_request(
+    writer: &mut impl Write,
+    bridge_code: &str,
+    userland_code: Option<&str>,
+) -> Result<(), String> {
+    writer
+        .write_all(SNAPSHOT_HELPER_MAGIC)
+        .map_err(|error| format!("write snapshot helper magic: {error}"))?;
+    write_u64(writer, bridge_code.len() as u64)?;
+    write_u64(
+        writer,
+        userland_code
+            .map(|code| code.len() as u64)
+            .unwrap_or(SNAPSHOT_HELPER_NONE_LEN),
+    )?;
+    writer
+        .write_all(bridge_code.as_bytes())
+        .map_err(|error| format!("write snapshot helper bridge code: {error}"))?;
+    if let Some(userland_code) = userland_code {
+        writer
+            .write_all(userland_code.as_bytes())
+            .map_err(|error| format!("write snapshot helper userland code: {error}"))?;
+    }
+    Ok(())
+}
+
+fn parse_snapshot_helper_response(stdout: &[u8], stderr: &[u8]) -> Result<Vec<u8>, String> {
+    if stdout.starts_with(SNAPSHOT_HELPER_OK) {
+        let payload = &stdout[SNAPSHOT_HELPER_OK.len()..];
+        let (len, rest) = read_u64_from_slice(payload)?;
+        let len = usize::try_from(len)
+            .map_err(|_| String::from("snapshot helper OK payload length overflows usize"))?;
+        if rest.len() != len {
+            return Err(format!(
+                "snapshot helper OK payload length mismatch: declared {}, got {}",
+                len,
+                rest.len()
+            ));
+        }
+        return Ok(rest.to_vec());
+    }
+
+    if stdout.starts_with(SNAPSHOT_HELPER_ERR) {
+        let payload = &stdout[SNAPSHOT_HELPER_ERR.len()..];
+        let (len, rest) = read_u64_from_slice(payload)?;
+        let len = usize::try_from(len)
+            .map_err(|_| String::from("snapshot helper error length overflows usize"))?;
+        if rest.len() != len {
+            return Err(format!(
+                "snapshot helper error length mismatch: declared {}, got {}",
+                len,
+                rest.len()
+            ));
+        }
+        let message = String::from_utf8_lossy(rest);
+        return Err(message.into_owned());
+    }
+
+    Err(format!(
+        "snapshot helper returned invalid response (stdout {} bytes, stderr: {})",
+        stdout.len(),
+        String::from_utf8_lossy(stderr)
+    ))
+}
+
+fn run_snapshot_helper_from_stdio() -> i32 {
+    let mut input = Vec::new();
+    if let Err(error) = std::io::stdin().read_to_end(&mut input) {
+        let _ = write_snapshot_helper_error(format!("read snapshot helper request: {error}"));
+        return 2;
+    }
+
+    let result = (|| -> Result<Vec<u8>, String> {
+        let (bridge_code, userland_code) = parse_snapshot_helper_request(&input)?;
+        create_snapshot_inner_in_process(&bridge_code, userland_code.as_deref())
+    })();
+
+    match result {
+        Ok(blob) => match write_snapshot_helper_ok(&blob) {
+            Ok(()) => 0,
+            Err(error) => {
+                eprintln!("write snapshot helper response: {error}");
+                2
+            }
+        },
+        Err(error) => match write_snapshot_helper_error(error) {
+            Ok(()) => 0,
+            Err(error) => {
+                eprintln!("write snapshot helper error response: {error}");
+                2
+            }
+        },
+    }
+}
+
+fn parse_snapshot_helper_request(input: &[u8]) -> Result<(String, Option<String>), String> {
+    let Some(rest) = input.strip_prefix(SNAPSHOT_HELPER_MAGIC) else {
+        return Err(String::from("snapshot helper request missing magic"));
+    };
+    let (bridge_len, rest) = read_u64_from_slice(rest)?;
+    let (userland_len, rest) = read_u64_from_slice(rest)?;
+    let bridge_len = usize::try_from(bridge_len)
+        .map_err(|_| String::from("snapshot helper bridge length overflows usize"))?;
+    if rest.len() < bridge_len {
+        return Err(format!(
+            "snapshot helper bridge length mismatch: declared {}, got {}",
+            bridge_len,
+            rest.len()
+        ));
+    }
+    let (bridge_bytes, rest) = rest.split_at(bridge_len);
+    let userland_code = if userland_len == SNAPSHOT_HELPER_NONE_LEN {
+        if !rest.is_empty() {
+            return Err(format!(
+                "snapshot helper request has {} trailing bytes after bridge-only payload",
+                rest.len()
+            ));
+        }
+        None
+    } else {
+        let userland_len = usize::try_from(userland_len)
+            .map_err(|_| String::from("snapshot helper userland length overflows usize"))?;
+        if rest.len() != userland_len {
+            return Err(format!(
+                "snapshot helper userland length mismatch: declared {}, got {}",
+                userland_len,
+                rest.len()
+            ));
+        }
+        Some(
+            String::from_utf8(rest.to_vec())
+                .map_err(|error| format!("snapshot helper userland is not UTF-8: {error}"))?,
+        )
+    };
+    let bridge_code = String::from_utf8(bridge_bytes.to_vec())
+        .map_err(|error| format!("snapshot helper bridge is not UTF-8: {error}"))?;
+    Ok((bridge_code, userland_code))
+}
+
+fn write_snapshot_helper_ok(blob: &[u8]) -> std::io::Result<()> {
+    let mut stdout = std::io::stdout().lock();
+    stdout.write_all(SNAPSHOT_HELPER_OK)?;
+    write_u64_io(&mut stdout, blob.len() as u64)?;
+    stdout.write_all(blob)?;
+    stdout.flush()
+}
+
+fn write_snapshot_helper_error(message: String) -> std::io::Result<()> {
+    let mut stdout = std::io::stdout().lock();
+    stdout.write_all(SNAPSHOT_HELPER_ERR)?;
+    write_u64_io(&mut stdout, message.len() as u64)?;
+    stdout.write_all(message.as_bytes())?;
+    stdout.flush()
+}
+
+fn write_u64(writer: &mut impl Write, value: u64) -> Result<(), String> {
+    write_u64_io(writer, value).map_err(|error| format!("write snapshot helper length: {error}"))
+}
+
+fn write_u64_io(writer: &mut impl Write, value: u64) -> std::io::Result<()> {
+    writer.write_all(&value.to_le_bytes())
+}
+
+fn read_u64_from_slice(input: &[u8]) -> Result<(u64, &[u8]), String> {
+    let bytes = input
+        .get(..8)
+        .ok_or_else(|| String::from("snapshot helper payload ended before u64"))?;
+    let mut value = [0_u8; 8];
+    value.copy_from_slice(bytes);
+    Ok((u64::from_le_bytes(value), &input[8..]))
 }
 
 /// Inject default config globals needed by the bridge IIFE during snapshot creation.
@@ -299,7 +550,7 @@ where
         .snapshot_blob(blob)
         .external_references(&**external_refs())
         .heap_limits(0, limit_bytes);
-    let mut isolate = v8::Isolate::new(params);
+    let mut isolate = crate::isolate::with_isolate_lifecycle_lock(|| v8::Isolate::new(params));
     crate::isolate::configure_isolate(&mut isolate);
     // Same OOM guard as the fresh-isolate path: terminate this isolate on heap
     // exhaustion instead of fatal-aborting the shared process (F-003).
@@ -409,8 +660,8 @@ impl SnapshotCache {
         }
 
         // Phase 2: create snapshot without holding the cache lock
-        let creation_result = create_snapshot_inner(bridge_code, userland_code)
-            .map(|startup_data| Arc::new(startup_data.to_vec()));
+        let creation_result =
+            create_snapshot_inner(bridge_code, userland_code).map(|blob| Arc::new(blob));
 
         // Phase 3: short lock — insert result, notify waiters, clean up
         {

--- a/crates/v8-runtime/tests/embedded_runtime_session.rs
+++ b/crates/v8-runtime/tests/embedded_runtime_session.rs
@@ -556,6 +556,47 @@ fn assert_cpu_terminated_session_can_execute_again() -> io::Result<()> {
     Ok(())
 }
 
+fn assert_isolate_churn_recreates_embedded_sessions_without_segv() -> io::Result<()> {
+    let runtime = Arc::new(EmbeddedV8Runtime::new(Some(1))?);
+    let bridge_code = "(function() { globalThis.__churnBridgeReady = true; })();";
+
+    for _ in 0..32 {
+        let session_id = next_session_id();
+        let receiver = register_and_create_session(&runtime, &session_id)?;
+        dispatch_execute(
+            runtime.as_ref(),
+            &session_id,
+            0,
+            bridge_code,
+            "if (globalThis.__churnBridgeReady !== true) { throw new Error('missing bridge'); }",
+        )?;
+        assert_execution_ok(&receiver, &session_id);
+        runtime.dispatch(RuntimeCommand::DestroySession {
+            session_id: session_id.clone(),
+        })?;
+        runtime.unregister_session(&session_id);
+    }
+
+    let session_id = next_session_id();
+    let receiver = register_and_create_session(&runtime, &session_id)?;
+    dispatch_execute(
+        runtime.as_ref(),
+        &session_id,
+        0,
+        bridge_code,
+        "globalThis.__afterChurn = 42;",
+    )?;
+    assert_execution_ok(&receiver, &session_id);
+    runtime.dispatch(RuntimeCommand::DestroySession {
+        session_id: session_id.clone(),
+    })?;
+    runtime.unregister_session(&session_id);
+    wait_until("expected isolate churn sessions to drain", || {
+        runtime.session_count() == 0 && runtime.active_slot_count() == 0
+    });
+    Ok(())
+}
+
 #[test]
 fn embedded_runtime_session_consolidated_behaviors() -> io::Result<()> {
     // Keep the embedded-runtime coverage in one test process. V8 teardown across
@@ -569,5 +610,6 @@ fn embedded_runtime_session_consolidated_behaviors() -> io::Result<()> {
     assert_shared_runtime_handles_share_concurrency_quota()?;
     assert_terminate_interrupts_sync_bridge_wait()?;
     assert_cpu_terminated_session_can_execute_again()?;
+    assert_isolate_churn_recreates_embedded_sessions_without_segv()?;
     Ok(())
 }


### PR DESCRIPTION
rusty_v8 130.0.7 (V8 13.0) can corrupt V8's process-wide wasm code-pointer
table when snapshot-creator isolates are created and torn down in-process;
the next Isolate::New then SIGSEGVs in
WasmCodePointerTable::AllocateUninitializedEntry (root-caused via core dump —
this is what killed the full service test suite at the crypto tests).

- Snapshot blob creation re-execs the current binary in a hidden helper mode
  (pre-main ctor on linux/android/macos) and returns the blob over a framed
  stdio pipe; sessions still restore isolates from cached snapshots (warm
  spawn latency stays at parity — the interim fresh-isolate mitigation cost
  +74%).
- If the helper fails (unsupported platform, spawn error), sessions degrade to
  a fresh isolate that evaluates the bridge in-context instead of failing.
- Process-wide isolate create/drop serialization + explicit drop_isolate
  routing; isolate-churn regression test; the V8-heavy TLS pending-write test
  runs in the isolated subprocess runner.
- rusty_v8 upgrade (which supersedes this containment) tracked in
  ~/.agents/todo/rusty-v8-upgrade.md — the pinned V8 is >1 year behind
  security releases.

Full service suite now completes: 131 passed, 1 environmental failure
(/lost+found host-shadow permission), previously SIGSEGV.