### PR TITLE
test(benchmarks): automatic peak-memory-vs-native column

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Every bound that protects a shared resource — memory/heap, CPU/wall-clock, fd/
 ## Benchmarks
 
 - **Purpose:** `packages/benchmarks` owns the differential matrix for the runtime surface. It compares four lanes: native (host Rust `crates/native-baseline`), node (host Node.js), vm-js (guest V8 Node emulation), and vm-wasm (`native-baseline` compiled to `wasm32-wasip1` and run in the VM). `guest/node` is JS-emulation tax, `wasm/native` is WASM-runtime tax, and `node/native` is Node's own cost.
+- **Memory columns:** matrix rows carry `mem`/`memTax` columns, with guest-backed lanes measured above the prewarmed-sidecar baseline.
 - **Ecosystem family:** `BENCH_FAMILIES=ecosystem` is command-pair only: `hostCmd` (host binary) vs `vmCmd` (VM WASM command), with `tax.command = vmCmd/hostCmd`.
 - **Layout:** matrix families and the lane engine live in `packages/benchmarks/src`; Rust op implementations live in `crates/native-baseline` and build for both host and wasm. Run one family with `BENCH_FAMILIES=fs pnpm --dir packages/benchmarks bench:matrix` or through `bash packages/benchmarks/run-benchmarks.sh`; results land in `packages/benchmarks/results/`.
 - **Verify work:** every op must verify its payload or side effect, so a fast-but-broken path fails instead of passing.

--- a/packages/benchmarks/README.md
+++ b/packages/benchmarks/README.md
@@ -60,6 +60,8 @@ BENCH_FAMILIES=net BENCH_OP_FILTER=tls_loopback_get pnpm --dir packages/benchmar
 
 The latency matrix gives each guest-backed benchmark op a dedicated sidecar and VM by default. Host-only lanes (`native`, `node`, and `hostCmd`) run before that VM is created; guest-backed lanes (`guest`, `wasm`, and `vmCmd`) run inside the op's VM, which is disposed before the next op.
 
+Each row also reports peak memory where the lane can be measured. Guest-backed lanes (`guest`, `wasm`, and `vmCmd`) use Linux `/proc/<sidecarPid>/clear_refs=5`, then subtract baseline `VmRSS` from post-lane `VmHWM` so the value is above the prewarmed-sidecar baseline. Native and default host Node lanes spawn the measured child directly and sample `/proc/<pid>/status` `VmHWM`, minus a startup no-op baseline (`native-baseline cpu_loop --iters 1 --warmup 0` and `node -e ""`), floored to one page. Non-Linux runs print one reason and render memory columns as `-`.
+
 Warmup contract:
 
 - **Guest Node prewarm**: `prewarmBenchVm(vm, op)` runs one trivial guest Node program to force isolate creation, bridge snapshot load, and first-exec paths before timed sampling.

--- a/packages/benchmarks/src/lib/layers.ts
+++ b/packages/benchmarks/src/lib/layers.ts
@@ -11,7 +11,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { NativeOp } from "./native.js";
-import { runNativeLayer } from "./native.js";
+import { runNativeLayerMeasured } from "./native.js";
+import {
+	NODE_MEMORY_PROVENANCE,
+	SidecarPeakMemorySampler,
+	hostPeakMemorySupportReason,
+	pageSizeBytes,
+	runCommandWithMaxRss,
+	type LaneMemory,
+} from "./memory.js";
 import { nowMs, round, stats, type Stats } from "./perf-utils.js";
 import type { BenchVm, BenchVmOptions } from "./vm.js";
 
@@ -44,11 +52,18 @@ export interface LayerSamples {
 	wasm?: number[];
 }
 
+export interface LayerSampleSet {
+	samples: number[];
+	memory?: LaneMemory;
+}
+
+export type LayerStatsEntry = Stats & Partial<LaneMemory>;
+
 export interface LayerStats {
-	native?: Stats;
-	node: Stats;
-	guest: Stats;
-	wasm?: Stats;
+	native?: LayerStatsEntry;
+	node: LayerStatsEntry;
+	guest: LayerStatsEntry;
+	wasm?: LayerStatsEntry;
 }
 
 export interface BenchmarkOp {
@@ -105,6 +120,7 @@ export interface OpResult {
 		emulation: number;
 		total?: number;
 		wasm?: number;
+		mem?: number;
 	};
 }
 
@@ -116,11 +132,12 @@ export interface CommandOpResult {
 	skipped?: true;
 	skipReason?: string;
 	layers: {
-		hostCmd?: Stats;
-		vmCmd?: Stats;
+		hostCmd?: LayerStatsEntry;
+		vmCmd?: LayerStatsEntry;
 	};
 	tax: {
 		command?: number;
+		mem?: number;
 	};
 }
 
@@ -209,6 +226,50 @@ export function runNodeProgram(
 			maxBuffer: 128 * 1024 * 1024,
 		});
 		return JSON.parse(stdout).samples;
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+export async function runNodeProgramMeasured(
+	source: string,
+	iters: number,
+	warmup: number,
+): Promise<LayerSampleSet> {
+	const dir = mkdtempSync(join(tmpdir(), "secure-exec-fuzz-perf-node-"));
+	const file = join(dir, "bench.mjs");
+	try {
+		writeFileSync(file, source);
+		const env = {
+			...process.env,
+			BENCH_ITERATIONS: String(iters),
+			BENCH_WARMUP: String(warmup),
+		};
+		const timed =
+			hostPeakMemorySupportReason() === undefined
+				? await runCommandWithMaxRss("node", [file], {
+						env,
+						maxBuffer: 128 * 1024 * 1024,
+					})
+				: undefined;
+		const stdout =
+			timed?.stdout ??
+			execFileSync("node", [file], {
+				encoding: "utf8",
+				env,
+				maxBuffer: 128 * 1024 * 1024,
+			});
+		return {
+			samples: JSON.parse(stdout).samples,
+			...(timed
+				? {
+						memory: {
+							memBytes: await subtractNodeStartupBaseline(timed.maxRssBytes),
+							memProvenance: NODE_MEMORY_PROVENANCE,
+						},
+					}
+				: {}),
+		};
 	} finally {
 		rmSync(dir, { recursive: true, force: true });
 	}
@@ -331,13 +392,13 @@ export async function runWasmLayer(
 }
 
 export interface OpHostSamples {
-	native?: number[];
-	node: number[];
+	native?: LayerSampleSet;
+	node: LayerSampleSet;
 }
 
 export interface OpVmSamples {
-	guest: number[];
-	wasm?: number[];
+	guest: LayerSampleSet;
+	wasm?: LayerSampleSet;
 }
 
 export async function runOpHostLayers(
@@ -345,10 +406,16 @@ export async function runOpHostLayers(
 	iters: number,
 	warmup: number,
 ): Promise<OpHostSamples> {
-	const native = op.nativeOp ? runNativeLayer(op.nativeOp, iters, warmup) : undefined;
+	const native = op.nativeOp
+		? await runNativeLayerMeasured(op.nativeOp, iters, warmup)
+		: undefined;
 	const node = op.runNode
-		? await op.runNode(iters, warmup)
-		: runNodeProgram(timedProgram(op.program ?? "() => {}", op.setup), iters, warmup);
+		? { samples: await op.runNode(iters, warmup) }
+		: await runNodeProgramMeasured(
+				timedProgram(op.program ?? "() => {}", op.setup),
+				iters,
+				warmup,
+			);
 	return {
 		...(native ? { native } : {}),
 		node,
@@ -362,18 +429,23 @@ export async function runOpVmLayers(
 	warmup: number,
 	context?: unknown,
 ): Promise<OpVmSamples> {
-	const guest = op.runGuest
-		? await op.runGuest(vm, iters, warmup, context)
-		: await runGuestProgram(
-				vm,
-				timedProgram(op.program ?? "() => {}", op.setup),
-				iters,
-				warmup,
-				`${op.family}-${op.name}`,
-			);
+	const sampler = SidecarPeakMemorySampler.forVm(vm);
+	const guest = await measureWithSidecarPeak(sampler, () =>
+		op.runGuest
+			? op.runGuest(vm, iters, warmup, context)
+			: runGuestProgram(
+					vm,
+					timedProgram(op.program ?? "() => {}", op.setup),
+					iters,
+					warmup,
+					`${op.family}-${op.name}`,
+				),
+	);
 	const wasm =
 		op.nativeOp && !op.wasmUnsupportedReason
-			? await runWasmLayer(vm, op.nativeOp, iters, warmup)
+			? await measureOptionalWithSidecarPeak(sampler, () =>
+					runWasmLayer(vm, op.nativeOp!, iters, warmup),
+				)
 			: undefined;
 	return {
 		guest,
@@ -387,10 +459,10 @@ export function buildOpResult(
 	vmSamples: OpVmSamples,
 ): OpResult {
 	const layers = {
-		...(hostSamples.native ? { native: stats(hostSamples.native) } : {}),
-		node: stats(hostSamples.node),
-		guest: stats(vmSamples.guest),
-		...(vmSamples.wasm ? { wasm: stats(vmSamples.wasm) } : {}),
+		...(hostSamples.native ? { native: statsWithMemory(hostSamples.native) } : {}),
+		node: statsWithMemory(hostSamples.node),
+		guest: statsWithMemory(vmSamples.guest),
+		...(vmSamples.wasm ? { wasm: statsWithMemory(vmSamples.wasm) } : {}),
 	};
 	return {
 		family: op.family,
@@ -408,6 +480,9 @@ export function buildOpResult(
 			...(layers.native ? { total: round(layers.guest.p50 / layers.native.p50) } : {}),
 			...(layers.wasm && layers.native
 				? { wasm: round(layers.wasm.p50 / layers.native.p50) }
+				: {}),
+			...(layers.guest.memBytes !== undefined && layers.native?.memBytes !== undefined
+				? { mem: round(layers.guest.memBytes / layers.native.memBytes) }
 				: {}),
 		},
 	};
@@ -430,8 +505,8 @@ export async function runCommandHostLayer(
 	op: CommandBenchmarkOp,
 	iters: number,
 	warmup: number,
-): Promise<Stats> {
-	return stats(await op.runHostCmd(iters, warmup));
+): Promise<LayerStatsEntry> {
+	return statsWithMemory({ samples: await op.runHostCmd(iters, warmup) });
 }
 
 export async function runCommandVmLayer(
@@ -439,14 +514,18 @@ export async function runCommandVmLayer(
 	vm: BenchVm,
 	iters: number,
 	warmup: number,
-): Promise<Stats> {
-	return stats(await op.runVmCmd(vm, iters, warmup));
+): Promise<LayerStatsEntry> {
+	const sampler = SidecarPeakMemorySampler.forVm(vm);
+	const measured = await measureWithSidecarPeak(sampler, () =>
+		op.runVmCmd(vm, iters, warmup),
+	);
+	return statsWithMemory(measured);
 }
 
 export function buildCommandOpResult(
 	op: CommandBenchmarkOp,
-	hostCmd: Stats,
-	vmCmd: Stats,
+	hostCmd: LayerStatsEntry,
+	vmCmd: LayerStatsEntry,
 ): CommandOpResult {
 	return {
 		family: op.family,
@@ -456,6 +535,64 @@ export function buildCommandOpResult(
 		layers: { hostCmd, vmCmd },
 		tax: {
 			command: round(vmCmd.p50 / hostCmd.p50),
+			...(vmCmd.memBytes !== undefined && hostCmd.memBytes !== undefined
+				? { mem: round(vmCmd.memBytes / hostCmd.memBytes) }
+				: {}),
 		},
+	};
+}
+
+let nodeStartupMaxRssBytes: number | undefined;
+
+export async function primeNodeMemoryBaseline(): Promise<number | undefined> {
+	if (hostPeakMemorySupportReason()) return undefined;
+	if (nodeStartupMaxRssBytes !== undefined) return nodeStartupMaxRssBytes;
+	nodeStartupMaxRssBytes = (
+		await runCommandWithMaxRss("node", ["-e", ""], {
+			maxBuffer: 128 * 1024 * 1024,
+		})
+	).maxRssBytes;
+	return nodeStartupMaxRssBytes;
+}
+
+async function subtractNodeStartupBaseline(opMaxRssBytes: number): Promise<number> {
+	const baseline = (await primeNodeMemoryBaseline()) ?? 0;
+	return Math.max(opMaxRssBytes - baseline, pageSizeBytes());
+}
+
+async function measureWithSidecarPeak<T extends number[] | undefined>(
+	sampler: SidecarPeakMemorySampler | undefined,
+	fn: () => Promise<T> | T,
+): Promise<LayerSampleSet> {
+	if (!sampler) {
+		return { samples: (await fn()) ?? [] };
+	}
+	const measured = await sampler.measure(fn);
+	return {
+		samples: measured.value ?? [],
+		...(measured.memory ? { memory: measured.memory } : {}),
+	};
+}
+
+async function measureOptionalWithSidecarPeak(
+	sampler: SidecarPeakMemorySampler | undefined,
+	fn: () => Promise<number[] | undefined>,
+): Promise<LayerSampleSet | undefined> {
+	if (!sampler) {
+		const samples = await fn();
+		return samples ? { samples } : undefined;
+	}
+	const measured = await sampler.measure(fn);
+	if (!measured.value) return undefined;
+	return {
+		samples: measured.value,
+		...(measured.memory ? { memory: measured.memory } : {}),
+	};
+}
+
+function statsWithMemory(sampleSet: LayerSampleSet): LayerStatsEntry {
+	return {
+		...stats(sampleSet.samples),
+		...(sampleSet.memory ? sampleSet.memory : {}),
 	};
 }

--- a/packages/benchmarks/src/lib/memory.ts
+++ b/packages/benchmarks/src/lib/memory.ts
@@ -1,4 +1,5 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { forceGC } from "./perf-utils.js";
 import type { BenchVm } from "./vm.js";
 
@@ -42,6 +43,208 @@ export function readRssBytes(pid: number | null): number {
 	} catch {
 		return 0;
 	}
+}
+
+export interface LaneMemory {
+	memBytes: number;
+	memProvenance: string;
+}
+
+export interface MeasuredValue<T> {
+	value: T;
+	memory?: LaneMemory;
+}
+
+export const SIDECAR_MEMORY_PROVENANCE =
+	"/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)";
+
+export const NATIVE_MEMORY_PROVENANCE =
+	"direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page";
+
+export const NODE_MEMORY_PROVENANCE =
+	'direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e "" startup baseline, floored to one page';
+
+export function procPeakMemorySupportReason(): string | undefined {
+	if (process.platform !== "linux") {
+		return "Linux /proc clear_refs/VmHWM memory measurement is unavailable on this platform";
+	}
+	if (!existsSync("/proc/self/status") || !existsSync("/proc/self/clear_refs")) {
+		return "Linux /proc status/clear_refs memory measurement is unavailable";
+	}
+	return undefined;
+}
+
+export function hostPeakMemorySupportReason(): string | undefined {
+	if (process.platform !== "linux") {
+		return "host child /proc VmHWM memory measurement is only enabled on Linux";
+	}
+	if (!existsSync("/proc/self/status")) {
+		return "Linux /proc status memory measurement is unavailable";
+	}
+	return undefined;
+}
+
+export function formatBytes(bytes: number | undefined): string {
+	if (bytes === undefined) return "-";
+	const units = ["B", "KiB", "MiB", "GiB"];
+	let value = bytes;
+	let unit = 0;
+	while (value >= 1024 && unit < units.length - 1) {
+		value /= 1024;
+		unit++;
+	}
+	const decimals = unit === 0 || value >= 10 ? 0 : 1;
+	return `${value.toFixed(decimals)}${units[unit]}`;
+}
+
+export function pageSizeBytes(): number {
+	try {
+		const stdout = execFileSync("getconf", ["PAGESIZE"], {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+		const parsed = Number(stdout.trim());
+		if (Number.isFinite(parsed) && parsed > 0) return parsed;
+	} catch {
+		// Fall through to the common Linux page size.
+	}
+	return 4096;
+}
+
+export interface TimedCommandResult {
+	stdout: string;
+	stderr: string;
+	maxRssBytes: number;
+}
+
+export function runCommandWithMaxRss(
+	command: string,
+	args: string[],
+	options: {
+		cwd?: string;
+		env?: NodeJS.ProcessEnv;
+		maxBuffer?: number;
+	} = {},
+): Promise<TimedCommandResult> {
+	const reason = hostPeakMemorySupportReason();
+	if (reason) throw new Error(reason);
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			cwd: options.cwd,
+			env: options.env,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		const maxBuffer = options.maxBuffer ?? 128 * 1024 * 1024;
+		const stdout: Buffer[] = [];
+		const stderr: Buffer[] = [];
+		let stdoutBytes = 0;
+		let stderrBytes = 0;
+		let maxRssBytes = 0;
+		let poll: NodeJS.Timeout | undefined;
+
+		const sample = () => {
+			if (child.pid === undefined) return;
+			try {
+				maxRssBytes = Math.max(maxRssBytes, readStatusBytes(child.pid, "VmHWM"));
+			} catch {
+				try {
+					maxRssBytes = Math.max(maxRssBytes, readStatusBytes(child.pid, "VmRSS"));
+				} catch {
+					// The child may have exited between polls.
+				}
+			}
+		};
+		const collect = (chunks: Buffer[], kind: "stdout" | "stderr") => (chunk: Buffer) => {
+			if (kind === "stdout") stdoutBytes += chunk.length;
+			else stderrBytes += chunk.length;
+			if (stdoutBytes + stderrBytes > maxBuffer) {
+				child.kill("SIGKILL");
+				reject(new Error(`${command} output exceeded maxBuffer ${maxBuffer}`));
+				return;
+			}
+			chunks.push(chunk);
+		};
+
+		child.stdout.on("data", collect(stdout, "stdout"));
+		child.stderr.on("data", collect(stderr, "stderr"));
+		child.on("spawn", () => {
+			sample();
+			poll = setInterval(sample, 1);
+		});
+		child.on("error", (error) => {
+			if (poll) clearInterval(poll);
+			reject(error);
+		});
+		child.on("close", (code, signal) => {
+			if (poll) clearInterval(poll);
+			sample();
+			const stdoutText = Buffer.concat(stdout).toString("utf8");
+			const stderrText = Buffer.concat(stderr).toString("utf8");
+			if (code !== 0) {
+				reject(
+					new Error(
+						`${command} ${args.join(" ")} exited ${code ?? signal}\n${stdoutText}\n${stderrText}`,
+					),
+				);
+				return;
+			}
+			resolve({
+				stdout: stdoutText,
+				stderr: stderrText,
+				maxRssBytes,
+			});
+		});
+	});
+}
+
+export class SidecarPeakMemorySampler {
+	private constructor(private readonly pid: number) {}
+
+	static forVm(vm: BenchVm): SidecarPeakMemorySampler | undefined {
+		if (procPeakMemorySupportReason()) return undefined;
+		const pid = vm.sidecarPid();
+		return typeof pid === "number" ? new SidecarPeakMemorySampler(pid) : undefined;
+	}
+
+	async measure<T>(fn: () => Promise<T> | T): Promise<MeasuredValue<T>> {
+		this.resetHighWaterMark();
+		const baselineRss = this.readStatusBytes("VmRSS");
+		const value = await fn();
+		const highWater = this.readStatusBytes("VmHWM");
+		return {
+			value,
+			memory: {
+				memBytes: Math.max(0, highWater - baselineRss),
+				memProvenance: SIDECAR_MEMORY_PROVENANCE,
+			},
+		};
+	}
+
+	async measureIdle(waitMs: number): Promise<LaneMemory> {
+		this.resetHighWaterMark();
+		const baselineRss = this.readStatusBytes("VmRSS");
+		await new Promise((resolve) => setTimeout(resolve, waitMs));
+		const highWater = this.readStatusBytes("VmHWM");
+		return {
+			memBytes: Math.max(0, highWater - baselineRss),
+			memProvenance: SIDECAR_MEMORY_PROVENANCE,
+		};
+	}
+
+	private resetHighWaterMark(): void {
+		writeFileSync(`/proc/${this.pid}/clear_refs`, "5");
+	}
+
+	private readStatusBytes(field: "VmRSS" | "VmHWM"): number {
+		return readStatusBytes(this.pid, field);
+	}
+}
+
+function readStatusBytes(pid: number, field: "VmRSS" | "VmHWM"): number {
+	const status = readFileSync(`/proc/${pid}/status`, "utf8");
+	const match = status.match(new RegExp(`^${field}:\\s+(\\d+)\\s+kB`, "m"));
+	if (!match) throw new Error(`could not read ${field} for pid ${pid}`);
+	return Number(match[1]) * 1024;
 }
 
 export async function sampleMemory(vm: BenchVm, cycle: number): Promise<MemorySample> {

--- a/packages/benchmarks/src/lib/native.ts
+++ b/packages/benchmarks/src/lib/native.ts
@@ -1,12 +1,20 @@
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+	NATIVE_MEMORY_PROVENANCE,
+	hostPeakMemorySupportReason,
+	pageSizeBytes,
+	runCommandWithMaxRss,
+	type LaneMemory,
+} from "./memory.js";
 
 const DEFAULT_NATIVE_BIN =
 	join(
 		fileURLToPath(new URL("../../../..", import.meta.url)),
 		"target/release/native-baseline",
 	);
+let nativeStartupMaxRssBytes: number | undefined;
 
 export type NativeOp =
 	| "spawn_exit"
@@ -45,12 +53,77 @@ export function runNativeLayer(
 	iters: number,
 	warmup: number,
 ): number[] {
-	const bin = process.env.NATIVE_BASELINE_BIN ?? DEFAULT_NATIVE_BIN;
+	const bin = resolveNativeBaselineBin();
 	const stdout = execFileSync(
 		bin,
 		["--op", op, "--iters", String(iters), "--warmup", String(warmup)],
 		{ encoding: "utf8", maxBuffer: 128 * 1024 * 1024 },
 	);
+	return parseNativeSamples(stdout);
+}
+
+export interface NativeLayerMeasurement {
+	samples: number[];
+	memory?: LaneMemory;
+}
+
+export async function runNativeLayerMeasured(
+	op: NativeOp,
+	iters: number,
+	warmup: number,
+): Promise<NativeLayerMeasurement> {
+	const bin = resolveNativeBaselineBin();
+	const args = ["--op", op, "--iters", String(iters), "--warmup", String(warmup)];
+	const timed =
+		hostPeakMemorySupportReason() === undefined
+			? await runCommandWithMaxRss(bin, args)
+			: undefined;
+	const stdout =
+		timed?.stdout ??
+		execFileSync(bin, args, {
+			encoding: "utf8",
+			maxBuffer: 128 * 1024 * 1024,
+		});
+	const samples = parseNativeSamples(stdout);
+	return {
+		samples,
+		...(timed
+			? {
+					memory: {
+						memBytes: await subtractStartupBaseline(timed.maxRssBytes),
+						memProvenance: NATIVE_MEMORY_PROVENANCE,
+					},
+				}
+			: {}),
+	};
+}
+
+export async function primeNativeMemoryBaseline(): Promise<number | undefined> {
+	if (hostPeakMemorySupportReason()) return undefined;
+	if (nativeStartupMaxRssBytes !== undefined) return nativeStartupMaxRssBytes;
+	nativeStartupMaxRssBytes = (
+		await runCommandWithMaxRss(resolveNativeBaselineBin(), [
+			"--op",
+			"cpu_loop",
+			"--iters",
+			"1",
+			"--warmup",
+			"0",
+		])
+	).maxRssBytes;
+	return nativeStartupMaxRssBytes;
+}
+
+function resolveNativeBaselineBin(): string {
+	return process.env.NATIVE_BASELINE_BIN ?? DEFAULT_NATIVE_BIN;
+}
+
+async function subtractStartupBaseline(opMaxRssBytes: number): Promise<number> {
+	const baseline = (await primeNativeMemoryBaseline()) ?? 0;
+	return Math.max(opMaxRssBytes - baseline, pageSizeBytes());
+}
+
+function parseNativeSamples(stdout: string): number[] {
 	const parsed = JSON.parse(stdout) as {
 		unit: string;
 		samples: number[];

--- a/packages/benchmarks/src/lib/vm.ts
+++ b/packages/benchmarks/src/lib/vm.ts
@@ -289,9 +289,21 @@ export function formatSidecarProvenance(
 }
 
 function sidecarPidFromRuntime(runtime: NodeRuntime): number | null {
-	const pid = (runtime as unknown as {
-		kernel?: { client?: { child?: { pid?: number } } };
-	}).kernel?.client?.child?.pid;
+	const kernel = (runtime as unknown as {
+		kernel?: {
+			client?: {
+				child?: { pid?: number };
+				protocolClient?: {
+					child?: { pid?: number };
+					sidecarProcess?: { child?: { pid?: number } };
+				};
+			};
+		};
+	}).kernel;
+	const pid =
+		kernel?.client?.child?.pid ??
+		kernel?.client?.protocolClient?.child?.pid ??
+		kernel?.client?.protocolClient?.sidecarProcess?.child?.pid;
 	return typeof pid === "number" ? pid : null;
 }
 

--- a/packages/benchmarks/src/run-all.ts
+++ b/packages/benchmarks/src/run-all.ts
@@ -11,10 +11,12 @@ import {
 	skippedCommandOpResult,
 	supportsWasmLayer,
 	wasmLayerOptions,
+	primeNodeMemoryBaseline,
 	type BenchmarkOp,
 	type CommandBenchmarkOp,
 	type LatencyResult,
 } from "./lib/layers.js";
+import { primeNativeMemoryBaseline } from "./lib/native.js";
 import {
 	createBenchVm,
 	formatSidecarProvenance,
@@ -27,6 +29,12 @@ import {
 } from "./lib/vm.js";
 import { findingsFromLatency, refutedFromLatency, writeJson } from "./lib/report.js";
 import { getHardware, printTable } from "./lib/perf-utils.js";
+import {
+	SidecarPeakMemorySampler,
+	formatBytes,
+	hostPeakMemorySupportReason,
+	procPeakMemorySupportReason,
+} from "./lib/memory.js";
 import { runFuzz } from "./fuzz/run.js";
 import { runLeakSuite } from "./leak.js";
 import { runFootprint } from "./footprint.js";
@@ -87,6 +95,8 @@ export async function runLatencyMatrix(): Promise<LatencyMatrixRun> {
 		const filteredOps = OP_FILTER
 			? ops.filter((op) => OP_FILTER.includes(op.name) || OP_FILTER.includes(`${op.family}/${op.name}`))
 			: ops;
+		await primeMemoryBaselines(filteredOps);
+		await runIdleVmMemorySelfCheck(baseVmOptions);
 		for (const op of filteredOps) {
 			console.error(`latency ${op.family}/${op.name}`);
 			if (!("runHostCmd" in op) && op.nativeOp && supportsWasmLayer(op.nativeOp)) {
@@ -175,6 +185,13 @@ async function main(): Promise<void> {
 			"hostCmd p50",
 			"vmCmd p50",
 			"vm/host",
+			"native mem",
+			"node mem",
+			"guest mem",
+			"wasm mem",
+			"hostCmd mem",
+			"vmCmd mem",
+			"memTax",
 		],
 		latency.map((result) => {
 			if (isLayerOpResult(result)) {
@@ -194,6 +211,13 @@ async function main(): Promise<void> {
 					"-",
 					"-",
 					"-",
+					formatBytes(result.layers.native?.memBytes),
+					formatBytes(result.layers.node.memBytes),
+					formatBytes(result.layers.guest.memBytes),
+					formatBytes(result.layers.wasm?.memBytes),
+					"-",
+					"-",
+					result.tax.mem ?? "-",
 				];
 			}
 			return [
@@ -206,6 +230,13 @@ async function main(): Promise<void> {
 				result.layers.hostCmd ? `${result.layers.hostCmd.p50}ms` : "-",
 				result.layers.vmCmd ? `${result.layers.vmCmd.p50}ms` : "-",
 				result.tax.command ?? result.skipReason ?? "-",
+				"-",
+				"-",
+				"-",
+				"-",
+				formatBytes(result.layers.hostCmd?.memBytes),
+				formatBytes(result.layers.vmCmd?.memBytes),
+				result.tax.mem ?? "-",
 			];
 		}),
 	);
@@ -284,6 +315,60 @@ function mergeBenchVmOptions(
 			...(extra.loopbackExemptPorts ?? []),
 		],
 	};
+}
+
+async function primeMemoryBaselines(
+	ops: Array<BenchmarkOp | CommandBenchmarkOp>,
+): Promise<void> {
+	const hostReason = hostPeakMemorySupportReason();
+	if (hostReason) {
+		console.error(`host memory columns disabled: ${hostReason}`);
+	} else {
+		if (ops.some((op) => !("runHostCmd" in op) && op.nativeOp)) {
+			const nativeBaseline = await primeNativeMemoryBaseline();
+			console.error(`native memory startup baseline: ${formatBytes(nativeBaseline)}`);
+		}
+		if (ops.some((op) => !("runHostCmd" in op) && !op.runNode)) {
+			const nodeBaseline = await primeNodeMemoryBaseline();
+			console.error(`node memory startup baseline: ${formatBytes(nodeBaseline)}`);
+		}
+	}
+
+	const procReason = procPeakMemorySupportReason();
+	if (procReason) {
+		console.error(`guest/vm memory columns disabled: ${procReason}`);
+	}
+}
+
+async function runIdleVmMemorySelfCheck(
+	baseVmOptions: BenchVmOptions,
+): Promise<void> {
+	const reason = procPeakMemorySupportReason();
+	if (reason) {
+		console.error(`idle prewarmed VM memory self-check skipped: ${reason}`);
+		return;
+	}
+	const vm = await createBenchVm(baseVmOptions);
+	try {
+		await prewarmBenchVm(vm, {
+			family: "self_check",
+			name: "idle_prewarmed_vm",
+			fileLine: "packages/benchmarks/src/run-all.ts",
+			reproducer: "prewarm VM, clear_refs=5, wait 2s, read VmHWM - baseline VmRSS",
+		});
+		const sampler = SidecarPeakMemorySampler.forVm(vm);
+		if (!sampler) {
+			console.error("idle prewarmed VM memory self-check skipped: sidecar pid unavailable");
+			return;
+		}
+		const memory = await sampler.measureIdle(2_000);
+		const warning = memory.memBytes > 2 * 1024 * 1024 ? " WARN >2MiB" : "";
+		console.error(
+			`idle prewarmed VM op memory self-check: ${formatBytes(memory.memBytes)} (${memory.memBytes} bytes)${warning}`,
+		);
+	} finally {
+		await vm.dispose();
+	}
 }
 
 function criticGaps(


### PR DESCRIPTION
Every latency-matrix op now reports peak memory attributable to the work, per
lane, plus memTax = guestPeak/nativePeak:

- guest/wasm/vmCmd lanes: sidecar peak above the prewarmed baseline — write 5
  to /proc/<sidecarPid>/clear_refs after prewarm (resets VmHWM), baseline
  VmRSS, then post-op VmHWM minus baseline (clamped >= 0). Idle-VM self-check
  runs once per matrix invocation and prints ~0 (measured 0B).
- native/node lanes: live-child /proc VmHWM polling minus a measured nop
  startup baseline (native-baseline cpu_loop --iters 1 / node -e ''), floored
  to one page. GNU time -v is absent on this host, so /proc sampling is used
  uniformly.
- Per-lane provenance strings recorded in results JSON; columns render '-'
  with a printed reason on non-Linux. Documented in the benchmarks README and
  CLAUDE.md §Benchmarks.