### PR TITLE
fix(core): drop the fixed 10ms trailing-output drain when exit arrives via event

### DIFF
--- a/packages/core/src/kernel-proxy.ts
+++ b/packages/core/src/kernel-proxy.ts
@@ -308,6 +308,7 @@ interface TrackedProcessEntry {
 	waitWithFallbackPromise: Promise<number> | null;
 	hostExitObservedAt: number | null;
 	outputGeneration: number;
+	exitViaEvent: boolean;
 }
 
 interface NativeSidecarKernelProxyOptions {
@@ -649,6 +650,7 @@ export class NativeSidecarKernelProxy {
 			waitWithFallbackPromise: null,
 			hostExitObservedAt: null,
 			outputGeneration: 0,
+			exitViaEvent: false,
 		};
 		this.trackedProcesses.set(pid, entry);
 		this.trackedProcessesById.set(processId, entry);
@@ -1463,6 +1465,16 @@ export class NativeSidecarKernelProxy {
 			return;
 		}
 
+		if (entry.exitViaEvent) {
+			// The sidecar drains process output before it emits `process_exited`,
+			// the stdio frame stream is FIFO, and this pump dispatches events in
+			// order. Once the exit event reaches this entry, no trailing output can
+			// follow it; one zero-delay turn is cheap insurance for same-tick
+			// listener scheduling.
+			await drainTrailingProcessOutputTurn(0);
+			return;
+		}
+
 		let observedGeneration = entry.outputGeneration;
 		let quietTurns = 0;
 		let delayMs = 0;
@@ -1499,7 +1511,10 @@ export class NativeSidecarKernelProxy {
 		entry.started = true;
 		this.updateTrackedProcessSnapshot(entry);
 		void this.refreshProcessSnapshot().catch(() => {});
-		await this.refreshSignalState(entry);
+		this.signalRefreshes.set(
+			entry.pid,
+			this.refreshSignalState(entry).catch(() => {}),
+		);
 
 		void this.flushPendingStdin(entry).catch((error) => {
 			this.handleBackgroundProcessError(entry, error);
@@ -1533,8 +1548,10 @@ export class NativeSidecarKernelProxy {
 					entry.outputGeneration += 1;
 					void this.refreshProcessSnapshot().catch(() => {});
 					if (!this.signalRefreshes.has(entry.pid)) {
-						this.signalRefreshes.set(entry.pid, this.refreshSignalState(entry));
-						await this.signalRefreshes.get(entry.pid);
+						this.signalRefreshes.set(
+							entry.pid,
+							this.refreshSignalState(entry).catch(() => {}),
+						);
 					}
 					const chunk = event.payload.chunk;
 					const listeners =
@@ -1553,7 +1570,7 @@ export class NativeSidecarKernelProxy {
 						continue;
 					}
 					void this.refreshProcessSnapshot().catch(() => {});
-					this.signalRefreshes.delete(entry.pid);
+					entry.exitViaEvent = true;
 					this.finishProcess(entry, event.payload.exit_code);
 				}
 			} catch (error) {
@@ -1583,6 +1600,10 @@ export class NativeSidecarKernelProxy {
 		if (entry.exitCode !== null) {
 			return;
 		}
+		// Every started process now parks a signal-state refresh here, so clean
+		// up on the shared exit path — the snapshot-poll fallback exits never
+		// pass through the event pump's `process_exited` branch.
+		this.signalRefreshes.delete(entry.pid);
 		entry.exitCode = exitCode;
 		entry.exitTime = Date.now();
 		this.updateTrackedProcessSnapshot(entry);
@@ -1658,6 +1679,7 @@ export class NativeSidecarKernelProxy {
 		entry: TrackedProcessEntry,
 		signal: number,
 	): Promise<void> {
+		await this.signalRefreshes.get(entry.pid);
 		try {
 			await this.client.killProcess(
 				this.session,

--- a/packages/core/tests/node-runtime-exec-output.test.ts
+++ b/packages/core/tests/node-runtime-exec-output.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { NodeRuntime } from "../src/index.js";
+
+describe("NodeRuntime execCommand output capture", () => {
+	test(
+		"captures complete stdout when a fast process exits immediately",
+		async () => {
+			const runtime = await NodeRuntime.create();
+			const expected = "x".repeat(64 * 1024);
+			const script = [
+				'const fs = require("node:fs");',
+				"const chunk = Buffer.alloc(4096, 120);",
+				"for (let i = 0; i < 16; i += 1) fs.writeSync(1, chunk);",
+				"process.exit(0);",
+			].join(" ");
+
+			try {
+				for (let i = 0; i < 10; i += 1) {
+					const result = await runtime.execCommand("node", ["-e", script]);
+
+					expect(result.exitCode).toBe(0);
+					expect(result.stdout).toBe(expected);
+					expect(result.stderr).toBe("");
+				}
+			} finally {
+				await runtime.dispose();
+			}
+		},
+		120_000,
+	);
+});


### PR DESCRIPTION
The sidecar drains process output before emitting process_exited and the
frame stream + event pump are FIFO, so once the exit event is observed no
trailing output can follow it; the host-side quiet-turn drain (2 turns at
10ms) only remains for the snapshot-poll fallback exit path. Also stop
awaiting signal-state refreshes on the exec critical path (start + first
output) — kill paths await the in-flight refresh instead — and clean up
the parked refresh in finishProcess so fallback exits release it too.

Warm host-driven exec p50: node -e '' 30ms -> ~17ms, wasm true 52ms ->
39ms; whole wasm-command-floor lane down ~13ms/row; bench:gate green.
New regression test: 10 sequential fast-exit 64KiB stdout captures.