### PR TITLE
fix(ci): install build-tools workspace deps in the bench workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -30,7 +30,10 @@ jobs:
         run: corepack enable
 
       - name: Install benchmark workspace dependencies
-        run: pnpm install --frozen-lockfile --filter "@secure-exec/benchmarks..."
+        run: pnpm install --frozen-lockfile --filter "@secure-exec/benchmarks..." --filter "@secure-exec/build-tools..."
+
+      - name: Build @secure-exec/core (bench ops import its dist)
+        run: pnpm --dir packages/core build
 
       - name: Build release benchmark binaries
         run: |
@@ -66,7 +69,15 @@ jobs:
         run: corepack enable
 
       - name: Install benchmark workspace dependencies
-        run: pnpm install --frozen-lockfile --filter "@secure-exec/benchmarks..."
+        run: pnpm install --frozen-lockfile --filter "@secure-exec/benchmarks..." --filter "@secure-exec/build-tools..."
+
+      - name: Build @secure-exec/core (bench ops import its dist)
+        run: pnpm --dir packages/core build
+
+      - name: Build guest WASM command binaries (VM boot + ecosystem rows)
+        run: |
+          make -C registry/native wasm
+          node packages/core/scripts/copy-wasm-commands.mjs
 
       - name: Build release benchmark binaries
         run: |

--- a/crates/execution/src/javascript.rs
+++ b/crates/execution/src/javascript.rs
@@ -2136,6 +2136,43 @@ impl JavascriptExecutionEngine {
         self.start_execution_with_module_reader(request, None, None)
     }
 
+    fn ensure_v8_host(&mut self) -> Result<(), JavascriptExecutionError> {
+        let should_spawn_v8_host = match self.v8_host.as_mut() {
+            Some(v8_host) => !v8_host
+                .is_alive()
+                .map_err(JavascriptExecutionError::Spawn)?,
+            None => true,
+        };
+        if should_spawn_v8_host {
+            self.v8_host = Some(V8RuntimeHost::spawn().map_err(JavascriptExecutionError::Spawn)?);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn snapshot_userland_ready(
+        &mut self,
+        userland_code: &str,
+    ) -> Result<bool, JavascriptExecutionError> {
+        self.ensure_v8_host()?;
+        Ok(self
+            .v8_host
+            .as_ref()
+            .expect("V8 host initialized")
+            .snapshot_ready(userland_code))
+    }
+
+    pub(crate) fn pre_warm_snapshot(
+        &mut self,
+        userland_code: &str,
+    ) -> Result<(), JavascriptExecutionError> {
+        self.ensure_v8_host()?;
+        self.v8_host
+            .as_ref()
+            .expect("V8 host initialized")
+            .pre_warm_snapshot(userland_code)
+            .map_err(JavascriptExecutionError::Spawn)
+    }
+
     /// Like [`start_execution`](Self::start_execution) but with an optional
     /// read-only VFS reader over the mounted `node_modules` tree. When supplied,
     /// the bridge thread resolves module-resolution RPCs inline against this
@@ -2179,16 +2216,7 @@ impl JavascriptExecutionEngine {
         let sync_rpc_timeout = javascript_sync_rpc_timeout(&request);
 
         let phase_start = Instant::now();
-        // Lazily spawn the V8 runtime host, or replace a dead shared host.
-        let should_spawn_v8_host = match self.v8_host.as_mut() {
-            Some(v8_host) => !v8_host
-                .is_alive()
-                .map_err(JavascriptExecutionError::Spawn)?,
-            None => true,
-        };
-        if should_spawn_v8_host {
-            self.v8_host = Some(V8RuntimeHost::spawn().map_err(JavascriptExecutionError::Spawn)?);
-        }
+        self.ensure_v8_host()?;
         let v8_host = self.v8_host.as_ref().unwrap();
         record_js_start_phase("js_start_v8_host_ready", phase_start.elapsed());
 

--- a/crates/execution/src/v8_host.rs
+++ b/crates/execution/src/v8_host.rs
@@ -105,6 +105,38 @@ impl V8RuntimeHost {
         })
     }
 
+    /// True when the process-wide snapshot cache already has this userland
+    /// bundle. This is a lookup only; it never creates a snapshot.
+    pub fn snapshot_ready(&self, userland_code: &str) -> bool {
+        self.shared
+            .runtime
+            .snapshot_ready(Self::bridge_code(), userland_code)
+    }
+
+    /// Kick a process-wide async warm for the wasm runner snapshot. At most one
+    /// warm thread is spawned per process; blocking callers should use
+    /// [`pre_warm_snapshot`](Self::pre_warm_snapshot).
+    pub fn warm_snapshot_async(userland_code: String) {
+        if userland_code.is_empty() {
+            return;
+        }
+        static WASM_RUNNER_WARM_STARTED: OnceLock<()> = OnceLock::new();
+        let _ = WASM_RUNNER_WARM_STARTED.get_or_init(|| {
+            let _ = thread::Builder::new()
+                .name(String::from("secure-exec-wasm-snapshot-warm"))
+                .spawn(move || {
+                    let Ok(host) = V8RuntimeHost::spawn() else {
+                        return;
+                    };
+                    if let Err(error) = host.pre_warm_snapshot(&userland_code) {
+                        eprintln!(
+                            "secure-exec-v8-runtime: wasm runner snapshot warm failed: {error}"
+                        );
+                    }
+                });
+        });
+    }
+
     /// Create a session handle for sending session-scoped frames and cleanup.
     pub fn session_handle(&self, session_id: String) -> V8SessionHandle {
         V8SessionHandle::new(session_id, Arc::clone(&self.shared.runtime))

--- a/crates/execution/src/wasm.rs
+++ b/crates/execution/src/wasm.rs
@@ -9,21 +9,21 @@ use crate::javascript::{
 use crate::node_import_cache::NodeImportCache;
 use crate::runtime_support::{env_flag_enabled, file_fingerprint, warmup_marker_path};
 use crate::signal::{NodeSignalDispositionAction, NodeSignalHandlerRegistration};
-use crate::v8_host::V8SessionHandle;
+use crate::v8_host::{V8RuntimeHost, V8SessionHandle};
 use crate::v8_runtime;
 use base64::Engine as _;
 use secure_exec_bridge::queue_tracker::{
     register_limit, warn_limit_exhausted, QueueGauge, TrackedLimit,
 };
 use serde_json::{json, Value};
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fmt;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::os::unix::fs::{FileExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 const WASM_MODULE_PATH_ENV: &str = "AGENTOS_WASM_MODULE_PATH";
@@ -92,6 +92,9 @@ const MAX_SYNC_WASM_PREWARM_MODULE_BYTES: u64 = 16 * 1024 * 1024;
 const WASM_CAPTURED_OUTPUT_LIMIT_BYTES: usize = 16 * 1024 * 1024;
 const WASM_SYNC_READ_LIMIT_BYTES: usize = 16 * 1024 * 1024;
 const WASM_INLINE_RUNNER_ENTRYPOINT: &str = "./__agentos_wasm_runner__.mjs";
+const WASM_SNAPSHOT_RUNNER_ENV: &str = "AGENTOS_WASM_SNAPSHOT_RUNNER";
+const WASM_RUNNER_NO_CACHE_ENV: &str = "AGENTOS_WASM_RUNNER_NO_CACHE";
+const WASM_MODULE_BASE64_CACHE_CAPACITY: usize = 64;
 const NODE_WASI_MODULE_SOURCE: &str = include_str!("../assets/runners/wasi-module.js");
 const WASM_SIDECAR_ROUTED_FS_SYNC_METHODS: &[&str] = &[
     "fs.accessSync",
@@ -1068,6 +1071,20 @@ fn handle_internal_wasm_sync_rpc_request(
 
     if wasm_sync_rpc_method_routes_through_sidecar_kernel(request, internal_sync_rpc) {
         return Ok(false);
+    }
+
+    if request.method == "__kernel_isatty" {
+        execution
+            .respond_sync_rpc_success(request.id, Value::Bool(false))
+            .map_err(map_javascript_error)?;
+        return Ok(true);
+    }
+
+    if request.method == "__kernel_tty_size" {
+        execution
+            .respond_sync_rpc_success(request.id, json!([80, 24]))
+            .map_err(map_javascript_error)?;
+        return Ok(true);
     }
 
     if request.method == "fs.openSync" {
@@ -2158,6 +2175,29 @@ struct WasmJavascriptExecutionOptions<'a> {
     warmup_metrics: Option<&'a [u8]>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WasmSnapshotRunnerMode {
+    Auto,
+    Block,
+    Off,
+}
+
+fn wasm_snapshot_runner_mode() -> WasmSnapshotRunnerMode {
+    match std::env::var(WASM_SNAPSHOT_RUNNER_ENV) {
+        Ok(value) if value.eq_ignore_ascii_case("block") => WasmSnapshotRunnerMode::Block,
+        Ok(value) if value.eq_ignore_ascii_case("off") => WasmSnapshotRunnerMode::Off,
+        Ok(value) if value.eq_ignore_ascii_case("auto") => WasmSnapshotRunnerMode::Auto,
+        Ok(value) => {
+            tracing::warn!(
+                value,
+                "{WASM_SNAPSHOT_RUNNER_ENV} must be auto, block, or off; using auto"
+            );
+            WasmSnapshotRunnerMode::Auto
+        }
+        Err(_) => WasmSnapshotRunnerMode::Auto,
+    }
+}
+
 fn start_wasm_javascript_execution(
     javascript_engine: &mut JavascriptExecutionEngine,
     import_cache: &NodeImportCache,
@@ -2171,16 +2211,71 @@ fn start_wasm_javascript_execution(
         request,
         options.frozen_time_ms,
         options.prewarm_only,
-    );
-    let inline_code =
-        build_wasm_runner_module_source(import_cache, &internal_env, options.warmup_metrics)?;
+    )?;
+    let snapshot_mode = wasm_snapshot_runner_mode();
     let mut env = request.env.clone();
-    env.extend(
-        internal_env
-            .iter()
-            .filter(|(key, _)| key.as_str() != "AGENTOS_WASM_MODULE_BASE64")
-            .map(|(key, value)| (key.clone(), value.clone())),
-    );
+    let mut guest_runtime = request.guest_runtime.clone();
+
+    let inline_code = match snapshot_mode {
+        WasmSnapshotRunnerMode::Off => {
+            env.extend(
+                internal_env
+                    .iter()
+                    .filter(|(key, _)| key.as_str() != "AGENTOS_WASM_MODULE_BASE64")
+                    .map(|(key, value)| (key.clone(), value.clone())),
+            );
+            build_wasm_runner_module_source(import_cache, &internal_env, options.warmup_metrics)?
+        }
+        WasmSnapshotRunnerMode::Auto | WasmSnapshotRunnerMode::Block => {
+            let userland_bundle = build_wasm_runner_userland_bundle(import_cache)?;
+            V8RuntimeHost::warm_snapshot_async(userland_bundle.clone());
+            let use_snapshot = match snapshot_mode {
+                WasmSnapshotRunnerMode::Block => {
+                    if !javascript_engine
+                        .snapshot_userland_ready(&userland_bundle)
+                        .map_err(map_javascript_error)?
+                    {
+                        javascript_engine
+                            .pre_warm_snapshot(&userland_bundle)
+                            .map_err(map_javascript_error)?;
+                    }
+                    true
+                }
+                WasmSnapshotRunnerMode::Auto => javascript_engine
+                    .snapshot_userland_ready(&userland_bundle)
+                    .unwrap_or(false),
+                WasmSnapshotRunnerMode::Off => false,
+            };
+
+            if use_snapshot {
+                env = request
+                    .env
+                    .iter()
+                    .filter(|(key, _)| !is_internal_wasm_guest_env_key(key))
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect();
+                env.extend(
+                    internal_env
+                        .iter()
+                        .map(|(key, value)| (key.clone(), value.clone())),
+                );
+                guest_runtime.snapshot_userland_code = Some(userland_bundle);
+                build_wasm_snapshot_runner_inline_code(options.warmup_metrics)
+            } else {
+                env.extend(
+                    internal_env
+                        .iter()
+                        .filter(|(key, _)| key.as_str() != "AGENTOS_WASM_MODULE_BASE64")
+                        .map(|(key, value)| (key.clone(), value.clone())),
+                );
+                build_wasm_runner_module_source(
+                    import_cache,
+                    &internal_env,
+                    options.warmup_metrics,
+                )?
+            }
+        }
+    };
 
     javascript_engine
         .start_execution(StartJavascriptExecutionRequest {
@@ -2200,10 +2295,69 @@ fn start_wasm_javascript_execution(
             },
             // Forward the guest-runtime identity so the runner's shim sets
             // process.* from typed config rather than env.
-            guest_runtime: request.guest_runtime.clone(),
+            guest_runtime,
             inline_code: Some(inline_code),
         })
         .map_err(map_javascript_error)
+}
+
+struct WasmModuleBase64Cache {
+    entries: HashMap<PathBuf, (String, Arc<String>)>,
+}
+
+fn wasm_module_base64_cache() -> &'static Mutex<WasmModuleBase64Cache> {
+    static CACHE: OnceLock<Mutex<WasmModuleBase64Cache>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        Mutex::new(WasmModuleBase64Cache {
+            entries: HashMap::new(),
+        })
+    })
+}
+
+fn cached_wasm_module_base64(path: &Path) -> Result<Arc<String>, WasmExecutionError> {
+    let current_fingerprint = file_fingerprint(path);
+    {
+        let cache = wasm_module_base64_cache()
+            .lock()
+            .expect("wasm module base64 cache lock poisoned");
+        if let Some((fingerprint, encoded)) = cache.entries.get(path) {
+            if fingerprint == &current_fingerprint {
+                return Ok(Arc::clone(encoded));
+            }
+        }
+    }
+
+    let module_bytes = fs::read(path).map_err(WasmExecutionError::PrepareWarmPath)?;
+    let encoded = Arc::new(v8_runtime::base64_encode_pub(&module_bytes));
+    let fingerprint = file_fingerprint(path);
+    let mut cache = wasm_module_base64_cache()
+        .lock()
+        .expect("wasm module base64 cache lock poisoned");
+    if !cache.entries.contains_key(path) && cache.entries.len() >= WASM_MODULE_BASE64_CACHE_CAPACITY
+    {
+        if let Some(evicted_path) = cache.entries.keys().next().cloned() {
+            cache.entries.remove(&evicted_path);
+            tracing::warn!(
+                path = %evicted_path.display(),
+                "evicting cached wasm module base64 entry"
+            );
+        }
+    }
+    cache
+        .entries
+        .insert(path.to_path_buf(), (fingerprint, Arc::clone(&encoded)));
+    let cumulative_bytes: usize = cache
+        .entries
+        .values()
+        .map(|(_, encoded)| encoded.len())
+        .sum();
+    tracing::debug!(
+        path = %path.display(),
+        encoded_bytes = encoded.len(),
+        cumulative_bytes,
+        "cached wasm module base64 entry"
+    );
+    Ok(encoded)
 }
 
 fn build_wasm_internal_env(
@@ -2211,7 +2365,7 @@ fn build_wasm_internal_env(
     request: &StartWasmExecutionRequest,
     frozen_time_ms: u128,
     prewarm_only: bool,
-) -> BTreeMap<String, String> {
+) -> Result<BTreeMap<String, String>, WasmExecutionError> {
     let guest_path_mappings = wasm_guest_path_mappings(request);
     let mut internal_env = request
         .env
@@ -2230,12 +2384,11 @@ fn build_wasm_internal_env(
         String::from("AGENTOS_FORWARD_KERNEL_STDIN_RPC"),
         String::from("1"),
     );
-    if let Ok(module_bytes) = fs::read(&resolved_module.resolved_path) {
-        internal_env.insert(
-            String::from("AGENTOS_WASM_MODULE_BASE64"),
-            v8_runtime::base64_encode_pub(&module_bytes),
-        );
-    }
+    let module_base64 = cached_wasm_module_base64(&resolved_module.resolved_path)?;
+    internal_env.insert(
+        String::from("AGENTOS_WASM_MODULE_BASE64"),
+        module_base64.as_ref().clone(),
+    );
     internal_env.insert(
         WASM_GUEST_ARGV_ENV.to_string(),
         encode_json_string_array(&warmup_guest_argv(resolved_module, request)),
@@ -2267,7 +2420,7 @@ fn build_wasm_internal_env(
     } else {
         internal_env.remove(WASM_PREWARM_ONLY_ENV);
     }
-    internal_env
+    Ok(internal_env)
 }
 
 fn insert_optional_u64_env(env: &mut BTreeMap<String, String>, key: &str, value: Option<u64>) {
@@ -2309,14 +2462,100 @@ fn build_wasm_runner_module_source(
     internal_env: &BTreeMap<String, String>,
     warmup_metrics: Option<&[u8]>,
 ) -> Result<String, WasmExecutionError> {
-    let runner_source = fs::read_to_string(import_cache.wasm_runner_path())
-        .map_err(WasmExecutionError::PrepareWarmPath)?;
-    let runner_source = runner_source.replace(
-        "import { WASI } from 'node:wasi';\n",
-        "const { WASI } = globalThis.__agentOSWasiModule;\n",
-    );
+    let runner_source = transformed_wasm_runner_source(import_cache)?;
     let bootstrap = build_wasm_runner_bootstrap(internal_env, warmup_metrics);
     Ok(insert_wasm_runner_bootstrap(&runner_source, &bootstrap))
+}
+
+fn transformed_wasm_runner_source(
+    import_cache: &NodeImportCache,
+) -> Result<String, WasmExecutionError> {
+    if std::env::var(WASM_RUNNER_NO_CACHE_ENV).as_deref() == Ok("1") {
+        return read_transformed_wasm_runner_source(import_cache);
+    }
+
+    static RUNNER_SOURCE: OnceLock<Result<Arc<str>, Arc<str>>> = OnceLock::new();
+    RUNNER_SOURCE
+        .get_or_init(|| {
+            read_transformed_wasm_runner_source(import_cache)
+                .map(Arc::<str>::from)
+                .map_err(|error| Arc::<str>::from(error.to_string()))
+        })
+        .as_ref()
+        .map(|source| source.to_string())
+        .map_err(|message| {
+            WasmExecutionError::PrepareWarmPath(std::io::Error::other(message.to_string()))
+        })
+}
+
+fn read_transformed_wasm_runner_source(
+    import_cache: &NodeImportCache,
+) -> Result<String, WasmExecutionError> {
+    let runner_source = fs::read_to_string(import_cache.wasm_runner_path())
+        .map_err(WasmExecutionError::PrepareWarmPath)?;
+    Ok(runner_source.replace(
+        "import { WASI } from 'node:wasi';\n",
+        "const { WASI } = globalThis.__agentOSWasiModule;\n",
+    ))
+}
+
+fn build_wasm_runner_userland_bundle(
+    import_cache: &NodeImportCache,
+) -> Result<String, WasmExecutionError> {
+    if std::env::var(WASM_RUNNER_NO_CACHE_ENV).as_deref() == Ok("1") {
+        return build_wasm_runner_userland_bundle_uncached(import_cache);
+    }
+
+    static USERLAND_BUNDLE: OnceLock<Result<Arc<str>, Arc<str>>> = OnceLock::new();
+    USERLAND_BUNDLE
+        .get_or_init(|| {
+            build_wasm_runner_userland_bundle_uncached(import_cache)
+                .map(Arc::<str>::from)
+                .map_err(|error| Arc::<str>::from(error.to_string()))
+        })
+        .as_ref()
+        .map(|bundle| bundle.to_string())
+        .map_err(|message| {
+            WasmExecutionError::PrepareWarmPath(std::io::Error::other(message.to_string()))
+        })
+}
+
+fn build_wasm_runner_userland_bundle_uncached(
+    import_cache: &NodeImportCache,
+) -> Result<String, WasmExecutionError> {
+    let runner_source = transformed_wasm_runner_source(import_cache)?;
+    if runner_source
+        .lines()
+        .any(|line| line.trim_start().starts_with("import "))
+    {
+        return Err(WasmExecutionError::PrepareWarmPath(std::io::Error::other(
+            "transformed wasm runner still contains an ESM import statement",
+        )));
+    }
+
+    let mut bundle = build_wasm_runner_snapshot_prelude();
+    bundle.push_str("\nglobalThis.__agentOSWasmRunnerRun = async function () {\n");
+    bundle.push_str(&runner_source);
+    bundle.push_str("\n};\n");
+    Ok(bundle)
+}
+
+fn build_wasm_runner_snapshot_prelude() -> String {
+    let bootstrap = build_wasm_runner_bootstrap(&BTreeMap::new(), None);
+    let bootstrap = bootstrap
+        .strip_prefix("const __agentOSWasmInternalEnv = {};\n")
+        .unwrap_or(&bootstrap);
+    bootstrap.replace(wasm_internal_env_merge_source(), "")
+}
+
+fn build_wasm_snapshot_runner_inline_code(warmup_metrics: Option<&[u8]>) -> String {
+    let warmup_emit = wasm_warmup_metrics_emit_source(warmup_metrics);
+    format!(
+        r#"{warmup_emit}if (typeof process !== "undefined" && typeof globalThis.__agentOSProcessConfigEnv === "object") {{
+  process.env = {{ ...(process.env || {{}}), ...globalThis.__agentOSProcessConfigEnv }};
+}}
+await globalThis.__agentOSWasmRunnerRun();"#
+    )
 }
 
 fn build_wasm_runner_bootstrap(
@@ -2325,18 +2564,9 @@ fn build_wasm_runner_bootstrap(
 ) -> String {
     let internal_env_json =
         serde_json::to_string(internal_env).unwrap_or_else(|_| String::from("{}"));
-    let warmup_metrics_json = warmup_metrics.map(|bytes| {
-        serde_json::to_string(&String::from_utf8_lossy(bytes).to_string())
-            .unwrap_or_else(|_| String::from("\"\""))
-    });
-    let warmup_emit = warmup_metrics_json
-		.map(|metrics| {
-			format!(
-				"if (typeof process?.stderr?.write === \"function\") {{\n  process.stderr.write({metrics});\n}}\n"
-			)
-		})
-		.unwrap_or_default();
+    let warmup_emit = wasm_warmup_metrics_emit_source(warmup_metrics);
     let wasi_module_source = render_native_wasi_module_source();
+    let env_merge_source = wasm_internal_env_merge_source();
 
     format!(
         r#"const __agentOSWasmInternalEnv = {internal_env_json};
@@ -2350,10 +2580,8 @@ const __agentOSRequireBuiltin = (specifier) => {{
   throw new Error(`secure-exec WASM bootstrap cannot load ${{specifier}}`);
 }};
 {wasi_module_source}
-if (typeof process !== "undefined") {{
-  process.env = {{ ...(process.env || {{}}), ...__agentOSWasmInternalEnv }};
-}}
-if (typeof globalThis !== "undefined" && typeof globalThis.__agentOSSyncRpc === "undefined") {{
+{env_merge_source}
+if (typeof globalThis !== "undefined") {{
   const __agentOSNormalizeBytes = (value) => {{
     if (value == null) {{
       return value;
@@ -2611,11 +2839,35 @@ if (typeof globalThis !== "undefined" && typeof globalThis.__agentOSSyncRpc === 
     )
 }
 
-fn render_native_wasi_module_source() -> String {
-    NODE_WASI_MODULE_SOURCE.replace(
-        "__SECURE_EXEC_WASM_SYNC_READ_LIMIT_BYTES__",
-        &WASM_SYNC_READ_LIMIT_BYTES.to_string(),
-    )
+fn wasm_warmup_metrics_emit_source(warmup_metrics: Option<&[u8]>) -> String {
+    let warmup_metrics_json = warmup_metrics.map(|bytes| {
+        serde_json::to_string(&String::from_utf8_lossy(bytes).to_string())
+            .unwrap_or_else(|_| String::from("\"\""))
+    });
+    warmup_metrics_json
+        .map(|metrics| {
+            format!(
+                "if (typeof process?.stderr?.write === \"function\") {{\n  process.stderr.write({metrics});\n}}\n"
+            )
+        })
+        .unwrap_or_default()
+}
+
+fn wasm_internal_env_merge_source() -> &'static str {
+    r#"if (typeof process !== "undefined") {
+  process.env = { ...(process.env || {}), ...__agentOSWasmInternalEnv };
+}
+"#
+}
+
+fn render_native_wasi_module_source() -> &'static str {
+    static SOURCE: OnceLock<String> = OnceLock::new();
+    SOURCE.get_or_init(|| {
+        NODE_WASI_MODULE_SOURCE.replace(
+            "__SECURE_EXEC_WASM_SYNC_READ_LIMIT_BYTES__",
+            &WASM_SYNC_READ_LIMIT_BYTES.to_string(),
+        )
+    })
 }
 
 fn insert_wasm_runner_bootstrap(source: &str, bootstrap: &str) -> String {

--- a/crates/execution/tests/wasm.rs
+++ b/crates/execution/tests/wasm.rs
@@ -46,6 +46,16 @@ impl EnvVarGuard {
         }
         Self { key, previous }
     }
+
+    fn set_value(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        // SAFETY: The wasm suite runs these env-sensitive cases serially inside
+        // one libtest entry.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
 }
 
 impl Drop for EnvVarGuard {
@@ -919,6 +929,116 @@ fn wasm_execution_runs_guest_module_through_v8() {
 
     let stdout = String::from_utf8(result.stdout).expect("stdout utf8");
     assert!(stdout.contains("stdout:wasm-smoke"));
+}
+
+fn wasm_snapshot_runner_block_round_trips_twice() {
+    assert_node_available();
+    let _mode = EnvVarGuard::set_value("AGENTOS_WASM_SNAPSHOT_RUNNER", "block");
+
+    let temp = tempdir().expect("create temp dir");
+    write_fixture(
+        &temp.path().join("guest.wasm"),
+        &wasm_stdout_chunks_module(&["hello\n"]),
+    );
+
+    let mut engine = WasmExecutionEngine::default();
+    let context = engine.create_context(CreateWasmContextRequest {
+        vm_id: String::from("vm-wasm"),
+        module_path: Some(String::from("./guest.wasm")),
+    });
+
+    let (first_stdout, first_stderr, first_exit) = run_wasm_execution(
+        &mut engine,
+        context.context_id.clone(),
+        temp.path(),
+        Vec::new(),
+        BTreeMap::new(),
+        WasmPermissionTier::Full,
+    );
+    assert_eq!(first_exit, 0, "stderr={first_stderr}");
+    assert_eq!(first_stdout, "hello\n");
+
+    let (second_stdout, second_stderr, second_exit) = run_wasm_execution(
+        &mut engine,
+        context.context_id,
+        temp.path(),
+        Vec::new(),
+        BTreeMap::new(),
+        WasmPermissionTier::Full,
+    );
+    assert_eq!(second_exit, 0, "stderr={second_stderr}");
+    assert_eq!(second_stdout, "hello\n");
+}
+
+fn wasm_snapshot_runner_off_fallback_matches_inline() {
+    assert_node_available();
+    let _mode = EnvVarGuard::set_value("AGENTOS_WASM_SNAPSHOT_RUNNER", "off");
+
+    let temp = tempdir().expect("create temp dir");
+    write_fixture(
+        &temp.path().join("guest.wasm"),
+        &wasm_stdout_chunks_module(&["hello\n"]),
+    );
+
+    let mut engine = WasmExecutionEngine::default();
+    let context = engine.create_context(CreateWasmContextRequest {
+        vm_id: String::from("vm-wasm"),
+        module_path: Some(String::from("./guest.wasm")),
+    });
+
+    let (stdout, stderr, exit_code) = run_wasm_execution(
+        &mut engine,
+        context.context_id,
+        temp.path(),
+        Vec::new(),
+        BTreeMap::new(),
+        WasmPermissionTier::Full,
+    );
+
+    assert_eq!(exit_code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "hello\n");
+}
+
+fn wasm_module_base64_cache_invalidates_when_file_changes() {
+    assert_node_available();
+    let _mode = EnvVarGuard::set_value("AGENTOS_WASM_SNAPSHOT_RUNNER", "block");
+
+    let temp = tempdir().expect("create temp dir");
+    let module_path = temp.path().join("guest.wasm");
+    write_fixture(&module_path, &wasm_stdout_chunks_module(&["first\n"]));
+
+    let mut engine = WasmExecutionEngine::default();
+    let context = engine.create_context(CreateWasmContextRequest {
+        vm_id: String::from("vm-wasm"),
+        module_path: Some(String::from("./guest.wasm")),
+    });
+
+    let (first_stdout, first_stderr, first_exit) = run_wasm_execution(
+        &mut engine,
+        context.context_id.clone(),
+        temp.path(),
+        Vec::new(),
+        BTreeMap::new(),
+        WasmPermissionTier::Full,
+    );
+    assert_eq!(first_exit, 0, "stderr={first_stderr}");
+    assert_eq!(first_stdout, "first\n");
+
+    write_fixture(
+        &module_path,
+        &wasm_stdout_chunks_module(&["second-output\n"]),
+    );
+
+    let (second_stdout, second_stderr, second_exit) = run_wasm_execution(
+        &mut engine,
+        context.context_id,
+        temp.path(),
+        Vec::new(),
+        BTreeMap::new(),
+        WasmPermissionTier::Full,
+    );
+    assert_eq!(second_exit, 0, "stderr={second_stderr}");
+    assert_eq!(second_stdout, "second-output\n");
 }
 
 fn wasm_execution_supports_fd_fdstat_set_flags() {
@@ -2491,6 +2611,9 @@ fn wasm_suite() {
     wasm_contexts_preserve_vm_and_module_configuration();
     wasm_execution_stays_inside_v8_runtime_without_host_node_launches();
     wasm_execution_runs_guest_module_through_v8();
+    wasm_snapshot_runner_block_round_trips_twice();
+    wasm_snapshot_runner_off_fallback_matches_inline();
+    wasm_module_base64_cache_invalidates_when_file_changes();
     wasm_execution_supports_fd_fdstat_set_flags();
     wasm_execution_ignores_guest_overrides_for_internal_node_env();
     wasm_execution_freezes_wasi_clock_time();

--- a/crates/v8-runtime/src/embedded_runtime.rs
+++ b/crates/v8-runtime/src/embedded_runtime.rs
@@ -51,7 +51,9 @@ impl EmbeddedV8Runtime {
         bridge::acquire_embedded_cbor_codec();
         isolate::init_v8_platform();
 
-        let snapshot_cache = Arc::new(SnapshotCache::new(4));
+        // Keep bridge-only, agent-SDK, and wasm-runner userland variants warm
+        // without immediately evicting each other.
+        let snapshot_cache = Arc::new(SnapshotCache::new(8));
         let (event_tx, event_rx) = crossbeam_channel::bounded::<RuntimeEventEnvelope>(1024);
         let (dispatch_shutdown_tx, dispatch_shutdown_rx) = crossbeam_channel::bounded::<()>(1);
         let call_id_router: CallIdRouter = Arc::new(Mutex::new(HashMap::new()));
@@ -104,6 +106,15 @@ impl EmbeddedV8Runtime {
 
     pub fn is_alive(&self) -> bool {
         self.alive.load(Ordering::Acquire)
+    }
+
+    pub fn snapshot_ready(&self, bridge_code: &str, userland_code: &str) -> bool {
+        if userland_code.is_empty() {
+            return true;
+        }
+        self.snapshot_cache
+            .try_get_with_userland(bridge_code, Some(userland_code))
+            .is_some()
     }
 
     pub fn register_session(&self, session_id: &str) -> io::Result<mpsc::Receiver<RuntimeEvent>> {
@@ -468,7 +479,9 @@ fn default_max_concurrency() -> usize {
 }
 
 fn run_embedded_runtime(stream: UnixStream, max_concurrency: usize) {
-    let snapshot_cache = Arc::new(SnapshotCache::new(4));
+    // Keep bridge-only, agent-SDK, and wasm-runner userland variants warm
+    // without immediately evicting each other.
+    let snapshot_cache = Arc::new(SnapshotCache::new(8));
     let writer_stream = match stream.try_clone() {
         Ok(writer_stream) => writer_stream,
         Err(error) => {

--- a/crates/v8-runtime/src/session.rs
+++ b/crates/v8-runtime/src/session.rs
@@ -1,11 +1,11 @@
 // Session management: create/destroy sessions with V8 isolates on dedicated threads
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::thread;
 #[cfg(not(test))]
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crossbeam_channel::{Receiver, Sender};
 #[cfg(not(test))]
@@ -58,6 +58,57 @@ const DEFERRED_COMMAND_LIMIT_ERROR_CODE: &str = "ERR_SESSION_DEFERRED_COMMAND_LI
 const SESSION_COMMAND_CHANNEL_CAPACITY: usize = 256;
 const MAX_DEFERRED_SESSION_COMMANDS: usize = SESSION_COMMAND_CHANNEL_CAPACITY;
 const MAX_DEFERRED_SYNC_MESSAGES: usize = SESSION_COMMAND_CHANNEL_CAPACITY;
+
+#[cfg(not(test))]
+#[derive(Default)]
+struct V8SessionPhaseStats {
+    calls: u64,
+    total_ns: u128,
+    max_ns: u128,
+}
+
+#[cfg(not(test))]
+static V8_SESSION_PHASES: OnceLock<Mutex<BTreeMap<String, V8SessionPhaseStats>>> = OnceLock::new();
+
+#[cfg(not(test))]
+fn v8_session_phases_enabled() -> bool {
+    std::env::var("AGENTOS_V8_SESSION_PHASES").as_deref() == Ok("1")
+}
+
+#[cfg(not(test))]
+fn record_v8_session_phase(stage: &str, elapsed: Duration) {
+    if !v8_session_phases_enabled() {
+        return;
+    }
+    let phases = V8_SESSION_PHASES.get_or_init(|| Mutex::new(BTreeMap::new()));
+    let Ok(mut phases) = phases.lock() else {
+        return;
+    };
+    let stats = phases.entry(stage.to_string()).or_default();
+    stats.calls += 1;
+    let elapsed_ns = elapsed.as_nanos();
+    stats.total_ns += elapsed_ns;
+    stats.max_ns = stats.max_ns.max(elapsed_ns);
+
+    let Some(path) = std::env::var_os("AGENTOS_V8_SESSION_PHASES_FILE") else {
+        return;
+    };
+    let mut output = String::new();
+    for (stage, stats) in phases.iter() {
+        let total_us = stats.total_ns / 1_000;
+        let avg_us = if stats.calls == 0 {
+            0
+        } else {
+            total_us / u128::from(stats.calls)
+        };
+        let max_us = stats.max_ns / 1_000;
+        output.push_str(&format!(
+            "stage={stage} calls={} total_us={total_us} avg_us={avg_us} max_us={max_us}\n",
+            stats.calls
+        ));
+    }
+    let _ = std::fs::write(path, output);
+}
 
 /// Normalize an opt-in CPU-time budget: `Some(0)` means "disabled" and folds to
 /// `None` so the CPU-budget watchdog is NOT armed. There is no default — when the
@@ -926,6 +977,7 @@ fn session_thread(
                             // The snapshot captures the bridge AND (when present) the
                             // agent-SDK userland bundle, keyed process-wide by both, so
                             // the SDK is evaluated once per sidecar and reused here.
+                            let phase_start = Instant::now();
                             let snapshot_blob = match snapshot_cache.get_or_create_with_userland(
                                 &effective_bridge_code,
                                 (!effective_userland_code.is_empty())
@@ -944,20 +996,33 @@ fn session_thread(
                                     None
                                 }
                             };
+                            record_v8_session_phase("snapshot_get", phase_start.elapsed());
                             let mut iso = match snapshot_blob {
                                 Some(blob) => {
                                     from_snapshot = true;
                                     eprintln!(
                                         "secure-exec-v8-runtime: restored session isolate from_snapshot=true"
                                     );
-                                    snapshot::create_isolate_from_snapshot(
-                                        (*blob).clone(),
+                                    let phase_start = Instant::now();
+                                    // rusty_v8 0.130's CreateParams::snapshot_blob
+                                    // takes owned 'static data, so this copy remains
+                                    // per exec until the API can accept cached bytes.
+                                    let snapshot_blob = (*blob).clone();
+                                    record_v8_session_phase("blob_clone", phase_start.elapsed());
+                                    let phase_start = Instant::now();
+                                    let isolate = snapshot::create_isolate_from_snapshot(
+                                        snapshot_blob,
                                         heap_limit_mb,
-                                    )
+                                    );
+                                    record_v8_session_phase("isolate_new", phase_start.elapsed());
+                                    isolate
                                 }
                                 None => {
                                     from_snapshot = false;
-                                    isolate::create_isolate(heap_limit_mb)
+                                    let phase_start = Instant::now();
+                                    let isolate = isolate::create_isolate(heap_limit_mb);
+                                    record_v8_session_phase("isolate_new", phase_start.elapsed());
+                                    isolate
                                 }
                             };
                             iso.set_host_import_module_dynamically_callback(
@@ -1234,6 +1299,7 @@ fn session_thread(
                         } else {
                             Some(file_path.as_str())
                         };
+                        let phase_start = Instant::now();
                         let (mut code, mut exports, mut error) = if mode == 0 {
                             let scope = &mut v8::HandleScope::new(iso);
                             let ctx = v8::Local::new(scope, &exec_context);
@@ -1276,6 +1342,7 @@ fn session_thread(
                                 error = next_error;
                             }
                         }
+                        record_v8_session_phase("user_code_execute", phase_start.elapsed());
 
                         // Run event loop while bridge work or async ESM
                         // evaluation is still pending. For ESM modules (mode != 0),

--- a/crates/v8-runtime/src/snapshot.rs
+++ b/crates/v8-runtime/src/snapshot.rs
@@ -137,6 +137,11 @@ fn run_snapshot_script(scope: &mut v8::HandleScope, code: &str, label: &str) -> 
         Some(source) => source,
         None => return Err(format!("failed to create V8 string for {label}")),
     };
+    // NOTE(perf, measured 2026-07-02): do NOT switch this to
+    // script_compiler::compile(EagerCompile) to bake function bytecode into the
+    // blob. It moves cost instead of removing it: user_code_execute dropped
+    // 8.9ms -> 7.9ms on the wasm-runner floor, but the fatter blob made
+    // isolate_new 4.0ms -> 7.4ms per exec (net wash).
     let Some(script) = v8::Script::compile(try_catch, source, None) else {
         let message = try_catch
             .exception()
@@ -611,6 +616,25 @@ impl SnapshotCache {
     /// prevents duplicate snapshot creation for the same bridge code.
     pub fn get_or_create(&self, bridge_code: &str) -> Result<Arc<Vec<u8>>, String> {
         self.get_or_create_with_userland(bridge_code, None)
+    }
+
+    /// Return a cached snapshot if present. This never creates a snapshot or
+    /// waits on in-flight creation.
+    pub fn try_get_with_userland(
+        &self,
+        bridge_code: &str,
+        userland_code: Option<&str>,
+    ) -> Option<Arc<Vec<u8>>> {
+        let key = snapshot_cache_key(bridge_code, userland_code);
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(pos) = inner.entries.iter().position(|e| e.key == key) {
+            let entry = inner.entries.remove(pos);
+            let blob = Arc::clone(&entry.blob);
+            inner.entries.push(entry);
+            Some(blob)
+        } else {
+            None
+        }
     }
 
     /// Like [`get_or_create`], but the snapshot also captures an evaluated userland

--- a/packages/core/src/kernel-proxy.ts
+++ b/packages/core/src/kernel-proxy.ts
@@ -308,6 +308,7 @@ interface TrackedProcessEntry {
 	waitWithFallbackPromise: Promise<number> | null;
 	hostExitObservedAt: number | null;
 	outputGeneration: number;
+	exitViaEvent: boolean;
 }
 
 interface NativeSidecarKernelProxyOptions {
@@ -649,6 +650,7 @@ export class NativeSidecarKernelProxy {
 			waitWithFallbackPromise: null,
 			hostExitObservedAt: null,
 			outputGeneration: 0,
+			exitViaEvent: false,
 		};
 		this.trackedProcesses.set(pid, entry);
 		this.trackedProcessesById.set(processId, entry);
@@ -1463,6 +1465,16 @@ export class NativeSidecarKernelProxy {
 			return;
 		}
 
+		if (entry.exitViaEvent) {
+			// The sidecar drains process output before it emits `process_exited`,
+			// the stdio frame stream is FIFO, and this pump dispatches events in
+			// order. Once the exit event reaches this entry, no trailing output can
+			// follow it; one zero-delay turn is cheap insurance for same-tick
+			// listener scheduling.
+			await drainTrailingProcessOutputTurn(0);
+			return;
+		}
+
 		let observedGeneration = entry.outputGeneration;
 		let quietTurns = 0;
 		let delayMs = 0;
@@ -1499,7 +1511,10 @@ export class NativeSidecarKernelProxy {
 		entry.started = true;
 		this.updateTrackedProcessSnapshot(entry);
 		void this.refreshProcessSnapshot().catch(() => {});
-		await this.refreshSignalState(entry);
+		this.signalRefreshes.set(
+			entry.pid,
+			this.refreshSignalState(entry).catch(() => {}),
+		);
 
 		void this.flushPendingStdin(entry).catch((error) => {
 			this.handleBackgroundProcessError(entry, error);
@@ -1533,8 +1548,10 @@ export class NativeSidecarKernelProxy {
 					entry.outputGeneration += 1;
 					void this.refreshProcessSnapshot().catch(() => {});
 					if (!this.signalRefreshes.has(entry.pid)) {
-						this.signalRefreshes.set(entry.pid, this.refreshSignalState(entry));
-						await this.signalRefreshes.get(entry.pid);
+						this.signalRefreshes.set(
+							entry.pid,
+							this.refreshSignalState(entry).catch(() => {}),
+						);
 					}
 					const chunk = event.payload.chunk;
 					const listeners =
@@ -1553,7 +1570,7 @@ export class NativeSidecarKernelProxy {
 						continue;
 					}
 					void this.refreshProcessSnapshot().catch(() => {});
-					this.signalRefreshes.delete(entry.pid);
+					entry.exitViaEvent = true;
 					this.finishProcess(entry, event.payload.exit_code);
 				}
 			} catch (error) {
@@ -1583,6 +1600,10 @@ export class NativeSidecarKernelProxy {
 		if (entry.exitCode !== null) {
 			return;
 		}
+		// Every started process now parks a signal-state refresh here, so clean
+		// up on the shared exit path — the snapshot-poll fallback exits never
+		// pass through the event pump's `process_exited` branch.
+		this.signalRefreshes.delete(entry.pid);
 		entry.exitCode = exitCode;
 		entry.exitTime = Date.now();
 		this.updateTrackedProcessSnapshot(entry);
@@ -1658,6 +1679,7 @@ export class NativeSidecarKernelProxy {
 		entry: TrackedProcessEntry,
 		signal: number,
 	): Promise<void> {
+		await this.signalRefreshes.get(entry.pid);
 		try {
 			await this.client.killProcess(
 				this.session,

--- a/packages/core/tests/node-runtime-exec-output.test.ts
+++ b/packages/core/tests/node-runtime-exec-output.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { NodeRuntime } from "../src/index.js";
+
+describe("NodeRuntime execCommand output capture", () => {
+	test(
+		"captures complete stdout when a fast process exits immediately",
+		async () => {
+			const runtime = await NodeRuntime.create();
+			const expected = "x".repeat(64 * 1024);
+			const script = [
+				'const fs = require("node:fs");',
+				"const chunk = Buffer.alloc(4096, 120);",
+				"for (let i = 0; i < 16; i += 1) fs.writeSync(1, chunk);",
+				"process.exit(0);",
+			].join(" ");
+
+			try {
+				for (let i = 0; i < 10; i += 1) {
+					const result = await runtime.execCommand("node", ["-e", script]);
+
+					expect(result.exitCode).toBe(0);
+					expect(result.stdout).toBe(expected);
+					expect(result.stderr).toBe("");
+				}
+			} finally {
+				await runtime.dispose();
+			}
+		},
+		120_000,
+	);
+});

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,8 @@
 [toolchain]
 channel = "1.96.0"
 components = ["clippy", "rustfmt"]
+# wasm32-wasip1 is a first-class build target (native-baseline wasm lane, the
+# registry command builds); declaring it here makes rustup provision it for the
+# pinned toolchain everywhere, instead of each CI workflow's toolchain action
+# only adding it to a different (stable) toolchain.
+targets = ["wasm32-wasip1"]


### PR DESCRIPTION
The filtered install (--filter @secure-exec/benchmarks...) omitted
packages/build-tools, so every bench-gate run died in the v8-bridge build
script (missing Node dependencies) before gating anything — the PR gate has
never actually run green on CI.