### PR TITLE
test(benchmarks): canonical baseline and CI bench gate

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,91 @@
+name: Bench
+
+on:
+  pull_request:
+    paths:
+      - "crates/**"
+      - "packages/**"
+  schedule:
+    - cron: "17 9 * * *"
+  workflow_dispatch:
+
+jobs:
+  gate:
+    name: Bench gate
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+
+      - name: Enable pnpm
+        run: corepack enable
+
+      - name: Install benchmark workspace dependencies
+        run: pnpm install --frozen-lockfile --filter "@secure-exec/benchmarks..."
+
+      - name: Build release benchmark binaries
+        run: |
+          cargo build --release -p secure-exec-sidecar
+          cargo build --release -p native-baseline
+          cargo build --release -p native-baseline --target wasm32-wasip1
+
+      - name: Run quick benchmark gate
+        env:
+          SECURE_EXEC_SIDECAR_BIN: ${{ github.workspace }}/target/release/secure-exec-sidecar
+        run: pnpm --dir packages/benchmarks bench:gate
+
+  nightly:
+    name: Nightly benchmark matrix
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+
+      - name: Enable pnpm
+        run: corepack enable
+
+      - name: Install benchmark workspace dependencies
+        run: pnpm install --frozen-lockfile --filter "@secure-exec/benchmarks..."
+
+      - name: Build release benchmark binaries
+        run: |
+          cargo build --release -p secure-exec-sidecar
+          cargo build --release -p native-baseline
+          cargo build --release -p native-baseline --target wasm32-wasip1
+
+      - name: Run full benchmark matrix
+        env:
+          SECURE_EXEC_SIDECAR_BIN: ${{ github.workspace }}/target/release/secure-exec-sidecar
+        run: pnpm --dir packages/benchmarks bench:matrix
+
+      - name: Write CI candidate baseline
+        env:
+          SECURE_EXEC_SIDECAR_BIN: ${{ github.workspace }}/target/release/secure-exec-sidecar
+        run: pnpm --dir packages/benchmarks bench:baseline -- --ci --from packages/benchmarks/results/latency-matrix.json
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-benchmark-results
+          path: |
+            packages/benchmarks/results/latency-matrix.json
+            packages/benchmarks/results/findings.json
+            packages/benchmarks/results/baseline-ci.json

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,8 @@ crates/execution/async-out.txt
 crates/sidecar/.tmp-sidecar-tests/
 packages/browser/.cache/
 packages/benchmarks/results/*
+!packages/benchmarks/results/baseline-local.json
+!packages/benchmarks/results/baseline-ci.json
 website/.astro/
 website/public/docs/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Every bound that protects a shared resource — memory/heap, CPU/wall-clock, fd/
 - **Clock discipline:** guest clocks are 1ms-quantized by default for security. Bench VMs opt in to `jsRuntime.highResolutionTime`, or the op must amplify by call count.
 - **Unsupported cells:** unsupported lane/op cells are explicit and never silently dropped.
 - **Baselines:** regenerate baselines only on a canonical environment, with hardware and dependency metadata recorded.
+- **Bench gate:** `packages/benchmarks/results/baseline-local.json` is the canonical-machine baseline; `baseline-ci.json` is GitHub-runner-specific and bootstrapped from the nightly artifact before PR gates enforce it.
 - **Merge rule:** a perf fix whose row does not move gets reverted, matching the Performance section.
 - **Keep them current:** the benches are a maintained surface, not a one-off audit. New runtime surface (a syscall, a polyfill module, an executor capability, a registry command tier) needs a matrix op or focused lane in the same change or a filed follow-up; perf-relevant changes to existing surface must re-run the affected rows and update coverage when the shape changes (new lanes, renamed ops). If a bench stops compiling or a lane can no longer run, fix or explicitly skip it with a reason — never delete coverage silently.
 - **Agent OS boundary:** agent-os keeps product-surface benches only (session tax, ACP) and consumes this framework.

--- a/packages/benchmarks/README.md
+++ b/packages/benchmarks/README.md
@@ -58,6 +58,59 @@ Run one matrix op:
 BENCH_FAMILIES=net BENCH_OP_FILTER=tls_loopback_get pnpm --dir packages/benchmarks bench:matrix
 ```
 
+## Baseline And PR Gate
+
+The committed local baseline is `packages/benchmarks/results/baseline-local.json`. It is generated from the full 70-row latency matrix and records:
+
+- **Hardware**: `getHardware()` output for the canonical machine.
+- **Sidecar provenance**: binary path, inferred profile, mtime, and size.
+- **Engine defaults**: iterations, warmup, cold/shared-VM mode, and row count.
+- **Rows**: per-row lane p50 values and memory columns where available.
+
+Regenerate it only from a release sidecar on the canonical machine:
+
+```bash
+pnpm install --frozen-lockfile --filter "@secure-exec/benchmarks..."
+cargo build --release -p secure-exec-sidecar
+cargo build --release -p native-baseline
+cargo build --release -p native-baseline --target wasm32-wasip1
+SECURE_EXEC_SIDECAR_BIN="$PWD/target/release/secure-exec-sidecar" \
+	pnpm --dir packages/benchmarks bench:baseline
+```
+
+`bench:baseline` refuses debug sidecars and refuses filtered matrix runs. A complete baseline has `engine.rowCount = 70`.
+
+`pnpm --dir packages/benchmarks bench:gate` runs the deterministic PR subset with 9 measured iterations and 3 warmup iterations, then compares p50 against the baseline:
+
+- **Threshold**: fail when current p50 is greater than `2.0x` the baseline p50. Override with `BENCH_GATE_THRESHOLD`.
+- **Tiny-row floor**: rows with baseline p50 below `0.3ms` are ignored unless current p50 reaches at least `1ms`, so sub-millisecond timer noise does not flap the gate.
+- **Row override**: use `BENCH_GATE_ROWS=family/op[:lane],...` to run a smaller or different subset.
+- **Release-only**: the gate exits `2` if `SECURE_EXEC_SIDECAR_BIN` resolves to a debug sidecar.
+
+Gate rows:
+
+| Row | Lane | Why it is gated |
+| --- | --- | --- |
+| `fs/fs_write_small` | `guest` | Tiny sync write hot path, with the 1ms tiny-row floor. |
+| `fs/fs_write_big` | `guest` | Large write payload catches whole-buffer copy regressions. |
+| `fs/fs_read_small` | `guest` | Small read bridge/VFS floor. |
+| `fs/stat_storm` | `guest` | Metadata syscall hot path. |
+| `fs/readdir_small` | `guest` | Directory enumeration without the high variance of large listings. |
+| `net/tcp_connect_close` | `guest` | TCP socket lifecycle floor. |
+| `net/tcp_echo_small` | `guest` | Small TCP payload round trip. |
+| `net/http_loopback_get` | `guest` | HTTP over kernel sockets with a loopback server. |
+| `modules/import_fresh_file` | `guest` | Dynamic import and filesystem resolution. |
+| `modules/require_100_small` | `guest` | CommonJS resolver/cache behavior. |
+| `control/cpu_loop` | `wasm` | WASM runtime lane sanity check. |
+| `ecosystem/ls_100` | `vmCmd` | End-to-end WASM command tier. |
+
+The CI baseline is environment-specific because GitHub-hosted runner hardware differs from the canonical machine. In CI, `bench:gate` uses `packages/benchmarks/results/baseline-ci.json`. If it is missing, PR gates skip loudly. The nightly workflow runs the full matrix, writes a candidate `baseline-ci.json`, and uploads it as an artifact. Bootstrap is:
+
+1. Let the first nightly workflow finish.
+2. Download `baseline-ci.json` from the `nightly-benchmark-results` artifact.
+3. Commit it at `packages/benchmarks/results/baseline-ci.json`.
+4. Future PRs enforce the quick gate against that CI baseline.
+
 ### Latency Matrix VM Lifecycle
 
 The latency matrix gives each guest-backed benchmark op a dedicated sidecar and VM by default. Host-only lanes (`native`, `node`, and `hostCmd`) run before that VM is created; guest-backed lanes (`guest`, `wasm`, and `vmCmd`) run inside the op's VM, which is disposed before the next op.

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -5,6 +5,8 @@
 	"scripts": {
 		"bench": "./run-benchmarks.sh",
 		"bench:coldstart": "tsx coldstart.bench.ts",
+		"bench:baseline": "tsx src/baseline.ts",
+		"bench:gate": "tsx src/quick-gate.ts",
 		"bench:memory": "node --expose-gc --import tsx/esm memory.bench.ts",
 		"bench:matrix": "tsx src/run-all.ts",
 		"check-types": "pnpm --dir ../core build && tsc --noEmit"

--- a/packages/benchmarks/results/baseline-local.json
+++ b/packages/benchmarks/results/baseline-local.json
@@ -1,0 +1,1865 @@
+{
+  "schemaVersion": 1,
+  "kind": "local",
+  "generatedAt": "2026-07-02T06:51:37.933-07:00",
+  "hardware": {
+    "cpu": "12th Gen Intel(R) Core(TM) i7-12700KF",
+    "cores": 20,
+    "ram": "62.6 GB",
+    "node": "v24.17.0",
+    "os": "Linux 6.1.0-41-amd64",
+    "arch": "x64"
+  },
+  "sidecar": {
+    "path": "/home/nathan/.herdr/workspaces/agent-os/secure-exec-perf-rules/target/release/secure-exec-sidecar",
+    "profile": "release",
+    "mtimeMs": 1782991959165.789,
+    "mtimeIso": "2026-07-02T04:32:39.166-07:00",
+    "sizeBytes": 114963696
+  },
+  "engine": {
+    "iterations": 20,
+    "warmup": 5,
+    "cold": false,
+    "sharedVm": false,
+    "rowCount": 70
+  },
+  "rows": [
+    {
+      "key": "process/node_exit",
+      "family": "process",
+      "op": "node_exit",
+      "lanes": {
+        "native": {
+          "p50Ms": 14.64,
+          "memBytes": 1163264,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 15.26
+        },
+        "guest": {
+          "p50Ms": 16.24,
+          "memBytes": 33124352,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 1.06,
+        "total": 1.11,
+        "mem": 28.48
+      }
+    },
+    {
+      "key": "process/node_stdout_discard_2b",
+      "family": "process",
+      "op": "node_stdout_discard_2b",
+      "lanes": {
+        "native": {
+          "p50Ms": 15.45,
+          "memBytes": 1101824,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 17.54
+        },
+        "guest": {
+          "p50Ms": 15.12,
+          "memBytes": 33173504,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 0.86,
+        "total": 0.98,
+        "mem": 30.11
+      }
+    },
+    {
+      "key": "process/exec_capture",
+      "family": "process",
+      "op": "exec_capture",
+      "lanes": {
+        "native": {
+          "p50Ms": 16.47,
+          "memBytes": 1163264,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 17.26
+        },
+        "guest": {
+          "p50Ms": 29.41,
+          "memBytes": 33366016,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 1.7,
+        "total": 1.79,
+        "mem": 28.68
+      }
+    },
+    {
+      "key": "process/node_stdout_listener_only_2b",
+      "family": "process",
+      "op": "node_stdout_listener_only_2b",
+      "lanes": {
+        "native": {
+          "p50Ms": 16.24,
+          "memBytes": 1228800,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 17.5
+        },
+        "guest": {
+          "p50Ms": 29.11,
+          "memBytes": 33075200,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 1.66,
+        "total": 1.79,
+        "mem": 26.92
+      }
+    },
+    {
+      "key": "process/fanout_spawn_8",
+      "family": "process",
+      "op": "fanout_spawn_8",
+      "lanes": {
+        "native": {
+          "p50Ms": 21.4,
+          "memBytes": 1175552,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 28.06
+        },
+        "guest": {
+          "p50Ms": 45.59,
+          "memBytes": 321253376,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 1.62,
+        "total": 2.13,
+        "mem": 273.28
+      }
+    },
+    {
+      "key": "process/wait_reap_storm_8",
+      "family": "process",
+      "op": "wait_reap_storm_8",
+      "lanes": {
+        "native": {
+          "p50Ms": 22.07,
+          "memBytes": 1056768,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 27.73
+        },
+        "guest": {
+          "p50Ms": 46.62,
+          "memBytes": 322007040,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 1.68,
+        "total": 2.11,
+        "mem": 304.71
+      }
+    },
+    {
+      "key": "process/pipe_chain_3",
+      "family": "process",
+      "op": "pipe_chain_3",
+      "lanes": {
+        "native": {
+          "p50Ms": 2.74,
+          "memBytes": 1138688,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.17,
+          "memBytes": 9228288,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.04,
+          "memBytes": 24436736,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 0.24,
+        "total": 0.01,
+        "mem": 21.46
+      }
+    },
+    {
+      "key": "process/spawn_stdout_capture_small",
+      "family": "process",
+      "op": "spawn_stdout_capture_small",
+      "lanes": {
+        "native": {
+          "p50Ms": 17.07,
+          "memBytes": 1269760,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 17.3,
+          "memBytes": 8044544,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 35.97,
+          "memBytes": 75214848,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 2.08,
+        "total": 2.11,
+        "mem": 59.24
+      }
+    },
+    {
+      "key": "process/spawn_stdout_capture_big",
+      "family": "process",
+      "op": "spawn_stdout_capture_big",
+      "lanes": {
+        "native": {
+          "p50Ms": 17.3,
+          "memBytes": 1449984,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 17.9,
+          "memBytes": 17350656,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 52.63,
+          "memBytes": 116244480,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 2.94,
+        "total": 3.04,
+        "mem": 80.17
+      }
+    },
+    {
+      "key": "process/spawn_stdin_roundtrip",
+      "family": "process",
+      "op": "spawn_stdin_roundtrip",
+      "lanes": {
+        "native": {
+          "p50Ms": 2.05,
+          "memBytes": 1146880,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 17.54,
+          "memBytes": 8990720,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 44.25,
+          "memBytes": 75722752,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 2.52,
+        "total": 21.59,
+        "mem": 66.03
+      }
+    },
+    {
+      "key": "net/udp_echo_small",
+      "family": "net",
+      "op": "udp_echo_small",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.04,
+          "memBytes": 192512,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.04,
+          "memBytes": 5296128,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.22,
+          "memBytes": 24195072,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 5.5,
+        "total": 5.5,
+        "mem": 125.68
+      }
+    },
+    {
+      "key": "net/udp_echo_big",
+      "family": "net",
+      "op": "udp_echo_big",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.05,
+          "memBytes": 270336,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.08,
+          "memBytes": 7663616,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.69,
+          "memBytes": 39297024,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 8.63,
+        "total": 13.8,
+        "mem": 145.36
+      }
+    },
+    {
+      "key": "net/unix_echo_small",
+      "family": "net",
+      "op": "unix_echo_small",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.05,
+          "memBytes": 122880,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.22,
+          "memBytes": 10321920,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 6.26,
+          "memBytes": 18657280,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 28.45,
+        "total": 125.2,
+        "mem": 151.83
+      }
+    },
+    {
+      "key": "net/unix_echo_big",
+      "family": "net",
+      "op": "unix_echo_big",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.05,
+          "memBytes": 1519616,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.33,
+          "memBytes": 15990784,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 8.57,
+          "memBytes": 38117376,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 25.97,
+        "total": 171.4,
+        "mem": 25.08
+      }
+    },
+    {
+      "key": "net/http_loopback_get",
+      "family": "net",
+      "op": "http_loopback_get",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.07,
+          "memBytes": 270336,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.45,
+          "memBytes": 23060480,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 1.09,
+          "memBytes": 29556736,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 2.42,
+        "total": 15.57,
+        "mem": 109.33
+      }
+    },
+    {
+      "key": "net/http_external_get",
+      "family": "net",
+      "op": "http_external_get",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.04,
+          "memBytes": 192512,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.3
+        },
+        "guest": {
+          "p50Ms": 0.44,
+          "memBytes": 19480576,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 1.47,
+        "total": 11,
+        "mem": 101.19
+      }
+    },
+    {
+      "key": "net/http2_loopback_get",
+      "family": "net",
+      "op": "http2_loopback_get",
+      "lanes": {
+        "node": {
+          "p50Ms": 0.53,
+          "memBytes": 19943424,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 56.5,
+          "memBytes": 23142400,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 106.6
+      }
+    },
+    {
+      "key": "net/fetch_loopback_get",
+      "family": "net",
+      "op": "fetch_loopback_get",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.04,
+          "memBytes": 131072,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.76,
+          "memBytes": 48111616,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 1.68,
+          "memBytes": 55996416,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 2.21,
+        "total": 42,
+        "mem": 427.22
+      }
+    },
+    {
+      "key": "net/tls_loopback_get",
+      "family": "net",
+      "op": "tls_loopback_get",
+      "lanes": {
+        "node": {
+          "p50Ms": 1.72
+        },
+        "guest": {
+          "p50Ms": 13.71,
+          "memBytes": 34160640,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 7.97
+      }
+    },
+    {
+      "key": "net/tcp_connect_close",
+      "family": "net",
+      "op": "tcp_connect_close",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.06,
+          "memBytes": 221184,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.15,
+          "memBytes": 8359936,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.77,
+          "memBytes": 23437312,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 5.13,
+        "total": 12.83,
+        "mem": 105.96
+      }
+    },
+    {
+      "key": "net/tcp_echo_small",
+      "family": "net",
+      "op": "tcp_echo_small",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.05,
+          "memBytes": 196608,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.22,
+          "memBytes": 10305536,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 4.2,
+          "memBytes": 26132480,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 19.09,
+        "total": 84,
+        "mem": 132.92
+      }
+    },
+    {
+      "key": "net/tcp_external_echo",
+      "family": "net",
+      "op": "tcp_external_echo",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.04,
+          "memBytes": 270336,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.08
+        },
+        "guest": {
+          "p50Ms": 0.3,
+          "memBytes": 17211392,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 3.75,
+        "total": 7.5,
+        "mem": 63.67
+      }
+    },
+    {
+      "key": "net/tcp_concurrent_4",
+      "family": "net",
+      "op": "tcp_concurrent_4",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.15,
+          "memBytes": 270336,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.33,
+          "memBytes": 10207232,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 4.71,
+          "memBytes": 31715328,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 14.27,
+        "total": 31.4,
+        "mem": 117.32
+      }
+    },
+    {
+      "key": "net/tcp_echo_big",
+      "family": "net",
+      "op": "tcp_echo_big",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.13,
+          "memBytes": 1425408,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.32,
+          "memBytes": 15691776,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 3.59,
+          "memBytes": 38154240,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 11.22,
+        "total": 27.62,
+        "mem": 26.77
+      }
+    },
+    {
+      "key": "net/tcp_tiny_writes_16",
+      "family": "net",
+      "op": "tcp_tiny_writes_16",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.24,
+          "memBytes": 225280,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.24,
+          "memBytes": 9732096,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 4.42,
+          "memBytes": 25776128,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 18.42,
+        "total": 18.42,
+        "mem": 114.42
+      }
+    },
+    {
+      "key": "fs/open_close_churn",
+      "family": "fs",
+      "op": "open_close_churn",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.03,
+          "memBytes": 4096,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.01,
+          "memBytes": 3645440,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.07,
+          "memBytes": 18227200,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 18,
+          "memBytes": 14319616,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 7,
+        "total": 2.33,
+        "wasm": 600,
+        "mem": 4450
+      }
+    },
+    {
+      "key": "fs/stat_storm",
+      "family": "fs",
+      "op": "stat_storm",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.03,
+          "memBytes": 4096,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.01,
+          "memBytes": 3637248,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.07,
+          "memBytes": 10825728,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 12,
+          "memBytes": 14536704,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 7,
+        "total": 2.33,
+        "wasm": 400,
+        "mem": 2643
+      }
+    },
+    {
+      "key": "fs/fs_write_small",
+      "family": "fs",
+      "op": "fs_write_small",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.03,
+          "memBytes": 36864,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.03,
+          "memBytes": 3641344,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.06,
+          "memBytes": 9105408,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 10,
+          "memBytes": 13070336,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 2,
+        "total": 2,
+        "wasm": 333.33,
+        "mem": 247
+      }
+    },
+    {
+      "key": "fs/fs_write_big",
+      "family": "fs",
+      "op": "fs_write_big",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.94,
+          "memBytes": 1884160,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.84,
+          "memBytes": 29769728,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 4.1,
+          "memBytes": 38580224,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 15,
+          "memBytes": 56909824,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 4.88,
+        "total": 4.36,
+        "wasm": 15.96,
+        "mem": 20.48
+      }
+    },
+    {
+      "key": "fs/fs_read_small",
+      "family": "fs",
+      "op": "fs_read_small",
+      "lanes": {
+        "native": {
+          "p50Ms": 0,
+          "memBytes": 4096,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.02,
+          "memBytes": 3645440,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.07,
+          "memBytes": 11325440,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 9,
+          "memBytes": 24776704,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 3.5,
+        "total": null,
+        "wasm": null,
+        "mem": 2765
+      }
+    },
+    {
+      "key": "fs/fs_read_big",
+      "family": "fs",
+      "op": "fs_read_big",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.04,
+          "memBytes": 2170880,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.27,
+          "memBytes": 30363648,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 2.25,
+          "memBytes": 58142720,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 10,
+          "memBytes": 49135616,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 8.33,
+        "total": 56.25,
+        "wasm": 250,
+        "mem": 26.78
+      }
+    },
+    {
+      "key": "fs/mkdir_rmdir",
+      "family": "fs",
+      "op": "mkdir_rmdir",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.01,
+          "memBytes": 73728,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.03,
+          "memBytes": 3698688,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.15,
+          "memBytes": 18558976,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 4,
+          "memBytes": 14458880,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 5,
+        "total": 15,
+        "wasm": 400,
+        "mem": 251.72
+      }
+    },
+    {
+      "key": "fs/rename_file",
+      "family": "fs",
+      "op": "rename_file",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.02,
+          "memBytes": 4096,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.03,
+          "memBytes": 3645440,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.13,
+          "memBytes": 8835072,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 14,
+          "memBytes": 14630912,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 4.33,
+        "total": 6.5,
+        "wasm": 700,
+        "mem": 2157
+      }
+    },
+    {
+      "key": "fs/readdir_small",
+      "family": "fs",
+      "op": "readdir_small",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.17,
+          "memBytes": 12288,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.02,
+          "memBytes": 3649536,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.23,
+          "memBytes": 11612160,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 45,
+          "memBytes": 20062208,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 11.5,
+        "total": 1.35,
+        "wasm": 264.71,
+        "mem": 945
+      }
+    },
+    {
+      "key": "fs/readdir_big",
+      "family": "fs",
+      "op": "readdir_big",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.64,
+          "memBytes": 40960,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.3,
+          "memBytes": 7856128,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 6.14,
+          "memBytes": 13713408,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 1190,
+          "memBytes": 26738688,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 20.47,
+        "total": 9.59,
+        "wasm": 1859.38,
+        "mem": 334.8
+      }
+    },
+    {
+      "key": "fs/fsync_small",
+      "family": "fs",
+      "op": "fsync_small",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.6,
+          "memBytes": 16384,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.59,
+          "memBytes": 3624960,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.12,
+          "memBytes": 18284544,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 10,
+          "memBytes": 15773696,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 0.2,
+        "total": 0.2,
+        "wasm": 16.67,
+        "mem": 1116
+      }
+    },
+    {
+      "key": "fs/fs_promises_stat_x32",
+      "family": "fs",
+      "op": "fs_promises_stat_x32",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.05,
+          "memBytes": 4096,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.23,
+          "memBytes": 7090176,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 1.27,
+          "memBytes": 20365312,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 12,
+          "memBytes": 12759040,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 5.52,
+        "total": 25.4,
+        "wasm": 240,
+        "mem": 4972
+      }
+    },
+    {
+      "key": "fs/stream_copy_small",
+      "family": "fs",
+      "op": "stream_copy_small",
+      "lanes": {
+        "native": {
+          "p50Ms": 0,
+          "memBytes": 4096,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.22,
+          "memBytes": 9482240,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.63,
+          "memBytes": 14118912,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 9,
+          "memBytes": 25874432,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 2.86,
+        "total": null,
+        "wasm": null,
+        "mem": 3447
+      }
+    },
+    {
+      "key": "fs/stream_copy_big",
+      "family": "fs",
+      "op": "stream_copy_big",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.05,
+          "memBytes": 2068480,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 1.07,
+          "memBytes": 16568320,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 5.14,
+          "memBytes": 42487808,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 10,
+          "memBytes": 50937856,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 4.8,
+        "total": 102.8,
+        "wasm": 200,
+        "mem": 20.54
+      }
+    },
+    {
+      "key": "modules/require_100_small",
+      "family": "modules",
+      "op": "require_100_small",
+      "lanes": {
+        "node": {
+          "p50Ms": 2.3,
+          "memBytes": 19976192,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 12.24,
+          "memBytes": 20434944,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 5.32
+      }
+    },
+    {
+      "key": "modules/import_100_small_esm",
+      "family": "modules",
+      "op": "import_100_small_esm",
+      "lanes": {
+        "node": {
+          "p50Ms": 5.39,
+          "memBytes": 26738688,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 12,
+          "memBytes": 35631104,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 2.23
+      }
+    },
+    {
+      "key": "modules/import_npm_package",
+      "family": "modules",
+      "op": "import_npm_package",
+      "lanes": {
+        "node": {
+          "p50Ms": 42.83
+        },
+        "guest": {
+          "p50Ms": 50.76,
+          "memBytes": 39059456,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 1.19
+      }
+    },
+    {
+      "key": "modules/import_fresh_file",
+      "family": "modules",
+      "op": "import_fresh_file",
+      "lanes": {
+        "node": {
+          "p50Ms": 0.22,
+          "memBytes": 4337664,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.18,
+          "memBytes": 21098496,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 0.82
+      }
+    },
+    {
+      "key": "dns/resolve_uncached_localhost",
+      "family": "dns",
+      "op": "resolve_uncached_localhost",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.02,
+          "memBytes": 4096,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.05,
+          "memBytes": 4059136,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.03,
+          "memBytes": 14884864,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 0.6,
+        "total": 1.5,
+        "mem": 3634
+      }
+    },
+    {
+      "key": "dns/resolve_cached_localhost",
+      "family": "dns",
+      "op": "resolve_cached_localhost",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.05,
+          "memBytes": 12288,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.1,
+          "memBytes": 3457024,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.06,
+          "memBytes": 15011840,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 0.6,
+        "total": 1.2,
+        "mem": 1221.67
+      }
+    },
+    {
+      "key": "dns/resolve_concurrent_4",
+      "family": "dns",
+      "op": "resolve_concurrent_4",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.14,
+          "memBytes": 417792,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.17,
+          "memBytes": 3903488,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.07,
+          "memBytes": 22421504,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 0.41,
+        "total": 0.5,
+        "mem": 53.67
+      }
+    },
+    {
+      "key": "ecosystem/ls_100",
+      "family": "ecosystem",
+      "op": "ls_100",
+      "lanes": {
+        "hostCmd": {
+          "p50Ms": 3.79
+        },
+        "vmCmd": {
+          "p50Ms": 370.76,
+          "memBytes": 52047872,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "command": 97.83
+      }
+    },
+    {
+      "key": "ecosystem/grep_1m",
+      "family": "ecosystem",
+      "op": "grep_1m",
+      "lanes": {
+        "hostCmd": {
+          "p50Ms": 3.45
+        },
+        "vmCmd": {
+          "p50Ms": 126.28,
+          "memBytes": 117411840,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "command": 36.6
+      }
+    },
+    {
+      "key": "ecosystem/git_init_commit",
+      "family": "ecosystem",
+      "op": "git_init_commit",
+      "lanes": {
+        "hostCmd": {
+          "p50Ms": 12.27
+        },
+        "vmCmd": {
+          "p50Ms": 2115.8,
+          "memBytes": 138067968,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "command": 172.44
+      }
+    },
+    {
+      "key": "ecosystem/sh_pipeline",
+      "family": "ecosystem",
+      "op": "sh_pipeline",
+      "lanes": {
+        "hostCmd": {
+          "p50Ms": 9.28
+        },
+        "vmCmd": {
+          "p50Ms": 791.58,
+          "memBytes": 196358144,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "command": 85.3
+      }
+    },
+    {
+      "key": "permissions/fs_write_small_allow",
+      "family": "permissions",
+      "op": "fs_write_small_allow",
+      "lanes": {
+        "node": {
+          "p50Ms": 0.03,
+          "memBytes": 3645440,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.06,
+          "memBytes": 23642112,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 2
+      }
+    },
+    {
+      "key": "permissions/fs_write_small_policy",
+      "family": "permissions",
+      "op": "fs_write_small_policy",
+      "lanes": {
+        "node": {
+          "p50Ms": 0.03,
+          "memBytes": 3645440,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.06,
+          "memBytes": 16052224,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 2
+      }
+    },
+    {
+      "key": "permissions/stat_storm_allow",
+      "family": "permissions",
+      "op": "stat_storm_allow",
+      "lanes": {
+        "node": {
+          "p50Ms": 0.01,
+          "memBytes": 3645440,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.07,
+          "memBytes": 21839872,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 7
+      }
+    },
+    {
+      "key": "permissions/stat_storm_policy",
+      "family": "permissions",
+      "op": "stat_storm_policy",
+      "lanes": {
+        "node": {
+          "p50Ms": 0.01,
+          "memBytes": 3629056,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.07,
+          "memBytes": 21729280,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 7
+      }
+    },
+    {
+      "key": "permissions/readdir_small_allow",
+      "family": "permissions",
+      "op": "readdir_small_allow",
+      "lanes": {
+        "node": {
+          "p50Ms": 0.02,
+          "memBytes": 3645440,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.33,
+          "memBytes": 21815296,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 16.5
+      }
+    },
+    {
+      "key": "permissions/readdir_small_policy",
+      "family": "permissions",
+      "op": "readdir_small_policy",
+      "lanes": {
+        "node": {
+          "p50Ms": 0.02,
+          "memBytes": 3624960,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.26,
+          "memBytes": 21688320,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 13
+      }
+    },
+    {
+      "key": "permissions/tcp_echo_small_allow",
+      "family": "permissions",
+      "op": "tcp_echo_small_allow",
+      "lanes": {
+        "node": {
+          "p50Ms": 0.23,
+          "memBytes": 10084352,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 4.03,
+          "memBytes": 25886720,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 17.52
+      }
+    },
+    {
+      "key": "permissions/tcp_echo_small_policy",
+      "family": "permissions",
+      "op": "tcp_echo_small_policy",
+      "lanes": {
+        "node": {
+          "p50Ms": 0.21,
+          "memBytes": 8990720,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 3.9,
+          "memBytes": 26062848,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 18.57
+      }
+    },
+    {
+      "key": "permissions/http_loopback_get_allow",
+      "family": "permissions",
+      "op": "http_loopback_get_allow",
+      "lanes": {
+        "node": {
+          "p50Ms": 0.44,
+          "memBytes": 22331392,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 1.26,
+          "memBytes": 29966336,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 2.86
+      }
+    },
+    {
+      "key": "permissions/http_loopback_get_policy",
+      "family": "permissions",
+      "op": "http_loopback_get_policy",
+      "lanes": {
+        "node": {
+          "p50Ms": 0.44,
+          "memBytes": 22110208,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 1.27,
+          "memBytes": 21475328,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 2.89
+      }
+    },
+    {
+      "key": "pipes/pass_through_small",
+      "family": "pipes",
+      "op": "pass_through_small",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.74,
+          "memBytes": 1138688,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.04,
+          "memBytes": 2600960,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.01,
+          "memBytes": 21585920,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 0.25,
+        "total": 0.01,
+        "mem": 18.96
+      }
+    },
+    {
+      "key": "pipes/pass_through_big",
+      "family": "pipes",
+      "op": "pass_through_big",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.06,
+          "memBytes": 122880,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.07,
+          "memBytes": 6234112,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.21,
+          "memBytes": 34267136,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 3,
+        "total": 3.5,
+        "mem": 278.87
+      }
+    },
+    {
+      "key": "pipes/backpressure_chunks",
+      "family": "pipes",
+      "op": "backpressure_chunks",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.03,
+          "memBytes": 299008,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.08,
+          "memBytes": 7811072,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.05,
+          "memBytes": 27373568,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 0.63,
+        "total": 1.67,
+        "mem": 91.55
+      }
+    },
+    {
+      "key": "timers/settimeout_zero_x100",
+      "family": "timers",
+      "op": "settimeout_zero_x100",
+      "lanes": {
+        "native": {
+          "p50Ms": 1.26,
+          "memBytes": 40960,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 106.89,
+          "memBytes": 7806976,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 118.8,
+          "memBytes": 11530240,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 3,
+          "memBytes": 22585344,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 1.11,
+        "total": 94.29,
+        "wasm": 2.38,
+        "mem": 281.5
+      }
+    },
+    {
+      "key": "timers/settimeout_1ms_x50",
+      "family": "timers",
+      "op": "settimeout_1ms_x50",
+      "lanes": {
+        "native": {
+          "p50Ms": 1.26,
+          "memBytes": 4096,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 53.76,
+          "memBytes": 7790592,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 59.02,
+          "memBytes": 11128832,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 3,
+          "memBytes": 27394048,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 1.1,
+        "total": 46.84,
+        "wasm": 2.38,
+        "mem": 2717
+      }
+    },
+    {
+      "key": "timers/setimmediate_x1000",
+      "family": "timers",
+      "op": "setimmediate_x1000",
+      "lanes": {
+        "native": {
+          "p50Ms": 1.28,
+          "memBytes": 32768,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.73,
+          "memBytes": 13598720,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 1.8,
+          "memBytes": 14962688,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 3,
+          "memBytes": 11706368,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 2.47,
+        "total": 1.41,
+        "wasm": 2.34,
+        "mem": 456.63
+      }
+    },
+    {
+      "key": "control/cpu_loop",
+      "family": "control",
+      "op": "cpu_loop",
+      "lanes": {
+        "native": {
+          "p50Ms": 1.25,
+          "memBytes": 12288,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 7.81,
+          "memBytes": 7979008,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 7.77,
+          "memBytes": 19312640,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 3,
+          "memBytes": 16576512,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 0.99,
+        "total": 6.22,
+        "wasm": 2.4,
+        "mem": 1571.67
+      }
+    },
+    {
+      "key": "control/alloc_free",
+      "family": "control",
+      "op": "alloc_free",
+      "lanes": {
+        "native": {
+          "p50Ms": 2.15,
+          "memBytes": 5259264,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 4.44,
+          "memBytes": 71569408,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 4.25,
+          "memBytes": 41357312,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        },
+        "wasm": {
+          "p50Ms": 5,
+          "memBytes": 31191040,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 0.96,
+        "total": 1.98,
+        "wasm": 2.33,
+        "mem": 7.86
+      }
+    },
+    {
+      "key": "perf-finding/stdio_writeSync_8x64k",
+      "family": "perf-finding",
+      "op": "stdio_writeSync_8x64k",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.04,
+          "memBytes": 270336,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.13,
+          "memBytes": 5451776,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 0.85,
+          "memBytes": 35856384,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 6.54,
+        "total": 21.25,
+        "mem": 132.64
+      }
+    },
+    {
+      "key": "perf-finding/unix_accept_latency",
+      "family": "perf-finding",
+      "op": "unix_accept_latency",
+      "lanes": {
+        "native": {
+          "p50Ms": 0.05,
+          "memBytes": 126976,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus native-baseline cpu_loop --iters 1 startup baseline, floored to one page"
+        },
+        "node": {
+          "p50Ms": 0.14,
+          "memBytes": 8273920,
+          "memProvenance": "direct child spawn with /proc/<pid>/status VmHWM sampling minus node -e \"\" startup baseline, floored to one page"
+        },
+        "guest": {
+          "p50Ms": 2.89,
+          "memBytes": 18006016,
+          "memProvenance": "/proc/<sidecarPid>/clear_refs=5, baseline VmRSS, post-op VmHWM, max(VmHWM - baseline, 0)"
+        }
+      },
+      "tax": {
+        "emulation": 20.64,
+        "total": 57.8,
+        "mem": 141.81
+      }
+    }
+  ]
+}

--- a/packages/benchmarks/src/baseline.ts
+++ b/packages/benchmarks/src/baseline.ts
@@ -1,291 +1,260 @@
-/**
- * Baseline recording + regression-gate utilities for the JS-layer benchmarks.
- *
- * Strategy (chosen): a committed `baseline.json` in this directory holds the
- * "golden" numbers plus full metadata. A bench run records its own result JSON,
- * prints a delta table vs the baseline, and — when `--gate` is passed — exits
- * non-zero if a gated metric regresses beyond a *relative* tolerance. Baselines
- * are bumped explicitly with `--update-baseline` so the change is reviewed in a PR.
- *
- * Gate philosophy:
- *   - Gate on p50 (stable) of deterministic, llmock-backed metrics only.
- *   - Use *relative* thresholds (e.g. +12%), not absolute ms, so the gate tolerates
- *     hardware drift within a class.
- *   - Also gate hardware-independent ratios (e.g. the VM tax ratio), which survive
- *     cross-machine variance far better than absolute latencies.
- *   - Never gate on LLM-bound metrics (prompt latency) — those belong to a separate,
- *     informational real-API suite.
- */
+import { existsSync, readFileSync } from "node:fs";
+import { basename } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import type { LatencyResult, LayerStatsEntry } from "./lib/layers.js";
+import { getHardware, round } from "./lib/perf-utils.js";
+import { writeJson } from "./lib/report.js";
+import {
+	formatPacificIso,
+	formatSidecarProvenance,
+	resolveBenchSidecarProvenance,
+	type SidecarBinaryProvenance,
+} from "./lib/vm.js";
 
-import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { createRequire } from "node:module";
-import os from "node:os";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+export const LOCAL_BASELINE_PATH = fileURLToPath(
+	new URL("../results/baseline-local.json", import.meta.url),
+);
+export const CI_BASELINE_PATH = fileURLToPath(
+	new URL("../results/baseline-ci.json", import.meta.url),
+);
 
-const HERE = dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = join(HERE, "..", "..", "..");
-export const BASELINE_PATH = join(HERE, "..", "results", "baseline.json");
+export type GateLane =
+	| "native"
+	| "node"
+	| "guest"
+	| "wasm"
+	| "hostCmd"
+	| "vmCmd";
 
-export interface PhaseStats {
-	mean: number;
-	p50: number;
-	p95: number;
-	p99: number;
-	min: number;
-	max: number;
-	stddev: number;
-}
-
-export interface BenchMetadata {
-	timestamp: string;
-	gitSha: string;
-	gitDirty: boolean;
-	hardware: {
-		cpu: string;
-		cores: number;
-		ram: string;
-		node: string;
-		os: string;
-		arch: string;
+export interface MatrixBaseline {
+	schemaVersion: 1;
+	kind: "local" | "ci";
+	generatedAt: string;
+	hardware: ReturnType<typeof getHardware>;
+	sidecar: SidecarBinaryProvenance;
+	engine: {
+		iterations: number;
+		warmup: number;
+		cold: boolean;
+		sharedVm: boolean;
+		rowCount: number;
 	};
-	/** Versions that move the numbers — recorded so a baseline is interpretable. */
-	deps: Record<string, string>;
-	llmock: boolean;
-	iterations: number;
-	warmup: number;
+	rows: MatrixBaselineRow[];
 }
 
-export interface BenchResult extends BenchMetadata {
-	benchmark: string;
-	/** lane -> metric -> stats (e.g. lanes.vm.sessionCreate.p50). */
-	lanes: Record<string, Record<string, PhaseStats>>;
-	/** Derived comparison metrics (e.g. vmTaxMs, vmTaxRatio). */
-	derived: Record<string, number>;
+export interface MatrixBaselineRow {
+	key: string;
+	family: string;
+	op: string;
+	lanes: Partial<Record<GateLane, BaselineLane>>;
+	tax: Record<string, number>;
+	skipped?: true;
+	skipReason?: string;
 }
 
-/** A single gate rule. `path` is "lane.metric.field" or "derived.key". */
-export interface GateRule {
-	path: string;
-	/** Relative tolerance, e.g. 0.12 = fail if current exceeds baseline by >12%. */
-	tolerance: number;
-	/**
-	 * Noise floor: a regression only counts if the *absolute* delta also exceeds
-	 * this. Prevents tiny-value metrics (e.g. a ~10ms vmCreate) from flaking the
-	 * gate on sub-millisecond jitter that looks large in percent terms.
-	 */
-	noiseFloor?: number;
-	/** Human label for the delta table. */
-	label?: string;
+export interface BaselineLane {
+	p50Ms: number;
+	memBytes?: number;
+	memProvenance?: string;
 }
 
-// ── stats ────────────────────────────────────────────────────────────
-
-export function round(n: number, decimals = 2): number {
-	const f = 10 ** decimals;
-	return Math.round(n * f) / f;
+export interface LatencyMatrixLike {
+	results?: LatencyResult[];
+	latency?: LatencyResult[];
+	sidecar: SidecarBinaryProvenance;
+	mode?: {
+		cold: boolean;
+		sharedVm: boolean;
+	};
+	matrixMode?: {
+		cold: boolean;
+		sharedVm: boolean;
+	};
 }
 
-function percentile(sorted: number[], p: number): number {
-	const idx = Math.ceil((p / 100) * sorted.length) - 1;
-	return sorted[Math.max(0, Math.min(sorted.length - 1, idx))];
+export function baselinePathForEnvironment(): string {
+	return process.env.GITHUB_ACTIONS === "true" ? CI_BASELINE_PATH : LOCAL_BASELINE_PATH;
 }
 
-export function stats(samples: number[]): PhaseStats {
-	const sorted = [...samples].sort((a, b) => a - b);
-	const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
-	const variance =
-		samples.reduce((a, b) => a + (b - mean) ** 2, 0) / samples.length;
+export function loadMatrixBaseline(path: string): MatrixBaseline | null {
+	if (!existsSync(path)) return null;
+	return JSON.parse(readFileSync(path, "utf8")) as MatrixBaseline;
+}
+
+export function rowKey(row: Pick<LatencyResult, "family" | "op">): string {
+	return `${row.family}/${row.op}`;
+}
+
+export function laneMetric(
+	row: Pick<MatrixBaselineRow, "lanes">,
+	lane: GateLane,
+): BaselineLane | undefined {
+	return row.lanes[lane];
+}
+
+export function createMatrixBaseline(
+	matrix: LatencyMatrixLike,
+	options: {
+		kind: "local" | "ci";
+		iterations: number;
+		warmup: number;
+	},
+): MatrixBaseline {
+	const latency = matrix.results ?? matrix.latency ?? [];
+	const mode = matrix.mode ?? matrix.matrixMode ?? { cold: false, sharedVm: false };
 	return {
-		mean: round(mean),
-		p50: round(percentile(sorted, 50)),
-		p95: round(percentile(sorted, 95)),
-		p99: round(percentile(sorted, 99)),
-		min: round(sorted[0]),
-		max: round(sorted[sorted.length - 1]),
-		stddev: round(Math.sqrt(variance)),
+		schemaVersion: 1,
+		kind: options.kind,
+		generatedAt: formatPacificIso(new Date()),
+		hardware: getHardware(),
+		sidecar: matrix.sidecar,
+		engine: {
+			iterations: options.iterations,
+			warmup: options.warmup,
+			cold: mode.cold,
+			sharedVm: mode.sharedVm,
+			rowCount: latency.length,
+		},
+		rows: latency.map(baselineRowFromLatency),
 	};
 }
 
-// ── metadata ─────────────────────────────────────────────────────────
+export function baselineRowFromLatency(result: LatencyResult): MatrixBaselineRow {
+	const lanes: MatrixBaselineRow["lanes"] = {};
+	for (const lane of ["native", "node", "guest", "wasm", "hostCmd", "vmCmd"] as const) {
+		const stats = (result.layers as Partial<Record<GateLane, LayerStatsEntry>>)[lane];
+		if (stats) lanes[lane] = baselineLane(stats);
+	}
+	return {
+		key: rowKey(result),
+		family: result.family,
+		op: result.op,
+		lanes,
+		tax: Object.fromEntries(
+			Object.entries(result.tax).filter((entry): entry is [string, number] =>
+				typeof entry[1] === "number",
+			),
+		),
+		...("skipped" in result && result.skipped ? { skipped: true as const } : {}),
+		...("skipReason" in result && result.skipReason
+			? { skipReason: result.skipReason }
+			: {}),
+	};
+}
 
-function safe<T>(fn: () => T, fallback: T): T {
-	try {
-		return fn();
-	} catch {
-		return fallback;
+export function printBaselineMetadata(baseline: MatrixBaseline, path: string): void {
+	console.log(
+		JSON.stringify(
+			{
+				path,
+				kind: baseline.kind,
+				generatedAt: baseline.generatedAt,
+				hardware: baseline.hardware,
+				sidecar: baseline.sidecar,
+				engine: baseline.engine,
+			},
+			null,
+			2,
+		),
+	);
+}
+
+function baselineLane(stats: LayerStatsEntry): BaselineLane {
+	return {
+		p50Ms: stats.p50,
+		...(stats.memBytes !== undefined ? { memBytes: stats.memBytes } : {}),
+		...(stats.memProvenance ? { memProvenance: stats.memProvenance } : {}),
+	};
+}
+
+function parseArgs(argv: string[]): {
+	kind: "local" | "ci";
+	output: string;
+	from?: string;
+} {
+	let kind: "local" | "ci" = "local";
+	let output: string | undefined;
+	let from: string | undefined;
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--ci") {
+			kind = "ci";
+		} else if (arg === "--local") {
+			kind = "local";
+		} else if (arg === "--output") {
+			output = argv[++i];
+		} else if (arg === "--from") {
+			from = argv[++i];
+		} else {
+			throw new Error(`unknown ${basename(import.meta.url)} argument: ${arg}`);
+		}
+	}
+	return {
+		kind,
+		output: output ?? (kind === "ci" ? CI_BASELINE_PATH : LOCAL_BASELINE_PATH),
+		from,
+	};
+}
+
+async function loadOrRunMatrix(from: string | undefined): Promise<LatencyMatrixLike> {
+	if (from) {
+		return JSON.parse(readFileSync(from, "utf8")) as LatencyMatrixLike;
+	}
+	if (process.env.BENCH_FAMILIES || process.env.BENCH_OP_FILTER) {
+		throw new Error("baseline regeneration requires the full matrix; unset BENCH_FAMILIES and BENCH_OP_FILTER");
+	}
+	const sidecar = resolveBenchSidecarProvenance();
+	console.error(formatSidecarProvenance(sidecar));
+	if (sidecar.profile !== "release") {
+		throw new BaselineExitError(
+			2,
+			`refusing to regenerate baseline with ${sidecar.profile} sidecar; set SECURE_EXEC_SIDECAR_BIN to target/release/secure-exec-sidecar`,
+		);
+	}
+	const { runLatencyMatrix } = await import("./run-all.js");
+	return runLatencyMatrix();
+}
+
+class BaselineExitError extends Error {
+	constructor(
+		readonly code: number,
+		message: string,
+	) {
+		super(message);
 	}
 }
 
-function gitSha(): string {
-	// Works for both git and jj (colocated or standalone) checkouts.
-	const fromGit = safe(
-		() =>
-			execFileSync("git", ["rev-parse", "--short", "HEAD"], {
-				cwd: REPO_ROOT,
-				encoding: "utf8",
-				stdio: ["ignore", "pipe", "ignore"],
-			}).trim(),
-		"",
-	);
-	if (fromGit) return fromGit;
-	return safe(
-		() =>
-			execFileSync(
-				"jj",
-				["log", "-r", "@", "--no-graph", "-T", "commit_id.short()"],
-				{ cwd: REPO_ROOT, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
-			).trim(),
-		"unknown",
-	);
-}
-
-function gitDirty(): boolean {
-	return safe(
-		() =>
-			execFileSync("git", ["status", "--porcelain"], {
-				cwd: REPO_ROOT,
-				encoding: "utf8",
-				stdio: ["ignore", "pipe", "ignore"],
-			}).trim().length > 0,
-		false,
-	);
-}
-
-/**
- * Best-effort read of an installed package version. Resolves the package's main
- * entry then walks up to its package.json — `require.resolve("<name>/package.json")`
- * fails when the package's `exports` map doesn't expose `./package.json`.
- */
-function pkgVersion(name: string): string {
-	return safe(() => {
-		const req = createRequire(join(REPO_ROOT, "package.json"));
-		let dir = dirname(req.resolve(name));
-		for (let i = 0; i < 8; i++) {
-			const candidate = join(dir, "package.json");
-			if (existsSync(candidate)) {
-				const pkg = JSON.parse(readFileSync(candidate, "utf8"));
-				if (pkg.name === name && pkg.version) return pkg.version;
-			}
-			const parent = dirname(dir);
-			if (parent === dir) break;
-			dir = parent;
-		}
-		return "unknown";
-	}, "absent");
-}
-
-export function collectMetadata(opts: {
-	iterations: number;
-	warmup: number;
-	llmock: boolean;
-}): BenchMetadata {
-	const cpus = os.cpus();
-	return {
-		timestamp: new Date().toISOString(),
-		gitSha: gitSha(),
-		gitDirty: gitDirty(),
-		hardware: {
-			cpu: cpus[0]?.model ?? "unknown",
-			cores: os.availableParallelism(),
-			ram: `${round(os.totalmem() / 1024 ** 3, 1)} GB`,
-			node: process.version,
-			os: `${os.type()} ${os.release()}`,
-			arch: os.arch(),
-		},
-		// These are the versions that swing the numbers — the published-binary vs
-		// source-build gap proved versions matter for interpreting a baseline.
-		deps: {
-			"@secure-exec/core": pkgVersion("@secure-exec/core"),
-			"@secure-exec/sidecar": pkgVersion("@secure-exec/sidecar"),
-		},
-		iterations: opts.iterations,
-		warmup: opts.warmup,
-		llmock: opts.llmock,
-	};
-}
-
-// ── baseline IO ──────────────────────────────────────────────────────
-
-export function loadBaseline(): BenchResult | null {
-	if (!existsSync(BASELINE_PATH)) return null;
-	return JSON.parse(readFileSync(BASELINE_PATH, "utf8")) as BenchResult;
-}
-
-export function writeBaseline(result: BenchResult): void {
-	writeFileSync(BASELINE_PATH, `${JSON.stringify(result, null, 2)}\n`);
-}
-
-// ── compare + gate ───────────────────────────────────────────────────
-
-function resolvePath(result: BenchResult, path: string): number | undefined {
-	const parts = path.split(".");
-	if (parts[0] === "derived") return result.derived[parts[1]];
-	const [lane, metric, field] = parts;
-	const s = result.lanes[lane]?.[metric];
-	return s ? (s[field as keyof PhaseStats] as number) : undefined;
-}
-
-export interface GateOutcome {
-	path: string;
-	label: string;
-	baseline: number | undefined;
-	current: number | undefined;
-	deltaPct: number | undefined;
-	tolerance: number;
-	regressed: boolean;
-}
-
-export function evaluateGate(
-	current: BenchResult,
-	baseline: BenchResult | null,
-	rules: GateRule[],
-): GateOutcome[] {
-	return rules.map((rule) => {
-		const cur = resolvePath(current, rule.path);
-		const base = baseline ? resolvePath(baseline, rule.path) : undefined;
-		const deltaPct =
-			base !== undefined && base !== 0 && cur !== undefined
-				? round(((cur - base) / base) * 100)
-				: undefined;
-		const absDelta =
-			base !== undefined && cur !== undefined ? cur - base : undefined;
-		const regressed =
-			deltaPct !== undefined &&
-			absDelta !== undefined &&
-			deltaPct > rule.tolerance * 100 &&
-			absDelta > (rule.noiseFloor ?? 0);
-		return {
-			path: rule.path,
-			label: rule.label ?? rule.path,
-			baseline: base,
-			current: cur,
-			deltaPct,
-			tolerance: rule.tolerance,
-			regressed,
-		};
+async function main(): Promise<void> {
+	const args = parseArgs(process.argv.slice(2));
+	const matrix = await loadOrRunMatrix(args.from);
+	if (matrix.sidecar.profile !== "release") {
+		throw new BaselineExitError(
+			2,
+			`refusing to write ${args.output} from ${matrix.sidecar.profile} sidecar provenance`,
+		);
+	}
+	const baseline = createMatrixBaseline(matrix, {
+		kind: args.kind,
+		iterations: Number(process.env.BENCH_ITERATIONS ?? 20),
+		warmup: Number(process.env.BENCH_WARMUP ?? 5),
 	});
+	if (baseline.engine.rowCount !== 70) {
+		throw new BaselineExitError(
+			2,
+			`refusing to write incomplete baseline: expected 70 matrix rows, got ${baseline.engine.rowCount}`,
+		);
+	}
+	writeJson(args.output, baseline);
+	printBaselineMetadata(baseline, args.output);
 }
 
-export function printDeltaTable(outcomes: GateOutcome[]): void {
-	const headers = ["metric", "baseline", "current", "delta%", "budget%", ""];
-	const rows = outcomes.map((o) => [
-		o.label,
-		o.baseline ?? "—",
-		o.current ?? "—",
-		o.deltaPct === undefined ? "—" : `${o.deltaPct > 0 ? "+" : ""}${o.deltaPct}`,
-		`±${round(o.tolerance * 100)}`,
-		o.baseline === undefined ? "NEW" : o.regressed ? "❌ REGRESSED" : "✓",
-	]);
-	const widths = headers.map((h, i) =>
-		Math.max(h.length, ...rows.map((r) => String(r[i]).length)),
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+	main().then(
+		() => process.exit(0),
+		(error) => {
+			const code = error instanceof BaselineExitError ? error.code : 1;
+			console.error(error instanceof Error ? error.message : error);
+			process.exit(code);
+		},
 	);
-	const fmt = (row: (string | number)[]) =>
-		row.map((c, i) => String(c).padStart(widths[i])).join(" | ");
-	console.error("");
-	console.error(fmt(headers));
-	console.error(widths.map((w) => "-".repeat(w)).join("-+-"));
-	for (const row of rows) console.error(fmt(row));
-	console.error("");
 }

--- a/packages/benchmarks/src/compare-baseline.ts
+++ b/packages/benchmarks/src/compare-baseline.ts
@@ -1,26 +1,158 @@
-import { existsSync } from "node:fs";
-import { compareBaseline } from "./lib/report.js";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import {
+	baselineRowFromLatency,
+	laneMetric,
+	loadMatrixBaseline,
+	type GateLane,
+	type MatrixBaseline,
+	type MatrixBaselineRow,
+} from "./baseline.js";
+import type { LatencyResult } from "./lib/layers.js";
+import { round } from "./lib/perf-utils.js";
 
-export function compareBaselineFile(currentPath: string, baselinePath: string) {
-	if (!existsSync(baselinePath)) {
+export interface GateRow {
+	key: string;
+	lane: GateLane;
+}
+
+export interface MatrixComparison {
+	key: string;
+	lane: GateLane;
+	baselineP50Ms?: number;
+	currentP50Ms?: number;
+	ratio?: number;
+	deltaMs?: number;
+	status: "pass" | "fail" | "ignored" | "missing-baseline" | "missing-current";
+	reason: string;
+}
+
+export function compareMatrixBaseline(
+	currentRows: MatrixBaselineRow[],
+	baseline: MatrixBaseline,
+	gateRows: GateRow[],
+	options: {
+		threshold: number;
+		tinyBaselineFloorMs: number;
+		tinyCurrentFloorMs: number;
+	},
+): MatrixComparison[] {
+	const currentByKey = new Map(currentRows.map((row) => [row.key, row]));
+	const baselineByKey = new Map(baseline.rows.map((row) => [row.key, row]));
+	return gateRows.map((gate) => {
+		const current = currentByKey.get(gate.key);
+		const base = baselineByKey.get(gate.key);
+		const currentMetric = current ? laneMetric(current, gate.lane) : undefined;
+		const baselineMetric = base ? laneMetric(base, gate.lane) : undefined;
+		if (!base || !baselineMetric) {
+			return {
+				key: gate.key,
+				lane: gate.lane,
+				currentP50Ms: currentMetric?.p50Ms,
+				status: "missing-baseline",
+				reason: "baseline has no p50 for this row/lane",
+			};
+		}
+		if (!current || !currentMetric) {
+			return {
+				key: gate.key,
+				lane: gate.lane,
+				baselineP50Ms: baselineMetric.p50Ms,
+				status: "missing-current",
+				reason: "current run has no p50 for this row/lane",
+			};
+		}
+		const ratio = round(currentMetric.p50Ms / baselineMetric.p50Ms, 2);
+		const deltaMs = round(currentMetric.p50Ms - baselineMetric.p50Ms, 3);
+		const tinyBaseline = baselineMetric.p50Ms < options.tinyBaselineFloorMs;
+		if (tinyBaseline && currentMetric.p50Ms < options.tinyCurrentFloorMs) {
+			return {
+				key: gate.key,
+				lane: gate.lane,
+				baselineP50Ms: baselineMetric.p50Ms,
+				currentP50Ms: currentMetric.p50Ms,
+				ratio,
+				deltaMs,
+				status: "ignored",
+				reason: `baseline < ${options.tinyBaselineFloorMs}ms and current < ${options.tinyCurrentFloorMs}ms`,
+			};
+		}
+		const failed = ratio > options.threshold;
+		return {
+			key: gate.key,
+			lane: gate.lane,
+			baselineP50Ms: baselineMetric.p50Ms,
+			currentP50Ms: currentMetric.p50Ms,
+			ratio,
+			deltaMs,
+			status: failed ? "fail" : "pass",
+			reason: failed ? `ratio ${ratio} > ${options.threshold}` : `ratio ${ratio} <= ${options.threshold}`,
+		};
+	});
+}
+
+export function latencyResultsToBaselineRows(
+	results: LatencyResult[],
+): MatrixBaselineRow[] {
+	return results.map(baselineRowFromLatency);
+}
+
+export function compareBaselineFile(
+	currentPath: string,
+	baselinePath: string,
+	gateRows: GateRow[] = [],
+	options: {
+		threshold: number;
+		tinyBaselineFloorMs: number;
+		tinyCurrentFloorMs: number;
+	} = {
+		threshold: 2,
+		tinyBaselineFloorMs: 0.3,
+		tinyCurrentFloorMs: 1,
+	},
+) {
+	const baseline = loadMatrixBaseline(baselinePath);
+	if (!baseline) {
 		return {
 			status: "missing-baseline",
 			baselinePath,
-			regressions: [],
+			rows: [],
 		};
 	}
-	const rows = compareBaseline(currentPath, baselinePath);
+	const currentJson = JSON.parse(readFileSync(currentPath, "utf8")) as {
+		latency?: LatencyResult[];
+		rows?: MatrixBaselineRow[];
+	};
+	const currentRows =
+		currentJson.rows ?? latencyResultsToBaselineRows(currentJson.latency ?? []);
+	const rows = compareMatrixBaseline(currentRows, baseline, gateRows, options);
 	return {
-		status: rows.some((row) => row.regressed) ? "regressed" : "ok",
-		regressions: rows.filter((row) => row.regressed),
+		status: rows.some((row) => row.status === "fail") ? "regressed" : "ok",
 		rows,
 	};
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
-	const current = process.argv[2] ?? "packages/benchmarks/results/findings.json";
-	const baseline =
-		process.argv[3] ??
-		"packages/benchmarks/results/baseline/findings-baseline.json";
-	console.log(JSON.stringify(compareBaselineFile(current, baseline), null, 2));
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+	const current = process.argv[2] ?? "packages/benchmarks/results/latency-matrix.json";
+	const baseline = process.argv[3] ?? "packages/benchmarks/results/baseline-local.json";
+	const rowsArg = process.argv[4] ?? "";
+	const gateRows = rowsArg
+		.split(",")
+		.map((row) => row.trim())
+		.filter(Boolean)
+		.map((row) => {
+			const [key, lane = "guest"] = row.split(":");
+			return { key, lane: lane as GateLane };
+		});
+	console.log(
+		JSON.stringify(
+			compareBaselineFile(current, baseline, gateRows, {
+				threshold: 2,
+				tinyBaselineFloorMs: 0.3,
+				tinyCurrentFloorMs: 1,
+			}),
+			null,
+			2,
+		),
+	);
 }

--- a/packages/benchmarks/src/families/fs.ts
+++ b/packages/benchmarks/src/families/fs.ts
@@ -8,7 +8,7 @@ function fsWriteOp(name: string, sizeBytes: number): BenchmarkOp {
 		nativeArgs: ["--size-bytes", String(sizeBytes)],
 		fileLine: "crates/kernel/src/kernel.rs:1930",
 		reproducer: `node fs.writeFileSync('/tmp/fuzz-perf-write.txt', ${sizeBytes} byte payload)`,
-		program: `async (i) => {
+	program: `async (i) => {
   const fs = await import("node:fs");
   fs.writeFileSync("/tmp/fuzz-perf-write.txt", Buffer.alloc(${sizeBytes}, i & 255));
 }`,

--- a/packages/benchmarks/src/quick-gate.ts
+++ b/packages/benchmarks/src/quick-gate.ts
@@ -1,0 +1,141 @@
+import { existsSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import {
+	baselinePathForEnvironment,
+	baselineRowFromLatency,
+	loadMatrixBaseline,
+	type GateLane,
+} from "./baseline.js";
+import { compareMatrixBaseline, type GateRow } from "./compare-baseline.js";
+import { printTable } from "./lib/perf-utils.js";
+import {
+	formatSidecarProvenance,
+	resolveBenchSidecarProvenance,
+} from "./lib/vm.js";
+
+const GATE_DEFAULTS = {
+	iterations: 9,
+	warmup: 3,
+	threshold: 2.0,
+	tinyBaselineFloorMs: 0.3,
+	tinyCurrentFloorMs: 1.0,
+	rows: [
+		{ key: "fs/fs_write_small", lane: "guest", reason: "tiny sync write hot path; protected by the 1ms tiny-row floor" },
+		{ key: "fs/fs_write_big", lane: "guest", reason: "large write payload catches whole-buffer copy regressions" },
+		{ key: "fs/fs_read_small", lane: "guest", reason: "small read bridge/VFS floor" },
+		{ key: "fs/stat_storm", lane: "guest", reason: "metadata syscall hot path" },
+		{ key: "fs/readdir_small", lane: "guest", reason: "directory enumeration without the high variance of large listings" },
+		{ key: "net/tcp_connect_close", lane: "guest", reason: "TCP socket lifecycle floor" },
+		{ key: "net/tcp_echo_small", lane: "guest", reason: "small TCP payload round trip" },
+		{ key: "net/http_loopback_get", lane: "guest", reason: "HTTP over kernel sockets with loopback server" },
+		{ key: "modules/import_fresh_file", lane: "guest", reason: "dynamic import and filesystem resolution" },
+		{ key: "modules/require_100_small", lane: "guest", reason: "CommonJS resolver/cache behavior" },
+		{ key: "control/cpu_loop", lane: "wasm", reason: "WASM runtime lane sanity check" },
+		{ key: "ecosystem/ls_100", lane: "vmCmd", reason: "end-to-end WASM command tier" },
+	] satisfies Array<GateRow & { reason: string }>,
+};
+
+class GateExitError extends Error {
+	constructor(
+		readonly code: number,
+		message: string,
+	) {
+		super(message);
+	}
+}
+
+async function main(): Promise<void> {
+	const baselinePath = baselinePathForEnvironment();
+	if (process.env.GITHUB_ACTIONS === "true" && !existsSync(baselinePath)) {
+		console.error(
+			`BENCH GATE SKIPPED: ${baselinePath} is missing. Run the nightly benchmark, download its candidate baseline-ci.json artifact, commit it, and PR gates will enforce from then on.`,
+		);
+		return;
+	}
+	const baseline = loadMatrixBaseline(baselinePath);
+	if (!baseline) {
+		throw new GateExitError(
+			2,
+			`BENCH GATE REFUSED: missing baseline ${baselinePath}. Regenerate with pnpm --dir packages/benchmarks bench:baseline.`,
+		);
+	}
+
+	const sidecar = resolveBenchSidecarProvenance();
+	console.error(formatSidecarProvenance(sidecar));
+	if (sidecar.profile !== "release") {
+		throw new GateExitError(
+			2,
+			`BENCH GATE REFUSED: sidecar provenance profile is ${sidecar.profile}; set SECURE_EXEC_SIDECAR_BIN to target/release/secure-exec-sidecar`,
+		);
+	}
+
+	const gateRows = selectedGateRows();
+	process.env.BENCH_OP_FILTER = gateRows.map((row) => row.key).join(",");
+	process.env.BENCH_ITERATIONS ??= String(GATE_DEFAULTS.iterations);
+	process.env.BENCH_WARMUP ??= String(GATE_DEFAULTS.warmup);
+
+	const { runLatencyMatrix } = await import("./run-all.js");
+	const matrix = await runLatencyMatrix();
+	const currentRows = matrix.results.map(baselineRowFromLatency);
+	const threshold = Number(process.env.BENCH_GATE_THRESHOLD ?? GATE_DEFAULTS.threshold);
+	const comparisons = compareMatrixBaseline(currentRows, baseline, gateRows, {
+		threshold,
+		tinyBaselineFloorMs: GATE_DEFAULTS.tinyBaselineFloorMs,
+		tinyCurrentFloorMs: GATE_DEFAULTS.tinyCurrentFloorMs,
+	});
+
+	console.error(
+		`Bench gate baseline: ${baselinePath}; threshold > ${threshold}x; tiny rows baseline < ${GATE_DEFAULTS.tinyBaselineFloorMs}ms ignored until current >= ${GATE_DEFAULTS.tinyCurrentFloorMs}ms`,
+	);
+	printTable(
+		["row", "lane", "baseline p50", "current p50", "ratio", "status", "reason"],
+		comparisons.map((row) => [
+			row.key,
+			row.lane,
+			row.baselineP50Ms === undefined ? "-" : `${row.baselineP50Ms}ms`,
+			row.currentP50Ms === undefined ? "-" : `${row.currentP50Ms}ms`,
+			row.ratio === undefined ? "-" : `${row.ratio}x`,
+			row.status.toUpperCase(),
+			row.reason,
+		]),
+	);
+
+	const failures = comparisons.filter((row) =>
+		["fail", "missing-baseline", "missing-current"].includes(row.status),
+	);
+	if (failures.length > 0) {
+		throw new GateExitError(
+			1,
+			`BENCH GATE FAILED: ${failures.length} row(s) exceeded threshold or were missing`,
+		);
+	}
+	console.error("BENCH GATE PASSED");
+}
+
+function selectedGateRows(): GateRow[] {
+	const override = process.env.BENCH_GATE_ROWS;
+	if (!override) return GATE_DEFAULTS.rows;
+	return override
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter(Boolean)
+		.map((entry) => {
+			const [key, lane] = entry.split(":");
+			const configured = GATE_DEFAULTS.rows.find((row) => row.key === key);
+			return {
+				key,
+				lane: (lane ?? configured?.lane ?? "guest") as GateLane,
+			};
+		});
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+	main().then(
+		() => process.exit(0),
+		(error) => {
+			const code = error instanceof GateExitError ? error.code : 1;
+			console.error(error instanceof Error ? error.message : error);
+			process.exit(code);
+		},
+	);
+}

--- a/packages/benchmarks/src/run-all.ts
+++ b/packages/benchmarks/src/run-all.ts
@@ -45,6 +45,7 @@ import { runFuzz } from "./fuzz/run.js";
 import { runLeakSuite } from "./leak.js";
 import { runFootprint } from "./footprint.js";
 import { compareBaselineFile } from "./compare-baseline.js";
+import { pathToFileURL } from "node:url";
 
 const RESULTS_DIR = new URL("../results/", import.meta.url).pathname;
 const ITERATIONS = Number(process.env.BENCH_ITERATIONS ?? 20);
@@ -432,10 +433,12 @@ function criticGaps(
 	return gaps;
 }
 
-main().then(
-	() => process.exit(0),
-	(error) => {
-		console.error(error);
-		process.exit(1);
-	},
-);
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+	main().then(
+		() => process.exit(0),
+		(error) => {
+			console.error(error);
+			process.exit(1);
+		},
+	);
+}


### PR DESCRIPTION
Wins must not silently regress:

- Canonical baseline (results/baseline-local.json, committed): full 70-row
  matrix from a RELEASE sidecar with hardware, binary provenance, and engine
  defaults embedded; regeneration procedure documented.
- bench:gate: 12 deterministic rows across fs/net/modules/wasm/command tiers,
  relative threshold (fail > 2.0x) with a sub-ms noise floor (baseline <0.3ms
  ignored until current >= 1ms); REFUSES debug binaries (exit 2). Verified to
  bite: a deliberate slowdown in fs_write_big failed at 3.57x and passed after
  revert.
- .github/workflows/bench.yml: PR quick-gate using the filtered install
  (pnpm --filter '@secure-exec/benchmarks...' works without the gitignored
  website vendor dir, so the gate is independent of the broken root install)
  + release builds; nightly full matrix uploading results. CI baselines
  bootstrap per-environment: nightly produces a baseline-ci.json candidate, a
  human commits it, then PRs are gated on runner-native numbers.