### PR TITLE
test(benchmarks): two-tier sizes for payload-sensitive ops

### DIFF
--- a/crates/native-baseline/src/main.rs
+++ b/crates/native-baseline/src/main.rs
@@ -72,6 +72,11 @@ enum Op {
     AllocFree,
 }
 
+struct BenchConfig {
+    size_bytes: Option<usize>,
+    entry_count: Option<usize>,
+}
+
 impl Op {
     #[cfg(target_family = "wasm")]
     fn supported_on_wasm(self) -> bool {
@@ -128,7 +133,7 @@ fn elapsed_ns(timer: Timer) -> u128 {
     timer.system.elapsed().map(|d| d.as_nanos()).unwrap_or(0)
 }
 
-fn run_once(op: Op, iter: usize, base_dir: &Path) {
+fn run_once(op: Op, iter: usize, base_dir: &Path, config: &BenchConfig) {
     match op {
         #[cfg(not(target_family = "wasm"))]
         Op::SpawnExit => {
@@ -148,8 +153,11 @@ fn run_once(op: Op, iter: usize, base_dir: &Path) {
         }
         #[cfg(not(target_family = "wasm"))]
         Op::NodeStdoutDiscard2b => {
+            let size_bytes = config.size_bytes.unwrap_or(2);
+            let script = format!("process.stdout.write(Buffer.alloc({size_bytes}, 55))");
             let status = Command::new("node")
-                .args(["-e", "process.stdout.write('hi')"])
+                .arg("-e")
+                .arg(&script)
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
                 .status()
@@ -158,8 +166,11 @@ fn run_once(op: Op, iter: usize, base_dir: &Path) {
         }
         #[cfg(not(target_family = "wasm"))]
         Op::NodeStdoutCapture2b => {
+            let size_bytes = config.size_bytes.unwrap_or(2);
+            let script = format!("process.stdout.write(Buffer.alloc({size_bytes}, 55))");
             let out = Command::new("node")
-                .args(["-e", "process.stdout.write('hi')"])
+                .arg("-e")
+                .arg(&script)
                 .output()
                 .expect("spawn node failed");
             assert!(
@@ -167,12 +178,15 @@ fn run_once(op: Op, iter: usize, base_dir: &Path) {
                 "expected exit 0, got {:?}",
                 out.status
             );
-            assert_eq!(out.stdout, b"hi", "unexpected stdout");
+            assert_eq!(out.stdout.len(), size_bytes, "unexpected stdout byte count");
         }
         #[cfg(not(target_family = "wasm"))]
         Op::NodeStdoutListenerOnly2b => {
+            let size_bytes = config.size_bytes.unwrap_or(2);
+            let script = format!("process.stdout.write(Buffer.alloc({size_bytes}, 55))");
             let mut child = Command::new("node")
-                .args(["-e", "process.stdout.write('hi')"])
+                .arg("-e")
+                .arg(&script)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::null())
                 .spawn()
@@ -182,7 +196,7 @@ fn run_once(op: Op, iter: usize, base_dir: &Path) {
             stdout.read_to_end(&mut bytes).expect("read stdout");
             let status = child.wait().expect("wait node child");
             assert!(status.success(), "expected exit 0, got {status:?}");
-            assert_eq!(bytes.len(), 2, "unexpected stdout byte count");
+            assert_eq!(bytes.len(), size_bytes, "unexpected stdout byte count");
         }
         // Real host node process that immediately exits. This is the apples-to-apples
         // floor for the guest layer, where the same logical op spins a V8 isolate.
@@ -226,15 +240,23 @@ fn run_once(op: Op, iter: usize, base_dir: &Path) {
         }
         Op::FsWrite => {
             let path = base_dir.join("secure-exec-native-fs-write.txt");
-            std::fs::write(path, format!("hello-{iter:08}")).expect("write fixture");
+            if let Some(size_bytes) = config.size_bytes {
+                std::fs::write(path, vec![(iter & 255) as u8; size_bytes]).expect("write fixture");
+            } else {
+                std::fs::write(path, format!("hello-{iter:08}")).expect("write fixture");
+            }
         }
         Op::FsRead => {
+            let size_bytes = config.size_bytes.unwrap_or(64 * 1024);
             let path = base_dir.join("secure-exec-native-fs-read.bin");
-            if !path.exists() {
-                std::fs::write(&path, vec![7_u8; 64 * 1024]).expect("write read fixture");
+            let rewrite = std::fs::metadata(&path)
+                .map(|meta| meta.len() != size_bytes as u64)
+                .unwrap_or(true);
+            if rewrite {
+                std::fs::write(&path, vec![7_u8; size_bytes]).expect("write read fixture");
             }
             let data = std::fs::read(path).expect("read fixture");
-            assert_eq!(data.len(), 64 * 1024);
+            assert_eq!(data.len(), size_bytes);
         }
         Op::FsOpenClose => {
             let path = base_dir.join("secure-exec-native-fs-open-close.txt");
@@ -255,16 +277,17 @@ fn run_once(op: Op, iter: usize, base_dir: &Path) {
             std::fs::remove_file(&to).expect("remove rename fixture");
         }
         Op::FsReaddir => {
+            let entry_count = config.entry_count.unwrap_or(32);
             let dir = base_dir.join("secure-exec-native-readdir");
             std::fs::create_dir_all(&dir).expect("create readdir dir");
-            for i in 0..32 {
+            for i in 0..entry_count {
                 let path = dir.join(format!("{i}.txt"));
                 if !path.exists() {
                     std::fs::write(&path, b"hi").expect("write readdir fixture");
                 }
             }
             let count = std::fs::read_dir(dir).expect("read dir").count();
-            assert!(count >= 32);
+            assert!(count >= entry_count);
         }
         Op::FsFsync => {
             let path = base_dir.join("secure-exec-native-fsync.txt");
@@ -309,19 +332,21 @@ fn run_once(op: Op, iter: usize, base_dir: &Path) {
         }
         #[cfg(not(target_family = "wasm"))]
         Op::TcpEcho => {
+            let payload = vec![7_u8; config.size_bytes.unwrap_or(5)];
             let listener = TcpListener::bind("127.0.0.1:0").expect("bind tcp listener");
             let addr = listener.local_addr().expect("listener addr");
+            let expected_len = payload.len();
             let server = thread::spawn(move || {
                 let (mut stream, _) = listener.accept().expect("accept tcp echo");
-                let mut buf = [0_u8; 16];
-                let n = stream.read(&mut buf).expect("read tcp echo");
-                stream.write_all(&buf[..n]).expect("write tcp echo");
+                let mut buf = vec![0_u8; expected_len];
+                stream.read_exact(&mut buf).expect("read tcp echo");
+                stream.write_all(&buf).expect("write tcp echo");
             });
             let mut stream = TcpStream::connect(addr).expect("connect tcp echo");
-            stream.write_all(b"hello").expect("write client echo");
-            let mut buf = [0_u8; 5];
+            stream.write_all(&payload).expect("write client echo");
+            let mut buf = vec![0_u8; payload.len()];
             stream.read_exact(&mut buf).expect("read client echo");
-            assert_eq!(&buf, b"hello");
+            assert_eq!(buf, payload);
             server.join().expect("join tcp server");
         }
         #[cfg(not(target_family = "wasm"))]
@@ -346,7 +371,7 @@ fn run_once(op: Op, iter: usize, base_dir: &Path) {
         }
         #[cfg(not(target_family = "wasm"))]
         Op::TcpThroughput => {
-            let payload = vec![7_u8; 64 * 1024];
+            let payload = vec![7_u8; config.size_bytes.unwrap_or(64 * 1024)];
             let listener = TcpListener::bind("127.0.0.1:0").expect("bind tcp listener");
             let addr = listener.local_addr().expect("listener addr");
             let server = thread::spawn(move || {
@@ -382,18 +407,21 @@ fn run_once(op: Op, iter: usize, base_dir: &Path) {
         }
         #[cfg(not(target_family = "wasm"))]
         Op::UdpEcho => {
+            let payload = vec![7_u8; config.size_bytes.unwrap_or(5)];
             let server = UdpSocket::bind("127.0.0.1:0").expect("bind udp server");
             let addr = server.local_addr().expect("udp addr");
+            let expected_len = payload.len();
             let handle = thread::spawn(move || {
-                let mut buf = [0_u8; 32];
+                let mut buf = vec![0_u8; expected_len];
                 let (n, peer) = server.recv_from(&mut buf).expect("recv udp");
                 server.send_to(&buf[..n], peer).expect("send udp");
             });
             let client = UdpSocket::bind("127.0.0.1:0").expect("bind udp client");
-            client.send_to(b"hello", addr).expect("send udp client");
-            let mut buf = [0_u8; 5];
+            client.send_to(&payload, addr).expect("send udp client");
+            let mut buf = vec![0_u8; payload.len()];
             let (n, _) = client.recv_from(&mut buf).expect("recv udp client");
-            assert_eq!(n, 5);
+            assert_eq!(n, payload.len());
+            assert_eq!(buf, payload);
             handle.join().expect("join udp server");
         }
         #[cfg(not(target_family = "wasm"))]
@@ -409,7 +437,7 @@ fn run_once(op: Op, iter: usize, base_dir: &Path) {
             #[cfg(unix)]
             {
                 let (mut left, mut right) = UnixStream::pair().expect("unix stream pair");
-                let payload = vec![9_u8; 64 * 1024];
+                let payload = vec![9_u8; config.size_bytes.unwrap_or(64 * 1024)];
                 let expected_len = payload.len();
                 let reader = thread::spawn(move || {
                     let mut out = vec![0_u8; expected_len];
@@ -634,6 +662,10 @@ fn main() {
     } else {
         std::env::temp_dir()
     };
+    let config = BenchConfig {
+        size_bytes: arg_value(&args, "--size-bytes").and_then(|s| s.parse().ok()),
+        entry_count: arg_value(&args, "--entry-count").and_then(|s| s.parse().ok()),
+    };
     let phases = args.iter().any(|arg| arg == "--phases");
 
     let total = warmup + iters;
@@ -666,7 +698,7 @@ fn main() {
     let mut samples: Vec<u128> = Vec::with_capacity(iters);
     for i in 0..total {
         let t = timer_start();
-        run_once(op, i, &base_dir);
+        run_once(op, i, &base_dir, &config);
         let ns = elapsed_ns(t);
         if i >= warmup {
             samples.push(ns);

--- a/packages/benchmarks/README.md
+++ b/packages/benchmarks/README.md
@@ -117,16 +117,32 @@ The shell/coreutils focused lanes use the local `NodeRuntime` command-dir resolu
 
 Rows:
 
-- **`udp_echo_small`**: UDP loopback echo of one small datagram, currently expected to surface unsupported guest behavior.
-- **`unix_echo_small`**: Unix-domain socket echo of one small payload.
+- **`udp_echo_small` / `udp_echo_big`**: UDP loopback echo of one 16 byte datagram or one 60 KiB datagram, currently expected to surface unsupported guest behavior.
+- **`unix_echo_small` / `unix_echo_big`**: Unix-domain socket echo of one 16 byte or 64 KiB payload.
 - **`http_loopback_get`**: persistent `node:http` loopback server, fresh GET per iteration.
 - **`fetch_loopback_get`**: persistent HTTP loopback server, fresh global `fetch()` per iteration.
 - **`tls_loopback_get`**: persistent `node:https` loopback server, fresh `https.get` per iteration, verifies `hello-loopback-tls`. Native is unsupported until a native TLS-loopback pair exists, and WASM is unsupported because the native baseline has no TLS lane.
 - **`tcp_connect_close`**: TCP client connects to a loopback server and closes.
-- **`tcp_echo`**: TCP loopback echo of one small payload.
+- **`tcp_echo_small` / `tcp_echo_big`**: TCP loopback echo of one 16 byte or 64 KiB payload. The big tier carries forward the old throughput row's full-payload verification.
 - **`tcp_concurrent_4`**: four concurrent TCP loopback clients connect to one server.
-- **`tcp_throughput_64k`**: TCP loopback echo of one 64 KiB payload.
-- **`tcp_tiny_writes_16`**: TCP loopback echo using sixteen one-byte writes.
+- **`tcp_tiny_writes_16`**: TCP loopback echo using sixteen one-byte writes. This is a write-count/cadence row, not a payload-size tier.
+
+## Payload Tier Renames
+
+Payload-sensitive matrix rows use exactly two tiers named `<op>_small` and `<op>_big`. Retired names map to these successors:
+
+| Retired row | Successor row |
+| --- | --- |
+| `small_write` | `fs_write_small` |
+| `big_read` | `fs_read_big` |
+| `readdir_large` | `readdir_small` |
+| `stream_copy_1m` | `stream_copy_big` |
+| `tcp_echo` | `tcp_echo_small` |
+| `tcp_throughput_64k` | `tcp_echo_big` |
+| `unix_echo_small` | `unix_echo_small` (kept, added `unix_echo_big`) |
+| `udp_echo_small` | `udp_echo_small` (kept, added `udp_echo_big`) |
+| `throughput_64k` | `pass_through_big` |
+| `spawn_stdout_256k_capture` | `spawn_stdout_capture_big` |
 
 ## Permissions Family
 

--- a/packages/benchmarks/src/families/fs.ts
+++ b/packages/benchmarks/src/families/fs.ts
@@ -1,5 +1,92 @@
 import type { BenchmarkOp } from "../lib/layers.js";
 
+function fsWriteOp(name: string, sizeBytes: number): BenchmarkOp {
+	return {
+		family: "fs",
+		name,
+		nativeOp: "fs_write",
+		nativeArgs: ["--size-bytes", String(sizeBytes)],
+		fileLine: "crates/kernel/src/kernel.rs:1930",
+		reproducer: `node fs.writeFileSync('/tmp/fuzz-perf-write.txt', ${sizeBytes} byte payload)`,
+		program: `async (i) => {
+  const fs = await import("node:fs");
+  fs.writeFileSync("/tmp/fuzz-perf-write.txt", Buffer.alloc(${sizeBytes}, i & 255));
+}`,
+	};
+}
+
+function fsReadOp(name: string, sizeBytes: number): BenchmarkOp {
+	return {
+		family: "fs",
+		name,
+		nativeOp: "fs_read",
+		nativeArgs: ["--size-bytes", String(sizeBytes)],
+		fileLine: "crates/kernel/src/mount_table.rs:814",
+		reproducer: `node fs.readFileSync('/tmp/fuzz-perf-read-${sizeBytes}.bin')`,
+		program: `async () => {
+  const fs = await import("node:fs");
+  const path = "/tmp/fuzz-perf-read-${sizeBytes}.bin";
+  if (!fs.existsSync(path)) fs.writeFileSync(path, Buffer.alloc(${sizeBytes}, 7));
+  const data = fs.readFileSync(path);
+  if (data.length !== ${sizeBytes}) throw new Error("bad read: " + data.length);
+}`,
+	};
+}
+
+function readdirOp(name: string, entryCount: number): BenchmarkOp {
+	return {
+		family: "fs",
+		name,
+		nativeOp: "fs_readdir",
+		nativeArgs: ["--entry-count", String(entryCount)],
+		fileLine: "crates/kernel/src/mount_table.rs:814",
+		reproducer: `readdirSync over a ${entryCount}-entry VM directory`,
+		setup: `async () => {
+  const fs = await import("node:fs");
+  const dir = "/tmp/fuzz-perf-readdir-${entryCount}";
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir);
+  for (let i = 0; i < ${entryCount}; i++) {
+    const path = dir + "/" + i + ".txt";
+    if (!fs.existsSync(path)) fs.writeFileSync(path, "hi");
+  }
+}`,
+		program: `async () => {
+  const fs = await import("node:fs");
+  const dir = "/tmp/fuzz-perf-readdir-${entryCount}";
+  const entries = fs.readdirSync(dir);
+  if (entries.length < ${entryCount}) throw new Error("short readdir: " + entries.length);
+}`,
+	};
+}
+
+function streamCopyOp(name: string, sizeBytes: number): BenchmarkOp {
+	return {
+		family: "fs",
+		name,
+		// Phase 2 should add a native stream-copy op; fs_read is the closest current
+		// native/wasm stand-in for the payload size.
+		nativeOp: "fs_read",
+		nativeArgs: ["--size-bytes", String(sizeBytes)],
+		fileLine: "crates/kernel/src/mount_table.rs:814",
+		reproducer: `stream pipeline copies one ${sizeBytes} byte file inside VM`,
+		setup: `async () => {
+  const fs = await import("node:fs");
+  const src = "/tmp/fuzz-perf-stream-copy-src-${sizeBytes}.bin";
+  if (!fs.existsSync(src)) fs.writeFileSync(src, Buffer.alloc(${sizeBytes}, 7));
+}`,
+		program: `async (i) => {
+  const fs = await import("node:fs");
+  const { pipeline } = await import("node:stream/promises");
+  const src = "/tmp/fuzz-perf-stream-copy-src-${sizeBytes}.bin";
+  const dst = "/tmp/fuzz-perf-stream-copy-dst-${sizeBytes}-" + i + ".bin";
+  await pipeline(fs.createReadStream(src), fs.createWriteStream(dst));
+  const stat = fs.statSync(dst);
+  fs.unlinkSync(dst);
+  if (stat.size !== ${sizeBytes}) throw new Error("bad stream copy: " + stat.size);
+}`,
+	};
+}
+
 export const fsFamily: BenchmarkOp[] = [
 	{
 		family: "fs",
@@ -28,31 +115,10 @@ export const fsFamily: BenchmarkOp[] = [
   fs.statSync(path);
 }`,
 	},
-	{
-		family: "fs",
-		name: "small_write",
-		nativeOp: "fs_write",
-		fileLine: "crates/kernel/src/kernel.rs:1930",
-		reproducer: "node fs.writeFileSync('/tmp/fuzz-perf-write.txt', payload)",
-		program: `async (i) => {
-  const fs = await import("node:fs");
-  fs.writeFileSync("/tmp/fuzz-perf-write.txt", "hello-" + i);
-}`,
-	},
-	{
-		family: "fs",
-		name: "big_read",
-		nativeOp: "fs_read",
-		fileLine: "crates/kernel/src/mount_table.rs:814",
-		reproducer: "node fs.readFileSync('/tmp/fuzz-perf-read.bin')",
-		program: `async () => {
-  const fs = await import("node:fs");
-  const path = "/tmp/fuzz-perf-read.bin";
-  if (!fs.existsSync(path)) fs.writeFileSync(path, Buffer.alloc(64 * 1024, 7));
-  const data = fs.readFileSync(path);
-  if (data.length !== 64 * 1024) throw new Error("bad read");
-}`,
-	},
+	fsWriteOp("fs_write_small", 4 * 1024),
+	fsWriteOp("fs_write_big", 1024 * 1024),
+	fsReadOp("fs_read_small", 4 * 1024),
+	fsReadOp("fs_read_big", 1024 * 1024),
 	{
 		family: "fs",
 		name: "mkdir_rmdir",
@@ -81,28 +147,8 @@ export const fsFamily: BenchmarkOp[] = [
   fs.unlinkSync(to);
 }`,
 	},
-	{
-		family: "fs",
-		name: "readdir_large",
-		nativeOp: "fs_readdir",
-		fileLine: "crates/kernel/src/mount_table.rs:814",
-		reproducer: "readdirSync over a 32-entry VM directory",
-		setup: `async () => {
-  const fs = await import("node:fs");
-  const dir = "/tmp/fuzz-perf-readdir";
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir);
-  for (let i = 0; i < 32; i++) {
-    const path = dir + "/" + i + ".txt";
-    if (!fs.existsSync(path)) fs.writeFileSync(path, "hi");
-  }
-}`,
-		program: `async () => {
-  const fs = await import("node:fs");
-  const dir = "/tmp/fuzz-perf-readdir";
-  const entries = fs.readdirSync(dir);
-  if (entries.length < 32) throw new Error("short readdir");
-}`,
-	},
+	readdirOp("readdir_small", 32),
+	readdirOp("readdir_big", 1000),
 	{
 		family: "fs",
 		name: "fsync_small",
@@ -136,26 +182,6 @@ export const fsFamily: BenchmarkOp[] = [
   }
 }`,
 	},
-	{
-		family: "fs",
-		name: "stream_copy_1m",
-		nativeOp: "fs_read",
-		fileLine: "crates/kernel/src/mount_table.rs:814",
-		reproducer: "stream pipeline copies one 1MiB file inside VM",
-		setup: `async () => {
-  const fs = await import("node:fs");
-  const src = "/tmp/fuzz-perf-stream-copy-src.bin";
-  if (!fs.existsSync(src)) fs.writeFileSync(src, Buffer.alloc(1024 * 1024, 7));
-}`,
-		program: `async (i) => {
-  const fs = await import("node:fs");
-  const { pipeline } = await import("node:stream/promises");
-  const src = "/tmp/fuzz-perf-stream-copy-src.bin";
-  const dst = "/tmp/fuzz-perf-stream-copy-dst-" + i + ".bin";
-  await pipeline(fs.createReadStream(src), fs.createWriteStream(dst));
-  const stat = fs.statSync(dst);
-  fs.unlinkSync(dst);
-  if (stat.size !== 1024 * 1024) throw new Error("bad stream copy");
-}`,
-	},
+	streamCopyOp("stream_copy_small", 64 * 1024),
+	streamCopyOp("stream_copy_big", 1024 * 1024),
 ];

--- a/packages/benchmarks/src/families/net.ts
+++ b/packages/benchmarks/src/families/net.ts
@@ -15,6 +15,7 @@ const TLS_LOOPBACK_CERT = readFileSync(
 const TLS_LOOPBACK_BODY = "hello-loopback-tls";
 const EXTERNAL_HTTP_BODY = "external-host-http-ok";
 const EXTERNAL_TCP_PAYLOAD = "external-tcp-echo";
+const UDP_BIG_BYTES = 60 * 1024;
 
 async function closeServer(server: http.Server | net.Server): Promise<void> {
 	await new Promise<void>((resolve, reject) => {
@@ -287,15 +288,17 @@ try {
 `;
 }
 
-export const netFamily: BenchmarkOp[] = [
-	{
+function udpEchoOp(name: string, sizeBytes: number): BenchmarkOp {
+	return {
 		family: "net",
-		name: "udp_echo_small",
+		name,
 		nativeOp: "udp_echo",
+		nativeArgs: ["--size-bytes", String(sizeBytes)],
 		fileLine: "crates/sidecar/src/execution.rs:2712",
-		reproducer: "node:dgram udp4 socket sends hello to its own loopback address inside VM",
+		reproducer: `node:dgram udp4 socket sends one ${sizeBytes} byte datagram to its own loopback address inside VM`,
 		program: `async () => {
   const dgram = await import("node:dgram");
+  const payload = Buffer.alloc(${sizeBytes}, 7);
   const createSocket = dgram.createSocket ?? dgram.default?.createSocket;
   if (typeof createSocket !== "function") throw new Error("dgram.createSocket is not a function");
   await new Promise((resolve, reject) => {
@@ -305,32 +308,46 @@ export const netFamily: BenchmarkOp[] = [
       reject(error);
     });
     socket.on("message", (message) => {
-      socket.close(() => message.toString("utf8") === "hello" ? resolve() : reject(new Error("bad udp echo")));
+      socket.close(() => message.equals(payload) ? resolve() : reject(new Error("bad udp echo: " + message.length)));
     });
     socket.bind(0, "127.0.0.1", () => {
       const address = socket.address();
-      socket.send(Buffer.from("hello"), address.port, "127.0.0.1");
+      socket.send(payload, address.port, "127.0.0.1");
     });
   });
 }`,
-	},
-	{
+	};
+}
+
+function unixEchoOp(name: string, sizeBytes: number): BenchmarkOp {
+	return {
 		family: "net",
-		name: "unix_echo_small",
-		nativeOp: "tcp_echo",
+		name,
+		// Phase 2 should add a Unix-socket native op; TCP echo is the closest
+		// existing native baseline for the same payload shape.
+		nativeOp: sizeBytes > 16 ? "tcp_throughput" : "tcp_echo",
+		nativeArgs: ["--size-bytes", String(sizeBytes)],
 		fileLine: "crates/sidecar/src/execution.rs:2237",
-		reproducer: "Unix-domain socket echo one small payload inside VM",
+		reproducer: `Unix-domain socket echo one ${sizeBytes} byte payload inside VM`,
 		program: `async () => {
   const fs = await import("node:fs");
   const net = await import("node:net");
   const os = await import("node:os");
   const path = await import("node:path");
+  const payload = Buffer.alloc(${sizeBytes}, 7);
   const sock = path.join(
     os.tmpdir(),
     "fuzz-perf-unix-echo-" + process.pid + "-" + Math.random().toString(16).slice(2) + ".sock",
   );
   await new Promise((resolve, reject) => {
-    const server = net.createServer((socket) => socket.on("data", (data) => socket.end(data)));
+    const server = net.createServer((socket) => {
+      const chunks = [];
+      socket.on("data", (data) => {
+        chunks.push(data);
+        const got = Buffer.concat(chunks);
+        if (got.length >= payload.length) socket.end(got);
+      });
+    });
     const cleanup = () => {
       try { fs.unlinkSync(sock); } catch {}
     };
@@ -344,17 +361,62 @@ export const netFamily: BenchmarkOp[] = [
       client.on("data", (data) => chunks.push(data));
       client.on("error", reject);
       client.on("close", () => {
-        const got = Buffer.concat(chunks).toString("utf8");
+        const got = Buffer.concat(chunks);
         server.close(() => {
           cleanup();
-          got === "hello" ? resolve() : reject(new Error("bad unix echo"));
+          got.equals(payload) ? resolve() : reject(new Error("bad unix echo: " + got.length));
         });
       });
-      client.write("hello");
+      client.write(payload);
     });
   });
 }`,
-	},
+	};
+}
+
+function tcpEchoOp(name: string, sizeBytes: number, nativeOp: "tcp_echo" | "tcp_throughput"): BenchmarkOp {
+	return {
+		family: "net",
+		name,
+		nativeOp,
+		nativeArgs: ["--size-bytes", String(sizeBytes)],
+		fileLine: "crates/kernel/src/socket_table.rs:1413",
+		reproducer: `localhost TCP echo of one ${sizeBytes} byte payload inside VM`,
+		program: `async () => {
+  const net = await import("node:net");
+  const payload = Buffer.alloc(${sizeBytes}, 7);
+  await new Promise((resolve, reject) => {
+    const server = net.createServer((socket) => {
+      const chunks = [];
+      socket.on("data", (d) => {
+        chunks.push(d);
+        const got = Buffer.concat(chunks);
+        if (got.length >= payload.length) socket.end(got);
+      });
+    });
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      const socket = net.connect(port, "127.0.0.1");
+      const chunks = [];
+      socket.on("data", (d) => chunks.push(d));
+      socket.on("error", reject);
+      socket.on("close", () => {
+        const got = Buffer.concat(chunks);
+        server.close(() => got.equals(payload) ? resolve() : reject(new Error("short echo: " + got.length)));
+      });
+      socket.write(payload);
+    });
+  });
+}`,
+	};
+}
+
+export const netFamily: BenchmarkOp[] = [
+	udpEchoOp("udp_echo_small", 16),
+	udpEchoOp("udp_echo_big", UDP_BIG_BYTES),
+	unixEchoOp("unix_echo_small", 16),
+	unixEchoOp("unix_echo_big", 64 * 1024),
 	{
 		family: "net",
 		name: "http_loopback_get",
@@ -513,31 +575,7 @@ export const netFamily: BenchmarkOp[] = [
   });
 }`,
 	},
-	{
-		family: "net",
-		name: "tcp_echo",
-		nativeOp: "tcp_echo",
-		fileLine: "crates/kernel/src/socket_table.rs:1413",
-		reproducer: "localhost TCP echo one small payload inside VM",
-		program: `async () => {
-  const net = await import("node:net");
-  await new Promise((resolve, reject) => {
-    const server = net.createServer((socket) => socket.on("data", (d) => socket.end(d)));
-    server.on("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      const port = server.address().port;
-      const socket = net.connect(port, "127.0.0.1");
-      let data = "";
-      socket.on("data", (d) => data += d.toString("utf8"));
-      socket.on("error", reject);
-      socket.on("close", () => {
-        server.close(() => data === "hello" ? resolve() : reject(new Error(data)));
-      });
-      socket.write("hello");
-    });
-	  });
-}`,
-	},
+	tcpEchoOp("tcp_echo_small", 16, "tcp_echo"),
 	{
 		family: "net",
 		name: "tcp_external_echo",
@@ -590,34 +628,9 @@ export const netFamily: BenchmarkOp[] = [
   });
 }`,
 	},
+	tcpEchoOp("tcp_echo_big", 64 * 1024, "tcp_throughput"),
 	{
-		family: "net",
-		name: "tcp_throughput_64k",
-		nativeOp: "tcp_throughput",
-		fileLine: "crates/kernel/src/socket_table.rs:1413",
-		reproducer: "localhost TCP echo of one 64KiB payload inside VM",
-		program: `async () => {
-  const net = await import("node:net");
-  const payload = Buffer.alloc(64 * 1024, 7);
-  await new Promise((resolve, reject) => {
-    const server = net.createServer((socket) => socket.on("data", (d) => socket.end(d)));
-    server.on("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      const port = server.address().port;
-      const socket = net.connect(port, "127.0.0.1");
-      const chunks = [];
-      socket.on("data", (d) => chunks.push(d));
-      socket.on("error", reject);
-      socket.on("close", () => {
-        const got = Buffer.concat(chunks);
-        server.close(() => got.length === payload.length ? resolve() : reject(new Error("short echo")));
-      });
-      socket.write(payload);
-    });
-  });
-}`,
-	},
-	{
+		// Measures write count/cadence, not payload-size scaling; keep the count suffix.
 		family: "net",
 		name: "tcp_tiny_writes_16",
 		nativeOp: "tcp_tiny_writes",

--- a/packages/benchmarks/src/families/permissions.ts
+++ b/packages/benchmarks/src/families/permissions.ts
@@ -4,8 +4,8 @@ import { netFamily } from "./net.js";
 import type { BenchmarkOp } from "../lib/layers.js";
 
 const PERMISSION_OPS = [
-	...selectOps(fsFamily, ["small_write", "stat_storm", "readdir_large"]),
-	...selectOps(netFamily, ["tcp_echo", "http_loopback_get"]),
+	...selectOps(fsFamily, ["fs_write_small", "stat_storm", "readdir_small"]),
+	...selectOps(netFamily, ["tcp_echo_small", "http_loopback_get"]),
 ];
 
 // Policy shape under test:
@@ -33,8 +33,8 @@ export const restrictivePermissionsPolicy: NodeRuntimeCreateOptions["permissions
 			{ mode: "allow", operations: ["*"], paths: ["/tmp/fuzz-perf-permissions-*.mjs"] },
 			{ mode: "allow", operations: ["*"], paths: ["/tmp/fuzz-perf-write.txt"] },
 			{ mode: "allow", operations: ["*"], paths: ["/tmp/fuzz-perf-stat.txt"] },
-			{ mode: "allow", operations: ["*"], paths: ["/tmp/fuzz-perf-readdir"] },
-			{ mode: "allow", operations: ["*"], paths: ["/tmp/fuzz-perf-readdir/**"] },
+			{ mode: "allow", operations: ["*"], paths: ["/tmp/fuzz-perf-readdir-*"] },
+			{ mode: "allow", operations: ["*"], paths: ["/tmp/fuzz-perf-readdir-*/**"] },
 		],
 	},
 	network: {

--- a/packages/benchmarks/src/families/pipes.ts
+++ b/packages/benchmarks/src/families/pipes.ts
@@ -1,45 +1,35 @@
 import type { BenchmarkOp } from "../lib/layers.js";
 
-export const pipesFamily: BenchmarkOp[] = [
-	{
+function passThroughOp(name: string, sizeBytes: number): BenchmarkOp {
+	return {
 		family: "pipes",
-		name: "pass_through_small",
-		nativeOp: "pipe_echo",
+		name,
+		nativeOp: sizeBytes > 16 ? "pipe_throughput" : "pipe_echo",
+		nativeArgs: sizeBytes > 16 ? ["--size-bytes", String(sizeBytes)] : undefined,
 		fileLine: "crates/v8-runtime/src/host_call.rs:276",
-		reproducer: "node PassThrough write/read small payload inside VM",
+		reproducer: `node PassThrough write/read one ${sizeBytes} byte payload inside VM`,
 		program: `async () => {
   const { PassThrough } = await import("node:stream");
-  await new Promise((resolve, reject) => {
-    const stream = new PassThrough();
-    let out = "";
-    stream.on("data", (d) => out += d.toString("utf8"));
-    stream.on("end", () => out === "hello" ? resolve() : reject(new Error(out)));
-    stream.end("hello");
-  });
-}`,
-	},
-	{
-		family: "pipes",
-		name: "throughput_64k",
-		nativeOp: "pipe_throughput",
-		fileLine: "crates/v8-runtime/src/host_call.rs:276",
-		reproducer: "node PassThrough write/read one 64KiB payload inside VM",
-		program: `async () => {
-  const { PassThrough } = await import("node:stream");
-  const payload = Buffer.alloc(64 * 1024, 9);
+  const payload = Buffer.alloc(${sizeBytes}, 9);
   await new Promise((resolve, reject) => {
     const stream = new PassThrough();
     const chunks = [];
     stream.on("data", (d) => chunks.push(d));
     stream.on("end", () => {
       const got = Buffer.concat(chunks);
-      got.length === payload.length ? resolve() : reject(new Error("short pipe"));
+      got.equals(payload) ? resolve() : reject(new Error("bad pipe: " + got.length));
     });
     stream.end(payload);
   });
 }`,
-	},
+	};
+}
+
+export const pipesFamily: BenchmarkOp[] = [
+	passThroughOp("pass_through_small", 16),
+	passThroughOp("pass_through_big", 64 * 1024),
 	{
+		// Measures backpressure shape and chunk count, not payload-size scaling.
 		family: "pipes",
 		name: "backpressure_chunks",
 		nativeOp: "pipe_backpressure",

--- a/packages/benchmarks/src/families/process.ts
+++ b/packages/benchmarks/src/families/process.ts
@@ -140,6 +140,31 @@ async function runGuestFanout(vm: Parameters<NonNullable<BenchmarkOp["runGuest"]
 	return samples;
 }
 
+function spawnStdoutCaptureOp(name: string, sizeBytes: number): BenchmarkOp {
+	return {
+		family: "process",
+		name,
+		nativeOp: "node_stdout_capture_2b",
+		nativeArgs: ["--size-bytes", String(sizeBytes)],
+		fileLine: "crates/execution/src/v8_host.rs:296",
+		reproducer: `spawn node child writing ${sizeBytes} stdout bytes, capture and verify byte count`,
+		program: `async () => {
+  const { spawn } = await import("node:child_process");
+  const child = spawn("node", ["-e", "process.stdout.write(Buffer.alloc(${sizeBytes}, 55))"], {
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  const chunks = [];
+  child.stdout.on("data", (chunk) => chunks.push(chunk));
+  await new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code) => code === 0 ? resolve() : reject(new Error("exit " + code)));
+  });
+  const got = Buffer.concat(chunks);
+  if (got.length !== ${sizeBytes}) throw new Error("stdout byte mismatch: " + got.length);
+}`,
+	};
+}
+
 export const processFamily: BenchmarkOp[] = [
 	{
 		family: "process",
@@ -218,27 +243,8 @@ export const processFamily: BenchmarkOp[] = [
   if (Buffer.concat(chunks).toString("utf8") !== "hello") throw new Error("bad pipe chain");
 }`,
 	},
-	{
-		family: "process",
-		name: "spawn_stdout_256k_capture",
-		nativeOp: "exec_capture",
-		fileLine: "crates/execution/src/v8_host.rs:296",
-		reproducer: "spawn node child writing 256KiB stdout, capture and verify byte count",
-		program: `async () => {
-  const { spawn } = await import("node:child_process");
-  const child = spawn("node", ["-e", "process.stdout.write(Buffer.alloc(262144, 55))"], {
-    stdio: ["ignore", "pipe", "ignore"],
-  });
-  const chunks = [];
-  child.stdout.on("data", (chunk) => chunks.push(chunk));
-  await new Promise((resolve, reject) => {
-    child.on("error", reject);
-    child.on("close", (code) => code === 0 ? resolve() : reject(new Error("exit " + code)));
-  });
-  const got = Buffer.concat(chunks);
-  if (got.length !== 262144) throw new Error("stdout byte mismatch: " + got.length);
-}`,
-	},
+	spawnStdoutCaptureOp("spawn_stdout_capture_small", 4 * 1024),
+	spawnStdoutCaptureOp("spawn_stdout_capture_big", 256 * 1024),
 	{
 		family: "process",
 		name: "spawn_stdin_roundtrip",

--- a/packages/benchmarks/src/focused/net-tcp-event-floor.bench.ts
+++ b/packages/benchmarks/src/focused/net-tcp-event-floor.bench.ts
@@ -23,9 +23,9 @@ type CostAxis =
 	| "concurrency";
 type CompletionSemantics = "client_close" | "listener_close_after_accept";
 type BroadEquivalent =
-	| "tcp_echo"
+	| "tcp_echo_small"
 	| "tcp_tiny_writes_16"
-	| "tcp_throughput_64k"
+	| "tcp_echo_big"
 	| "tcp_concurrent_4"
 	| "tcp_connect_close";
 type PayloadKind = "buffer" | "string";
@@ -149,7 +149,7 @@ function defaultRows(): NetTcpRow[] {
 			writeCadence: "burstSameTick",
 			costAxis: "broad",
 			completionSemantics: "client_close",
-			broadMatrixEquivalent: "tcp_echo",
+			broadMatrixEquivalent: "tcp_echo_small",
 		},
 		{
 			id: "echo_1x5_string",
@@ -162,7 +162,7 @@ function defaultRows(): NetTcpRow[] {
 			costAxis: "payload_copy",
 			compareAgainst: "echo_1x5",
 			completionSemantics: "client_close",
-			broadMatrixEquivalent: "tcp_echo",
+			broadMatrixEquivalent: "tcp_echo_small",
 			payloadKind: "string",
 		},
 		{
@@ -199,7 +199,7 @@ function defaultRows(): NetTcpRow[] {
 			costAxis: "broad",
 			compareAgainst: "echo_1x1",
 			completionSemantics: "client_close",
-			broadMatrixEquivalent: "tcp_throughput_64k",
+			broadMatrixEquivalent: "tcp_echo_big",
 		},
 		{
 			id: "echo_1x256k",

--- a/packages/benchmarks/src/focused/readdir.bench.ts
+++ b/packages/benchmarks/src/focused/readdir.bench.ts
@@ -1,7 +1,7 @@
 /**
  * Focused readdir scaling benchmark.
  *
- * Matches fs/readdir_large by preparing fixtures outside the timed loop so the
+ * Matches fs/readdir_small by preparing fixtures outside the timed loop so the
  * measurement isolates fs.readdirSync cost.
  */
 

--- a/packages/benchmarks/src/lib/layers.ts
+++ b/packages/benchmarks/src/lib/layers.ts
@@ -70,6 +70,7 @@ export interface BenchmarkOp {
 	family: string;
 	name: string;
 	nativeOp?: NativeOp;
+	nativeArgs?: string[];
 	nativeUnsupportedReason?: string;
 	wasmUnsupportedReason?: string;
 	fileLine: string;
@@ -360,6 +361,7 @@ export async function runWasmLayer(
 	nativeOp: NativeOp,
 	iters: number,
 	warmup: number,
+	extraArgs: string[] = [],
 ): Promise<number[] | undefined> {
 	if (!supportsWasmLayer(nativeOp)) return undefined;
 	if (!resolveNativeBaselineWasm()) return undefined;
@@ -376,6 +378,7 @@ export async function runWasmLayer(
 		String(warmup),
 		"--base-dir",
 		guestBaseDir,
+		...extraArgs,
 	]);
 	if (result.exitCode !== 0) {
 		throw new Error(`wasm native-baseline ${nativeOp} exited ${result.exitCode}\n${result.stderr}`);
@@ -411,7 +414,7 @@ export async function runOpHostLayers(
 	warmup: number,
 ): Promise<OpHostSamples> {
 	const native = op.nativeOp
-		? await runNativeLayerMeasured(op.nativeOp, iters, warmup)
+		? await runNativeLayerMeasured(op.nativeOp, iters, warmup, op.nativeArgs)
 		: undefined;
 	const node = op.runNode
 		? { samples: await op.runNode(iters, warmup) }
@@ -448,7 +451,7 @@ export async function runOpVmLayers(
 	const wasm =
 		op.nativeOp && !op.wasmUnsupportedReason
 			? await measureOptionalWithSidecarPeak(sampler, () =>
-					runWasmLayer(vm, op.nativeOp!, iters, warmup),
+					runWasmLayer(vm, op.nativeOp!, iters, warmup, op.nativeArgs),
 				)
 			: undefined;
 	return {

--- a/packages/benchmarks/src/lib/native.ts
+++ b/packages/benchmarks/src/lib/native.ts
@@ -52,11 +52,12 @@ export function runNativeLayer(
 	op: NativeOp,
 	iters: number,
 	warmup: number,
+	extraArgs: string[] = [],
 ): number[] {
 	const bin = resolveNativeBaselineBin();
 	const stdout = execFileSync(
 		bin,
-		["--op", op, "--iters", String(iters), "--warmup", String(warmup)],
+		["--op", op, "--iters", String(iters), "--warmup", String(warmup), ...extraArgs],
 		{ encoding: "utf8", maxBuffer: 128 * 1024 * 1024 },
 	);
 	return parseNativeSamples(stdout);
@@ -71,9 +72,10 @@ export async function runNativeLayerMeasured(
 	op: NativeOp,
 	iters: number,
 	warmup: number,
+	extraArgs: string[] = [],
 ): Promise<NativeLayerMeasurement> {
 	const bin = resolveNativeBaselineBin();
-	const args = ["--op", op, "--iters", String(iters), "--warmup", String(warmup)];
+	const args = ["--op", op, "--iters", String(iters), "--warmup", String(warmup), ...extraArgs];
 	const timed =
 		hostPeakMemorySupportReason() === undefined
 			? await runCommandWithMaxRss(bin, args)

--- a/packages/benchmarks/src/run-all.ts
+++ b/packages/benchmarks/src/run-all.ts
@@ -167,7 +167,7 @@ async function main(): Promise<void> {
 			...fuzz.refuted,
 			{
 				family: "net",
-				op: "udp_echo",
+				op: "udp_echo_small",
 				reason: "guest UDP datagrams are unsupported in the current kernel-backed V8 bridge",
 				evidence: "ERR_NOT_IMPLEMENTED: external UDP datagrams are not yet supported by the kernel-backed V8 bridge",
 			},
@@ -410,7 +410,7 @@ function criticGaps(
 	for (const required of [
 		"process/fanout_spawn_8",
 		"process/wait_reap_storm_8",
-		"fs/readdir_large",
+		"fs/readdir_small",
 		"dns/resolve_concurrent_4",
 		"pipes/backpressure_chunks",
 		"control/cpu_loop",
@@ -418,7 +418,7 @@ function criticGaps(
 		if (!covered.has(required)) gaps.push(`missing fixed op ${required}`);
 	}
 	gaps.push(
-		"unsupported fixed op net/udp_echo: guest dgram send returns ERR_NOT_IMPLEMENTED for external UDP datagrams",
+		"unsupported fixed op net/udp_echo_small: guest dgram send returns ERR_NOT_IMPLEMENTED for external UDP datagrams",
 	);
 	if (!fuzz.findings.some((finding) => finding.op === "fanout-stdout-storm")) {
 		gaps.push("fuzz did not confirm the non-P2 stdout fanout slow path");


### PR DESCRIPTION
Normalizes the size-variant zoo into exactly two tiers per payload-sensitive
op, named <op>_small/<op>_big (fs read/write 4KiB/1MiB, socket echo 16B/64KiB,
readdir 32/1000 entries, stream copy 64KiB/1MiB, spawn capture, pass-through),
63 -> 70 matrix ops. Count/shape ops (tcp_tiny_writes_16, backpressure_chunks)
keep their names with clarifying comments. Renames are tabled in the README
(small_write->fs_write_small, big_read->fs_read_big, readdir_large->
readdir_small, stream_copy_1m->stream_copy_big, tcp_echo->tcp_echo_small,
tcp_throughput_64k->tcp_echo_big, throughput_64k->pass_through_big,
spawn_stdout_256k_capture->spawn_stdout_capture_big); native-baseline gained
the size knobs the new tiers needed, with three explicitly-commented borrowed
stand-ins left for Phase 2 (native stream-copy, unix echo). Baseline
continuity intentionally breaks here; 1.7 regenerates on the canonical
environment.