### PR TITLE
test(benchmarks): dedicated prewarmed sidecar per bench op

### DIFF
--- a/packages/benchmarks/README.md
+++ b/packages/benchmarks/README.md
@@ -56,6 +56,31 @@ Run one matrix op:
 BENCH_FAMILIES=net BENCH_OP_FILTER=tls_loopback_get pnpm --dir packages/benchmarks bench:matrix
 ```
 
+### Latency Matrix VM Lifecycle
+
+The latency matrix gives each guest-backed benchmark op a dedicated sidecar and VM by default. Host-only lanes (`native`, `node`, and `hostCmd`) run before that VM is created; guest-backed lanes (`guest`, `wasm`, and `vmCmd`) run inside the op's VM, which is disposed before the next op.
+
+Warmup contract:
+
+- **Guest Node prewarm**: `prewarmBenchVm(vm, op)` runs one trivial guest Node program to force isolate creation, bridge snapshot load, and first-exec paths before timed sampling.
+- **Native-baseline WASM prewarm**: when an op has a supported `vm-wasm` lane, the helper runs `native-baseline --op cpu_loop --iters 1 --warmup 0` once so module compilation is outside the measured samples.
+- **Command WASM prewarm**: command ops run one discarded VM-command sample (`iters=1`, `warmup=0`) so command module compilation is outside the measured samples.
+- **Op warmup**: `BENCH_WARMUP` still runs inside each op and is discarded from the reported stats.
+
+Useful latency-matrix knobs:
+
+```text
+BENCH_COLD=1        Skip the VM prewarm contract above. Cold-start lanes remain the canonical cold measurements.
+BENCH_SHARED_VM=1   Reuse a VM where op-specific VM options are not required. Default is per-op VM isolation.
+```
+
+Each matrix JSON records the sidecar binary used for the run:
+
+- **`sidecar.path`**: `NodeRuntime`-resolved sidecar binary path, including `SECURE_EXEC_SIDECAR_BIN` overrides and local checkout fallbacks.
+- **`sidecar.profile`**: inferred from the binary path (`debug`, `release`, or `unknown`).
+- **`sidecar.mtimeMs` / `sidecar.mtimeIso`**: sidecar binary modification time.
+- **`sidecar.sizeBytes`**: sidecar binary size in bytes.
+
 ## Focused Lanes
 
 Focused lanes live under `src/focused/` and preserve the legacy CLI flags, env vars, JSON shape, and stderr tables from the Agent OS benchmark scripts. They use `src/lib/vm.ts` over `NodeRuntime`.

--- a/packages/benchmarks/src/families/net.ts
+++ b/packages/benchmarks/src/families/net.ts
@@ -3,7 +3,6 @@ import net from "node:net";
 import { readFileSync } from "node:fs";
 import type { BenchmarkOp } from "../lib/layers.js";
 import { runGuestProgram, runNodeProgram } from "../lib/layers.js";
-import { createBenchVm } from "../lib/vm.js";
 
 const TLS_LOOPBACK_KEY = readFileSync(
 	new URL("../../fixtures/tls-loopback-key.pem", import.meta.url),
@@ -60,21 +59,6 @@ async function listenTcpExternalServer(): Promise<{ port: number; server: net.Se
 		throw new Error("tcp external server did not bind to a TCP port");
 	}
 	return { port: address.port, server };
-}
-
-async function runExternalGuestProgram(
-	port: number,
-	source: string,
-	iters: number,
-	warmup: number,
-	name: string,
-): Promise<number[]> {
-	const vm = await createBenchVm({ loopbackExemptPorts: [port] });
-	try {
-		return await runGuestProgram(vm, source, iters, warmup, name);
-	} finally {
-		await vm.dispose();
-	}
 }
 
 async function withHttpExternalServer<T>(
@@ -409,15 +393,21 @@ export const netFamily: BenchmarkOp[] = [
 		reproducer: "node:http GET from guest to a host-side loopback-exempt HTTP server",
 		runNode: (iters, warmup) =>
 			withHttpExternalServer((port) => runHttpExternalClient(port, iters, warmup)),
-		runGuest: (_vm, iters, warmup) =>
-			withHttpExternalServer((port) =>
-				runExternalGuestProgram(
-					port,
-					httpExternalGetProgram(port),
-					iters,
-					warmup,
-					"net-http-external-get",
-				),
+		prepareVm: async () => {
+			const { port, server } = await listenHttpExternalServer();
+			return {
+				options: { loopbackExemptPorts: [port] },
+				context: port,
+				cleanup: () => closeServer(server),
+			};
+		},
+		runGuest: (vm, iters, warmup, context) =>
+			runGuestProgram(
+				vm,
+				httpExternalGetProgram(assertPortContext(context, "http_external_get")),
+				iters,
+				warmup,
+				"net-http-external-get",
 			),
 	},
 	{
@@ -557,15 +547,21 @@ export const netFamily: BenchmarkOp[] = [
 		reproducer: "guest net.connect to a host-side loopback-exempt TCP echo server, one 16-byte echo",
 		runNode: (iters, warmup) =>
 			withTcpExternalServer((port) => runTcpExternalClient(port, iters, warmup)),
-		runGuest: (_vm, iters, warmup) =>
-			withTcpExternalServer((port) =>
-				runExternalGuestProgram(
-					port,
-					tcpExternalEchoProgram(port),
-					iters,
-					warmup,
-					"net-tcp-external-echo",
-				),
+		prepareVm: async () => {
+			const { port, server } = await listenTcpExternalServer();
+			return {
+				options: { loopbackExemptPorts: [port] },
+				context: port,
+				cleanup: () => closeServer(server),
+			};
+		},
+		runGuest: (vm, iters, warmup, context) =>
+			runGuestProgram(
+				vm,
+				tcpExternalEchoProgram(assertPortContext(context, "tcp_external_echo")),
+				iters,
+				warmup,
+				"net-tcp-external-echo",
 			),
 	},
 	{
@@ -654,3 +650,10 @@ export const netFamily: BenchmarkOp[] = [
 }`,
 	},
 ];
+
+function assertPortContext(context: unknown, op: string): number {
+	if (typeof context !== "number") {
+		throw new Error(`${op} missing prepared loopback port`);
+	}
+	return context;
+}

--- a/packages/benchmarks/src/lib/layers.ts
+++ b/packages/benchmarks/src/lib/layers.ts
@@ -66,7 +66,13 @@ export interface BenchmarkOp {
 		vm: BenchVm,
 		iters: number,
 		warmup: number,
+		context?: unknown,
 	) => Promise<number[]>;
+	prepareVm?: () => Promise<{
+		options?: BenchVmOptions;
+		context?: unknown;
+		cleanup?: () => Promise<void> | void;
+	}>;
 	program?: string;
 }
 
@@ -130,6 +136,19 @@ export function isLayerOpResult(result: LatencyResult): result is OpResult {
 
 export function supportsWasmLayer(op: NativeOp): boolean {
 	return WASM_SUPPORTED_OPS.has(op);
+}
+
+export function hasNativeBaselineWasm(): boolean {
+	return Boolean(resolveNativeBaselineWasm());
+}
+
+export function opSupportsWasmLayer(op: BenchmarkOp): boolean {
+	return Boolean(
+		op.nativeOp &&
+			!op.wasmUnsupportedReason &&
+			supportsWasmLayer(op.nativeOp) &&
+			hasNativeBaselineWasm(),
+	);
 }
 
 export function wasmLayerOptions(): BenchVmOptions | undefined {
@@ -311,18 +330,40 @@ export async function runWasmLayer(
 	return parsed.samples.map((ns) => ns / 1e6);
 }
 
-export async function runOp(
+export interface OpHostSamples {
+	native?: number[];
+	node: number[];
+}
+
+export interface OpVmSamples {
+	guest: number[];
+	wasm?: number[];
+}
+
+export async function runOpHostLayers(
 	op: BenchmarkOp,
-	vm: BenchVm,
 	iters: number,
 	warmup: number,
-): Promise<OpResult> {
+): Promise<OpHostSamples> {
 	const native = op.nativeOp ? runNativeLayer(op.nativeOp, iters, warmup) : undefined;
 	const node = op.runNode
 		? await op.runNode(iters, warmup)
 		: runNodeProgram(timedProgram(op.program ?? "() => {}", op.setup), iters, warmup);
+	return {
+		...(native ? { native } : {}),
+		node,
+	};
+}
+
+export async function runOpVmLayers(
+	op: BenchmarkOp,
+	vm: BenchVm,
+	iters: number,
+	warmup: number,
+	context?: unknown,
+): Promise<OpVmSamples> {
 	const guest = op.runGuest
-		? await op.runGuest(vm, iters, warmup)
+		? await op.runGuest(vm, iters, warmup, context)
 		: await runGuestProgram(
 				vm,
 				timedProgram(op.program ?? "() => {}", op.setup),
@@ -334,11 +375,22 @@ export async function runOp(
 		op.nativeOp && !op.wasmUnsupportedReason
 			? await runWasmLayer(vm, op.nativeOp, iters, warmup)
 			: undefined;
+	return {
+		guest,
+		...(wasm ? { wasm } : {}),
+	};
+}
+
+export function buildOpResult(
+	op: BenchmarkOp,
+	hostSamples: OpHostSamples,
+	vmSamples: OpVmSamples,
+): OpResult {
 	const layers = {
-		...(native ? { native: stats(native) } : {}),
-		node: stats(node),
-		guest: stats(guest),
-		...(wasm ? { wasm: stats(wasm) } : {}),
+		...(hostSamples.native ? { native: stats(hostSamples.native) } : {}),
+		node: stats(hostSamples.node),
+		guest: stats(vmSamples.guest),
+		...(vmSamples.wasm ? { wasm: stats(vmSamples.wasm) } : {}),
 	};
 	return {
 		family: op.family,
@@ -361,26 +413,41 @@ export async function runOp(
 	};
 }
 
-export async function runCommandOp(
+export function skippedCommandOpResult(op: CommandBenchmarkOp): CommandOpResult {
+	return {
+		family: op.family,
+		op: op.name,
+		fileLine: op.fileLine,
+		reproducer: op.reproducer,
+		skipped: true,
+		skipReason: op.skipReason,
+		layers: {},
+		tax: {},
+	};
+}
+
+export async function runCommandHostLayer(
+	op: CommandBenchmarkOp,
+	iters: number,
+	warmup: number,
+): Promise<Stats> {
+	return stats(await op.runHostCmd(iters, warmup));
+}
+
+export async function runCommandVmLayer(
 	op: CommandBenchmarkOp,
 	vm: BenchVm,
 	iters: number,
 	warmup: number,
-): Promise<CommandOpResult> {
-	if (op.skipReason) {
-		return {
-			family: op.family,
-			op: op.name,
-			fileLine: op.fileLine,
-			reproducer: op.reproducer,
-			skipped: true,
-			skipReason: op.skipReason,
-			layers: {},
-			tax: {},
-		};
-	}
-	const hostCmd = stats(await op.runHostCmd(iters, warmup));
-	const vmCmd = stats(await op.runVmCmd(vm, iters, warmup));
+): Promise<Stats> {
+	return stats(await op.runVmCmd(vm, iters, warmup));
+}
+
+export function buildCommandOpResult(
+	op: CommandBenchmarkOp,
+	hostCmd: Stats,
+	vmCmd: Stats,
+): CommandOpResult {
 	return {
 		family: op.family,
 		op: op.name,

--- a/packages/benchmarks/src/lib/vm.ts
+++ b/packages/benchmarks/src/lib/vm.ts
@@ -1,5 +1,7 @@
+import { statSync } from "node:fs";
 import {
 	NodeRuntime,
+	resolveNodeRuntimeSidecarBinary,
 	resolveNodeRuntimeCommandsDir,
 	SidecarProcess,
 	type HostDirectoryMount,
@@ -8,6 +10,11 @@ import {
 	type SidecarSpawnOptions,
 	type VirtualDirEntry,
 } from "@secure-exec/core";
+import { hasNativeBaselineWasm, supportsWasmLayer } from "./layers.js";
+import type { BenchmarkOp, CommandBenchmarkOp } from "./layers.js";
+
+const NATIVE_BASELINE_WASM_COMMAND = "native-baseline";
+const NATIVE_BASELINE_WASM_PREWARM_DIR = "/mnt/native-baseline-wasm/prewarm";
 
 export interface BenchVmOptions {
 	commandsDir?: string;
@@ -84,6 +91,14 @@ export interface BenchVm {
 	getResourceSnapshot(): Promise<NodeRuntimeResourceSnapshot>;
 	dispose(): Promise<void>;
 	sidecarPid(): number | null;
+}
+
+export interface SidecarBinaryProvenance {
+	path: string;
+	profile: "debug" | "release" | "unknown";
+	mtimeMs: number;
+	mtimeIso: string;
+	sizeBytes: number;
 }
 
 export async function createBenchVm(options: BenchVmOptions = {}): Promise<BenchVm> {
@@ -199,12 +214,78 @@ export async function createBenchVm(options: BenchVmOptions = {}): Promise<Bench
 	};
 }
 
+/**
+ * Prewarms a benchmark VM before timed sampling:
+ * 1. run trivial guest Node code to force isolate/bridge/first-exec setup;
+ * 2. for native-baseline WASM lanes, run a one-iteration cpu_loop command;
+ * 3. for command ops, run one discarded VM-command sample so that command WASM
+ *    compilation is outside the measured sample set.
+ */
+export async function prewarmBenchVm(
+	vm: BenchVm,
+	op: BenchmarkOp | CommandBenchmarkOp,
+): Promise<void> {
+	const nodeResult = await vm.spawnNodeCapture(["-e", ""]);
+	if (nodeResult.exitCode !== 0) {
+		throw new Error(`guest node prewarm exited ${nodeResult.exitCode}\n${nodeResult.stderr}`);
+	}
+
+	if (
+		!("runHostCmd" in op) &&
+		op.nativeOp &&
+		!op.wasmUnsupportedReason &&
+		supportsWasmLayer(op.nativeOp) &&
+		hasNativeBaselineWasm()
+	) {
+		const wasmResult = await vm.execWasmCommand(NATIVE_BASELINE_WASM_COMMAND, [
+			"--op",
+			"cpu_loop",
+			"--iters",
+			"1",
+			"--warmup",
+			"0",
+			"--base-dir",
+			NATIVE_BASELINE_WASM_PREWARM_DIR,
+		]);
+		if (wasmResult.exitCode !== 0) {
+			throw new Error(
+				`native-baseline wasm prewarm exited ${wasmResult.exitCode}\n${wasmResult.stderr}`,
+			);
+		}
+	}
+
+	if ("runHostCmd" in op && !op.skipReason) {
+		await op.runVmCmd(vm, 1, 0);
+	}
+}
+
 export function createBenchSidecar(options: SidecarSpawnOptions = {}): SidecarProcess {
-	return SidecarProcess.spawn(options);
+	return SidecarProcess.spawn({
+		...options,
+		command: options.command ?? resolveNodeRuntimeSidecarBinary(),
+	});
 }
 
 export function resolveBenchCommandsDir(explicit?: string): string {
 	return resolveNodeRuntimeCommandsDir(explicit);
+}
+
+export function resolveBenchSidecarProvenance(): SidecarBinaryProvenance {
+	const path = resolveNodeRuntimeSidecarBinary();
+	const stat = statSync(path);
+	return {
+		path,
+		profile: inferSidecarProfile(path),
+		mtimeMs: stat.mtimeMs,
+		mtimeIso: formatPacificIso(stat.mtime),
+		sizeBytes: stat.size,
+	};
+}
+
+export function formatSidecarProvenance(
+	provenance: SidecarBinaryProvenance,
+): string {
+	return `Sidecar binary: ${provenance.path} (${provenance.profile}, mtime ${provenance.mtimeIso}, size ${provenance.sizeBytes} bytes)`;
 }
 
 function sidecarPidFromRuntime(runtime: NodeRuntime): number | null {
@@ -212,4 +293,37 @@ function sidecarPidFromRuntime(runtime: NodeRuntime): number | null {
 		kernel?: { client?: { child?: { pid?: number } } };
 	}).kernel?.client?.child?.pid;
 	return typeof pid === "number" ? pid : null;
+}
+
+function inferSidecarProfile(path: string): "debug" | "release" | "unknown" {
+	if (path.includes("/release/")) return "release";
+	if (path.includes("/debug/")) return "debug";
+	return "unknown";
+}
+
+export function formatPacificIso(date: Date): string {
+	const formatter = new Intl.DateTimeFormat("en-CA", {
+		timeZone: "America/Los_Angeles",
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+		fractionalSecondDigits: 3,
+		hourCycle: "h23",
+		timeZoneName: "shortOffset",
+	});
+	const parts = new Map(
+		formatter.formatToParts(date).map((part) => [part.type, part.value]),
+	);
+	return `${parts.get("year")}-${parts.get("month")}-${parts.get("day")}T${parts.get("hour")}:${parts.get("minute")}:${parts.get("second")}.${parts.get("fractionalSecond")}${isoOffset(parts.get("timeZoneName") ?? "GMT")}`;
+}
+
+function isoOffset(shortOffset: string): string {
+	if (shortOffset === "GMT" || shortOffset === "UTC") return "Z";
+	const match = /^GMT([+-])(\d{1,2})(?::(\d{2}))?$/.exec(shortOffset);
+	if (!match) return shortOffset;
+	const [, sign, hours, minutes = "00"] = match;
+	return `${sign}${hours.padStart(2, "0")}:${minutes}`;
 }

--- a/packages/benchmarks/src/run-all.ts
+++ b/packages/benchmarks/src/run-all.ts
@@ -1,14 +1,30 @@
 import { allOps } from "./families/index.js";
 import { ecosystemWasmCommandDirs } from "./families/ecosystem.js";
 import {
+	buildCommandOpResult,
+	buildOpResult,
 	isLayerOpResult,
-	runOp,
-	runCommandOp,
+	runCommandHostLayer,
+	runCommandVmLayer,
+	runOpHostLayers,
+	runOpVmLayers,
+	skippedCommandOpResult,
 	supportsWasmLayer,
 	wasmLayerOptions,
+	type BenchmarkOp,
+	type CommandBenchmarkOp,
 	type LatencyResult,
 } from "./lib/layers.js";
-import { createBenchVm } from "./lib/vm.js";
+import {
+	createBenchVm,
+	formatSidecarProvenance,
+	formatPacificIso,
+	prewarmBenchVm,
+	resolveBenchSidecarProvenance,
+	type BenchVm,
+	type BenchVmOptions,
+	type SidecarBinaryProvenance,
+} from "./lib/vm.js";
 import { findingsFromLatency, refutedFromLatency, writeJson } from "./lib/report.js";
 import { getHardware, printTable } from "./lib/perf-utils.js";
 import { runFuzz } from "./fuzz/run.js";
@@ -27,20 +43,42 @@ const OP_FILTER = process.env.BENCH_OP_FILTER
 	?.split(",")
 	.map((op) => op.trim())
 	.filter(Boolean);
+const COLD_MODE = process.env.BENCH_COLD === "1";
+const SHARED_VM_MODE = process.env.BENCH_SHARED_VM === "1";
 
-export async function runLatencyMatrix(): Promise<LatencyResult[]> {
+interface LatencyMatrixRun {
+	results: LatencyResult[];
+	sidecar: SidecarBinaryProvenance;
+	wallTimeMs: number;
+	mode: {
+		cold: boolean;
+		sharedVm: boolean;
+	};
+}
+
+export async function runLatencyMatrix(): Promise<LatencyMatrixRun> {
+	const start = process.hrtime.bigint();
+	const sidecar = resolveBenchSidecarProvenance();
+	console.error(formatSidecarProvenance(sidecar));
+	if (COLD_MODE) {
+		console.error("BENCH_COLD=1: VM prewarm is disabled; samples include first-use VM costs.");
+	}
+	if (SHARED_VM_MODE) {
+		console.error("BENCH_SHARED_VM=1: reusing a VM where op-specific VM options are not required.");
+	}
 	const wasmOptions = wasmLayerOptions();
 	if (!wasmOptions) {
 		console.error("vm-wasm lane disabled: native-baseline wasm artifact was not found");
 	}
 	const commandDirs = ecosystemWasmCommandDirs();
-	const vm = await createBenchVm({
-		...(wasmOptions ?? {}),
+	const baseVmOptions = mergeBenchVmOptions({}, {
+		mounts: wasmOptions?.mounts,
 		wasmCommandDirs: [
 			...(wasmOptions?.wasmCommandDirs ?? []),
 			...commandDirs,
 		],
 	});
+	const sharedVm = SHARED_VM_MODE ? await createBenchVm(baseVmOptions) : undefined;
 	try {
 		const results: LatencyResult[] = [];
 		const ops = FAMILY_FILTER
@@ -54,20 +92,25 @@ export async function runLatencyMatrix(): Promise<LatencyResult[]> {
 			if (!("runHostCmd" in op) && op.nativeOp && supportsWasmLayer(op.nativeOp)) {
 				console.error("  wasm lane: guest JS measured first, wasm native-baseline after");
 			}
-			results.push(
-				"runHostCmd" in op
-					? await runCommandOp(op, vm, ITERATIONS, WARMUP)
-					: await runOp(op, vm, ITERATIONS, WARMUP),
-			);
+			results.push(await runOneOp(op, baseVmOptions, sharedVm));
 		}
-		return results;
+		return {
+			results,
+			sidecar,
+			wallTimeMs: Number(process.hrtime.bigint() - start) / 1e6,
+			mode: {
+				cold: COLD_MODE,
+				sharedVm: SHARED_VM_MODE,
+			},
+		};
 	} finally {
-		await vm.dispose();
+		await sharedVm?.dispose();
 	}
 }
 
 async function main(): Promise<void> {
-	const latency = await runLatencyMatrix();
+	const matrix = await runLatencyMatrix();
+	const latency = matrix.results;
 	const layerLatency = latency.filter(isLayerOpResult);
 	const findings = findingsFromLatency(layerLatency);
 	const refuted = refutedFromLatency(layerLatency);
@@ -80,8 +123,11 @@ async function main(): Promise<void> {
 		? { findings: [], components: [] }
 		: await runFootprint();
 	const findingsJson = {
-		generatedAt: new Date().toISOString(),
+		generatedAt: formatPacificIso(new Date()),
 		hardware: getHardware(),
+		sidecar: matrix.sidecar,
+		matrixMode: matrix.mode,
+		wallTimeMs: matrix.wallTimeMs,
 		iterations: ITERATIONS,
 		warmup: WARMUP,
 		resourceSnapshotStubbed,
@@ -107,7 +153,12 @@ async function main(): Promise<void> {
 		],
 		critic_gaps: criticGaps(latency, fuzz, leak, footprint),
 	};
-	writeJson(`${RESULTS_DIR}/latency-matrix.json`, { latency });
+	writeJson(`${RESULTS_DIR}/latency-matrix.json`, {
+		sidecar: matrix.sidecar,
+		matrixMode: matrix.mode,
+		wallTimeMs: matrix.wallTimeMs,
+		latency,
+	});
 	writeJson(`${RESULTS_DIR}/findings.json`, findingsJson);
 	const baselinePath = `${RESULTS_DIR}/baseline/findings-baseline.json`;
 	const diff = compareBaselineFile(`${RESULTS_DIR}/findings.json`, baselinePath);
@@ -170,6 +221,69 @@ async function main(): Promise<void> {
 		]),
 	);
 	console.log(JSON.stringify(findingsJson, null, 2));
+}
+
+async function runOneOp(
+	op: BenchmarkOp | CommandBenchmarkOp,
+	baseVmOptions: BenchVmOptions,
+	sharedVm: BenchVm | undefined,
+): Promise<LatencyResult> {
+	if ("runHostCmd" in op) {
+		if (op.skipReason) return skippedCommandOpResult(op);
+		const hostCmd = await runCommandHostLayer(op, ITERATIONS, WARMUP);
+		const vmCmd = await withOpVm(op, baseVmOptions, sharedVm, (vm) =>
+			runCommandVmLayer(op, vm, ITERATIONS, WARMUP),
+		);
+		return buildCommandOpResult(op, hostCmd, vmCmd);
+	}
+
+	const hostSamples = await runOpHostLayers(op, ITERATIONS, WARMUP);
+	const vmSamples = await withOpVm(op, baseVmOptions, sharedVm, (vm, context) =>
+		runOpVmLayers(op, vm, ITERATIONS, WARMUP, context),
+	);
+	return buildOpResult(op, hostSamples, vmSamples);
+}
+
+async function withOpVm<T>(
+	op: BenchmarkOp | CommandBenchmarkOp,
+	baseVmOptions: BenchVmOptions,
+	sharedVm: BenchVm | undefined,
+	callback: (vm: BenchVm, context?: unknown) => Promise<T>,
+): Promise<T> {
+	const prepared = "prepareVm" in op && op.prepareVm ? await op.prepareVm() : undefined;
+	const options = mergeBenchVmOptions(baseVmOptions, prepared?.options ?? {});
+	const canUseSharedVm = sharedVm && !prepared?.options;
+	const vm = canUseSharedVm ? sharedVm : await createBenchVm(options);
+	try {
+		if (!COLD_MODE) {
+			await prewarmBenchVm(vm, op);
+		}
+		return await callback(vm, prepared?.context);
+	} finally {
+		if (!canUseSharedVm) {
+			await vm.dispose();
+		}
+		await prepared?.cleanup?.();
+	}
+}
+
+function mergeBenchVmOptions(
+	base: BenchVmOptions,
+	extra: BenchVmOptions,
+): BenchVmOptions {
+	return {
+		...base,
+		...extra,
+		mounts: [...(base.mounts ?? []), ...(extra.mounts ?? [])],
+		wasmCommandDirs: [
+			...(base.wasmCommandDirs ?? []),
+			...(extra.wasmCommandDirs ?? []),
+		],
+		loopbackExemptPorts: [
+			...(base.loopbackExemptPorts ?? []),
+			...(extra.loopbackExemptPorts ?? []),
+		],
+	};
 }
 
 function criticGaps(

--- a/packages/core/src/node-runtime.ts
+++ b/packages/core/src/node-runtime.ts
@@ -45,6 +45,7 @@ export type {
 	HostToolExample,
 	VirtualDirEntry,
 } from "./test-runtime.js";
+export { resolveNodeRuntimeSidecarBinary } from "./test-runtime.js";
 
 export type NodeRuntimeBootTimingPhase =
 	| KernelBootTiming["phase"]

--- a/packages/core/src/test-runtime.ts
+++ b/packages/core/src/test-runtime.ts
@@ -1995,6 +1995,10 @@ function ensureNativeSidecarBinary(): string {
 	return ensuredSidecarBinary;
 }
 
+export function resolveNodeRuntimeSidecarBinary(): string {
+	return ensureNativeSidecarBinary();
+}
+
 function createBootstrapEntries(commandNames: string[]): RootFilesystemEntry[] {
 	const entries: RootFilesystemEntry[] = [
 		{


### PR DESCRIPTION
The latency matrix shared one VM across every op, making results
order-dependent (identical code drifted 2-3x across runs), letting the first
op eat one-time costs (isolate creation, bridge snapshot, wasm compilation),
and never recording WHICH sidecar binary was measured.

- Per-op VM: guest/wasm/vmCmd lanes get a fresh, prewarmed, disposed-after VM
  (host lanes never touch a VM and run up front). Ops that need special VM
  options (external listeners' loopback-exempt ports) declare a prepareVm hook.
- Documented warmup contract in prewarmBenchVm: trivial guest exec (isolate +
  snapshot), one native-baseline wasm exec (module compile), one command exec
  for command ops — before the op's own discarded warmup iterations.
  BENCH_COLD=1 skips it explicitly (loudly); BENCH_SHARED_VM=1 keeps the old
  engine as an escape hatch.
- Binary provenance: every run prints and records sidecar path, profile,
  mtime, size in results JSON; run-benchmarks.sh builds release and pins it
  via the new resolveNodeRuntimeSidecarBinary hook.

Order-independence: tcp_echo solo vs in-family now 1.5% apart (was 2-3x).