### PR TITLE
test(benchmarks): module-resolution family

### DIFF
--- a/packages/benchmarks/README.md
+++ b/packages/benchmarks/README.md
@@ -47,6 +47,7 @@ Run one matrix family:
 
 ```bash
 BENCH_FAMILIES=fs pnpm --dir packages/benchmarks bench:matrix
+BENCH_FAMILIES=modules pnpm --dir packages/benchmarks bench:matrix
 BENCH_FAMILIES=ecosystem pnpm --dir packages/benchmarks bench:matrix
 ```
 
@@ -125,6 +126,19 @@ Rows:
 - **`tcp_concurrent_4`**: four concurrent TCP loopback clients connect to one server.
 - **`tcp_throughput_64k`**: TCP loopback echo of one 64 KiB payload.
 - **`tcp_tiny_writes_16`**: TCP loopback echo using sixteen one-byte writes.
+
+## Modules Family
+
+`BENCH_FAMILIES=modules pnpm --dir packages/benchmarks bench:matrix` runs JavaScript module-resolution and import-heavy rows through the host Node and guest VM lanes. Native and WASM lanes are unsupported because module resolution is a JS-runtime surface.
+
+These rows cap the default matrix sample budget at five measured iterations plus one warmup so each row still loads 100 unique files per iteration without making debug-sidecar runs impractical.
+
+Rows:
+
+- **`require_100_small`**: stages 100 unique tiny CommonJS files per warmup/measured iteration, then requires that iteration's directory and verifies the exported-value sum.
+- **`import_100_small_esm`**: stages 100 unique tiny ESM files per warmup/measured iteration, then dynamic-imports that iteration's directory and verifies the exported-value sum.
+- **`import_npm_package`**: dynamic-imports `zod@4.3.6` from the workspace `node_modules` tree mounted read-only in the guest. The inspected static ESM graph from `index.js` contains 76 transitive module files. The benchmark uses one fresh Node process per measured iteration so the whole graph reloads instead of only cache-busting the entry URL.
+- **`import_fresh_file`**: moved from `fs/module_import_fresh`; writes a unique `.mjs` file, dynamic-imports it, verifies the exported value, and unlinks it.
 
 ## Ecosystem Family
 

--- a/packages/benchmarks/src/families/fs.ts
+++ b/packages/benchmarks/src/families/fs.ts
@@ -1,15 +1,5 @@
 import type { BenchmarkOp } from "../lib/layers.js";
 
-/**
- * Filesystem differential ops.
- *
- * Requested but not shipped:
- *   - module_import_fresh: guest dynamic import cannot resolve a freshly written
- *     file, even when written beside the running benchmark module. Verbatim
- *     smoke error: `Cannot resolve module 'file:///tmp/fuzz-perf-import-1-0-929830bf8caa7.mjs'
- *     (imported from '/tmp/fuzz-perf-fs-module_import_fresh.mjs'): not found.`
- */
-
 export const fsFamily: BenchmarkOp[] = [
 	{
 		family: "fs",
@@ -47,23 +37,6 @@ export const fsFamily: BenchmarkOp[] = [
 		program: `async (i) => {
   const fs = await import("node:fs");
   fs.writeFileSync("/tmp/fuzz-perf-write.txt", "hello-" + i);
-}`,
-	},
-	{
-		family: "fs",
-		name: "module_import_fresh",
-		nativeUnsupportedReason: "dynamic import of guest-written JavaScript module",
-		wasmUnsupportedReason: "dynamic import of guest-written JavaScript module",
-		fileLine: "crates/execution/src/javascript.rs:3939",
-		reproducer: "write a unique /tmp .mjs file, dynamic-import it, and verify the exported value",
-		program: `async (i) => {
-  const fs = await import("node:fs");
-  const value = "fresh-" + process.pid + "-" + i;
-  const path = "/tmp/fuzz-perf-import-" + process.pid + "-" + i + ".mjs";
-  fs.writeFileSync(path, "export const value = " + JSON.stringify(value) + ";\\n");
-  const mod = await import("file://" + path);
-  if (mod.value !== value) throw new Error("bad fresh import");
-  fs.unlinkSync(path);
 }`,
 	},
 	{

--- a/packages/benchmarks/src/families/index.ts
+++ b/packages/benchmarks/src/families/index.ts
@@ -2,6 +2,7 @@ import { controlFamily } from "./control.js";
 import { dnsFamily } from "./dns.js";
 import { ecosystemFamily } from "./ecosystem.js";
 import { fsFamily } from "./fs.js";
+import { modulesFamily } from "./modules.js";
 import { netFamily } from "./net.js";
 import { perfFindingsFamily } from "./perf-findings.js";
 import { pipesFamily } from "./pipes.js";
@@ -12,6 +13,7 @@ export const allFamilies = [
 	processFamily,
 	netFamily,
 	fsFamily,
+	modulesFamily,
 	dnsFamily,
 	ecosystemFamily,
 	pipesFamily,

--- a/packages/benchmarks/src/families/modules.ts
+++ b/packages/benchmarks/src/families/modules.ts
@@ -1,0 +1,234 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import type { BenchmarkOp } from "../lib/layers.js";
+import type { BenchVm } from "../lib/vm.js";
+
+const JS_RUNTIME_UNSUPPORTED = "module resolution is a JS-runtime surface";
+const MODULES_PER_ITERATION = 100;
+const MODULE_SAMPLE_CAP = {
+	maxIterations: 5,
+	maxWarmup: 1,
+};
+const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
+const ZOD_PACKAGE_HOST_DIR = join(
+	REPO_ROOT,
+	"node_modules/.pnpm/zod@4.3.6/node_modules/zod",
+);
+const ZOD_PACKAGE_GUEST_DIR = "/mnt/bench-zod";
+const ZOD_TRANSITIVE_MODULE_FILE_COUNT = 76;
+
+function require100SmallSetup(): string {
+	return `async () => {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  const { createRequire } = await import("node:module");
+  const root = "/tmp/fuzz-perf-modules-require-" + process.pid;
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(root, { recursive: true });
+  const total = Number(process.env.BENCH_WARMUP || 5) + Number(process.env.BENCH_ITERATIONS || 20);
+  for (let i = 0; i < total; i++) {
+    const dir = path.join(root, String(i));
+    fs.mkdirSync(dir, { recursive: true });
+    for (let file = 0; file < ${MODULES_PER_ITERATION}; file++) {
+      const value = i * ${MODULES_PER_ITERATION} + file;
+      fs.writeFileSync(path.join(dir, "mod-" + file + ".cjs"), "module.exports = " + value + ";\\n");
+    }
+  }
+  globalThis.__modulesBenchRequireRoot = root;
+  globalThis.__modulesBenchRequire = createRequire(import.meta.url);
+  globalThis.__modulesBenchPathJoin = path.join;
+}`;
+}
+
+function require100SmallProgram(): string {
+	return `async (i) => {
+  const root = globalThis.__modulesBenchRequireRoot;
+  const require = globalThis.__modulesBenchRequire;
+  const pathJoin = globalThis.__modulesBenchPathJoin;
+  let sum = 0;
+  for (let file = 0; file < ${MODULES_PER_ITERATION}; file++) {
+    sum += require(pathJoin(root, String(i), "mod-" + file + ".cjs"));
+  }
+  const expected = ${MODULES_PER_ITERATION} * (i * ${MODULES_PER_ITERATION}) + (${MODULES_PER_ITERATION} * (${MODULES_PER_ITERATION} - 1)) / 2;
+  if (sum !== expected) throw new Error("bad require sum " + sum + " expected " + expected);
+}`;
+}
+
+function import100SmallEsmSetup(): string {
+	return `async () => {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  const { pathToFileURL } = await import("node:url");
+  const root = "/tmp/fuzz-perf-modules-import-" + process.pid;
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(root, { recursive: true });
+  const total = Number(process.env.BENCH_WARMUP || 5) + Number(process.env.BENCH_ITERATIONS || 20);
+  for (let i = 0; i < total; i++) {
+    const dir = path.join(root, String(i));
+    fs.mkdirSync(dir, { recursive: true });
+    for (let file = 0; file < ${MODULES_PER_ITERATION}; file++) {
+      const value = i * ${MODULES_PER_ITERATION} + file;
+      fs.writeFileSync(path.join(dir, "mod-" + file + ".mjs"), "export const value = " + value + ";\\n");
+    }
+  }
+  globalThis.__modulesBenchImportRoot = root;
+  globalThis.__modulesBenchImportPathJoin = path.join;
+  globalThis.__modulesBenchPathToFileURL = pathToFileURL;
+}`;
+}
+
+function import100SmallEsmProgram(): string {
+	return `async (i) => {
+  const root = globalThis.__modulesBenchImportRoot;
+  const pathJoin = globalThis.__modulesBenchImportPathJoin;
+  const pathToFileURL = globalThis.__modulesBenchPathToFileURL;
+  let sum = 0;
+  for (let file = 0; file < ${MODULES_PER_ITERATION}; file++) {
+    const filePath = pathJoin(root, String(i), "mod-" + file + ".mjs");
+    const mod = await import(pathToFileURL(filePath).href);
+    sum += mod.value;
+  }
+  const expected = ${MODULES_PER_ITERATION} * (i * ${MODULES_PER_ITERATION}) + (${MODULES_PER_ITERATION} * (${MODULES_PER_ITERATION} - 1)) / 2;
+  if (sum !== expected) throw new Error("bad import sum " + sum + " expected " + expected);
+}`;
+}
+
+function npmPackageImportRunnerSource(): string {
+	return `
+const entryUrl = process.env.BENCH_NPM_ENTRY_URL;
+const iteration = process.env.BENCH_NPM_ITERATION;
+if (!entryUrl || !iteration) throw new Error("missing npm import bench env");
+const mod = await import(entryUrl + "?bench=" + iteration);
+if (!mod.z || typeof mod.z.object !== "function") {
+  throw new Error("zod export check failed");
+}
+`;
+}
+
+function runHostNpmPackageImport(iters: number, warmup: number): number[] {
+	const entryUrl = pathToFileURL(join(ZOD_PACKAGE_HOST_DIR, "index.js")).href;
+	const samples: number[] = [];
+	const dir = mkdtempSync(join(tmpdir(), "secure-exec-modules-npm-"));
+	const runner = join(dir, "import-zod.mjs");
+	try {
+		writeFileSync(runner, npmPackageImportRunnerSource());
+		for (let i = 0; i < warmup + iters; i++) {
+			const start = process.hrtime.bigint();
+			execFileSync("node", [runner], {
+				stdio: "pipe",
+				env: {
+					...process.env,
+					BENCH_NPM_ENTRY_URL: entryUrl,
+					BENCH_NPM_ITERATION: String(i),
+				},
+				maxBuffer: 128 * 1024 * 1024,
+			});
+			const ms = Number(process.hrtime.bigint() - start) / 1e6;
+			if (i >= warmup) samples.push(ms);
+		}
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+	return samples;
+}
+
+async function runGuestNpmPackageImport(
+	vm: BenchVm,
+	iters: number,
+	warmup: number,
+): Promise<number[]> {
+	const entryUrl = `file://${ZOD_PACKAGE_GUEST_DIR}/index.js`;
+	const runner = "/tmp/fuzz-perf-modules-import-zod.mjs";
+	await vm.writeFile(runner, npmPackageImportRunnerSource());
+	const samples: number[] = [];
+	for (let i = 0; i < warmup + iters; i++) {
+		const start = process.hrtime.bigint();
+		const result = await vm.spawnNodeCapture(runner, {
+			BENCH_NPM_ENTRY_URL: entryUrl,
+			BENCH_NPM_ITERATION: String(i),
+		});
+		const ms = Number(process.hrtime.bigint() - start) / 1e6;
+		if (result.exitCode !== 0) {
+			throw new Error(`guest zod import exited ${result.exitCode}\n${result.stderr}`);
+		}
+		if (i >= warmup) samples.push(ms);
+	}
+	return samples;
+}
+
+function ensureZodPackage(): void {
+	if (!existsSync(join(ZOD_PACKAGE_HOST_DIR, "index.js"))) {
+		throw new Error(`zod benchmark package not found at ${ZOD_PACKAGE_HOST_DIR}`);
+	}
+}
+
+export const modulesFamily: BenchmarkOp[] = [
+	{
+		family: "modules",
+		name: "require_100_small",
+		...MODULE_SAMPLE_CAP,
+		nativeUnsupportedReason: JS_RUNTIME_UNSUPPORTED,
+		wasmUnsupportedReason: JS_RUNTIME_UNSUPPORTED,
+		fileLine: "crates/execution/src/node_import_cache.rs:4750",
+		reproducer: "stage 100 unique tiny CJS files per iteration, require them, and verify exported sum",
+		setup: require100SmallSetup(),
+		program: require100SmallProgram(),
+	},
+	{
+		family: "modules",
+		name: "import_100_small_esm",
+		...MODULE_SAMPLE_CAP,
+		nativeUnsupportedReason: JS_RUNTIME_UNSUPPORTED,
+		wasmUnsupportedReason: JS_RUNTIME_UNSUPPORTED,
+		fileLine: "crates/execution/src/node_import_cache.rs:4750",
+		reproducer: "stage 100 unique tiny ESM files per iteration, dynamic-import them, and verify exported sum",
+		setup: import100SmallEsmSetup(),
+		program: import100SmallEsmProgram(),
+	},
+	{
+		family: "modules",
+		name: "import_npm_package",
+		...MODULE_SAMPLE_CAP,
+		nativeUnsupportedReason: JS_RUNTIME_UNSUPPORTED,
+		wasmUnsupportedReason: JS_RUNTIME_UNSUPPORTED,
+		fileLine: "crates/execution/src/node_import_cache.rs:4750",
+		reproducer: `dynamic-import zod@4.3.6 from a read-only mounted package tree (${ZOD_TRANSITIVE_MODULE_FILE_COUNT} transitive ESM files) and verify z.object`,
+		runNode: runHostNpmPackageImport,
+		prepareVm: async () => {
+			ensureZodPackage();
+			return {
+				options: {
+					mounts: [
+						{
+							guestPath: ZOD_PACKAGE_GUEST_DIR,
+							hostPath: ZOD_PACKAGE_HOST_DIR,
+							readOnly: true,
+						},
+					],
+				},
+			};
+		},
+		runGuest: (vm, iters, warmup) => runGuestNpmPackageImport(vm, iters, warmup),
+	},
+	{
+		family: "modules",
+		name: "import_fresh_file",
+		...MODULE_SAMPLE_CAP,
+		nativeUnsupportedReason: JS_RUNTIME_UNSUPPORTED,
+		wasmUnsupportedReason: JS_RUNTIME_UNSUPPORTED,
+		fileLine: "crates/execution/src/javascript.rs:3939",
+		reproducer: "write a unique /tmp .mjs file, dynamic-import it, and verify the exported value",
+		program: `async (i) => {
+  const fs = await import("node:fs");
+  const value = "fresh-" + process.pid + "-" + i;
+  const path = "/tmp/fuzz-perf-import-" + process.pid + "-" + i + ".mjs";
+  fs.writeFileSync(path, "export const value = " + JSON.stringify(value) + ";\\n");
+  const mod = await import("file://" + path);
+  if (mod.value !== value) throw new Error("bad fresh import");
+  fs.unlinkSync(path);
+}`,
+	},
+];

--- a/packages/benchmarks/src/lib/layers.ts
+++ b/packages/benchmarks/src/lib/layers.ts
@@ -83,6 +83,8 @@ export interface BenchmarkOp {
 		warmup: number,
 		context?: unknown,
 	) => Promise<number[]>;
+	maxIterations?: number;
+	maxWarmup?: number;
 	prepareVm?: () => Promise<{
 		options?: BenchVmOptions;
 		context?: unknown;
@@ -97,6 +99,8 @@ export interface CommandBenchmarkOp {
 	fileLine: string;
 	reproducer: string;
 	skipReason?: string;
+	maxIterations?: number;
+	maxWarmup?: number;
 	runHostCmd: (iters: number, warmup: number) => Promise<number[]> | number[];
 	runVmCmd: (
 		vm: BenchVm,

--- a/packages/benchmarks/src/lib/report.ts
+++ b/packages/benchmarks/src/lib/report.ts
@@ -101,6 +101,9 @@ function causeFor(family: string, op: string): string {
 	if (family === "fs") {
 		return "single sync filesystem bridge/VFS round trip floor on tiny filesystem operations";
 	}
+	if (family === "modules") {
+		return "module resolution, source loading, and import cache behavior in the guest JavaScript runtime";
+	}
 	if (family === "pipes") {
 		return "stdio pipe bytes cross synchronous bridge boundaries";
 	}

--- a/packages/benchmarks/src/run-all.ts
+++ b/packages/benchmarks/src/run-all.ts
@@ -259,18 +259,20 @@ async function runOneOp(
 	baseVmOptions: BenchVmOptions,
 	sharedVm: BenchVm | undefined,
 ): Promise<LatencyResult> {
+	const iterations = Math.min(ITERATIONS, op.maxIterations ?? ITERATIONS);
+	const warmup = Math.min(WARMUP, op.maxWarmup ?? WARMUP);
 	if ("runHostCmd" in op) {
 		if (op.skipReason) return skippedCommandOpResult(op);
-		const hostCmd = await runCommandHostLayer(op, ITERATIONS, WARMUP);
+		const hostCmd = await runCommandHostLayer(op, iterations, warmup);
 		const vmCmd = await withOpVm(op, baseVmOptions, sharedVm, (vm) =>
-			runCommandVmLayer(op, vm, ITERATIONS, WARMUP),
+			runCommandVmLayer(op, vm, iterations, warmup),
 		);
 		return buildCommandOpResult(op, hostCmd, vmCmd);
 	}
 
-	const hostSamples = await runOpHostLayers(op, ITERATIONS, WARMUP);
+	const hostSamples = await runOpHostLayers(op, iterations, warmup);
 	const vmSamples = await withOpVm(op, baseVmOptions, sharedVm, (vm, context) =>
-		runOpVmLayers(op, vm, ITERATIONS, WARMUP, context),
+		runOpVmLayers(op, vm, iterations, warmup, context),
 	);
 	return buildOpResult(op, hostSamples, vmSamples);
 }


### PR DESCRIPTION
New 'modules' family measuring the module-load surface that dominates
session-create tax (~1500ms vs 378ms bare-node) and agent require/import
storms:

- require_100_small / import_100_small_esm: 100 unique tiny modules per
  iteration (staged outside timing so the module cache never short-circuits),
  exports summed and verified. Guest ~40ms vs node ~2.4ms (17-20x) — the
  attribution row for the session tax.
- import_npm_package: real installed package (zod, 76 transitive module
  files) imported by a fresh process per iteration (same-process query-string
  busting only reloads the entry module, not the graph). Guest 163ms vs node
  39ms.
- import_fresh_file: moved from fs/module_import_fresh (the 0.3 regression
  row) into this family.
- native/wasm lanes explicitly unsupported (JS-runtime surface); per-op sample
  cap hook keeps default runs bounded (modules rows: 5 measured + 1 warmup).