### PR TITLE
perf(v8-runtime): parked warm session workers

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -30,7 +30,10 @@ jobs:
         run: corepack enable
 
       - name: Install benchmark workspace dependencies
-        run: pnpm install --frozen-lockfile --filter "@secure-exec/benchmarks..."
+        run: pnpm install --frozen-lockfile --filter "@secure-exec/benchmarks..." --filter "@secure-exec/build-tools..."
+
+      - name: Build @secure-exec/core (bench ops import its dist)
+        run: pnpm --dir packages/core build
 
       - name: Build release benchmark binaries
         run: |
@@ -66,7 +69,15 @@ jobs:
         run: corepack enable
 
       - name: Install benchmark workspace dependencies
-        run: pnpm install --frozen-lockfile --filter "@secure-exec/benchmarks..."
+        run: pnpm install --frozen-lockfile --filter "@secure-exec/benchmarks..." --filter "@secure-exec/build-tools..."
+
+      - name: Build @secure-exec/core (bench ops import its dist)
+        run: pnpm --dir packages/core build
+
+      - name: Build guest WASM command binaries (VM boot + ecosystem rows)
+        run: |
+          make -C registry/native wasm
+          node packages/core/scripts/copy-wasm-commands.mjs
 
       - name: Build release benchmark binaries
         run: |

--- a/crates/execution/src/javascript.rs
+++ b/crates/execution/src/javascript.rs
@@ -12,6 +12,7 @@ use crate::v8_ipc::BinaryFrame;
 use crate::v8_runtime;
 use getrandom::getrandom;
 use secure_exec_bridge::queue_tracker::{register_queue, TrackedLimit, TrackedReceiver};
+use secure_exec_v8_runtime::runtime_protocol::{RuntimeCommand, WarmSessionHint};
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -2055,21 +2056,23 @@ fn register_v8_session<F>(
     heap_limit_mb: u32,
     cpu_time_limit_ms: u32,
     wall_clock_limit_ms: u32,
-    send_frame: F,
+    warm_hint: Option<WarmSessionHint>,
+    create_session: F,
 ) -> Result<PendingV8SessionRegistration<'_>, JavascriptExecutionError>
 where
-    F: FnOnce(&BinaryFrame) -> std::io::Result<()>,
+    F: FnOnce(RuntimeCommand) -> std::io::Result<()>,
 {
     let frame_receiver = v8_host
         .register_session(&session_id)
         .map_err(JavascriptExecutionError::Spawn)?;
     let registration_guard = V8SessionRegistrationGuard::new(v8_host, session_id.clone());
 
-    send_frame(&BinaryFrame::CreateSession {
+    create_session(RuntimeCommand::CreateSession {
         session_id,
-        heap_limit_mb,
-        cpu_time_limit_ms,
-        wall_clock_limit_ms,
+        heap_limit_mb: (heap_limit_mb > 0).then_some(heap_limit_mb),
+        cpu_time_limit_ms: (cpu_time_limit_ms > 0).then_some(cpu_time_limit_ms),
+        wall_clock_limit_ms: (wall_clock_limit_ms > 0).then_some(wall_clock_limit_ms),
+        warm_hint,
     })
     .map_err(JavascriptExecutionError::Spawn)?;
 
@@ -2173,6 +2176,20 @@ impl JavascriptExecutionEngine {
             .map_err(JavascriptExecutionError::Spawn)
     }
 
+    pub(crate) fn pre_warm_workers(
+        &mut self,
+        userland_code: &str,
+        heap_limit_mb: u32,
+        count: usize,
+    ) -> Result<(), JavascriptExecutionError> {
+        self.ensure_v8_host()?;
+        self.v8_host
+            .as_ref()
+            .expect("V8 host initialized")
+            .pre_warm_workers(userland_code, heap_limit_mb, count);
+        Ok(())
+    }
+
     /// Like [`start_execution`](Self::start_execution) but with an optional
     /// read-only VFS reader over the mounted `node_modules` tree. When supplied,
     /// the bridge thread resolves module-resolution RPCs inline against this
@@ -2229,6 +2246,19 @@ impl JavascriptExecutionEngine {
         let heap_limit_mb = javascript_heap_limit_mb(&request);
         let cpu_time_limit_ms = javascript_cpu_time_limit_ms(&request);
         let wall_clock_limit_ms = javascript_wall_clock_limit_ms(&request);
+        let snapshot_userland_code = request
+            .guest_runtime
+            .snapshot_userland_code
+            .clone()
+            .unwrap_or_default();
+        let warm_hint = Some(WarmSessionHint {
+            bridge_code: V8RuntimeHost::bridge_code().to_owned(),
+            userland_code: snapshot_userland_code.clone(),
+            heap_limit_mb: (heap_limit_mb > 0).then_some(heap_limit_mb),
+        });
+        if snapshot_userland_code.is_empty() && heap_limit_mb == 0 {
+            v8_host.seed_default_warm_workers_async();
+        }
         let PendingV8SessionRegistration {
             frame_receiver,
             mut registration_guard,
@@ -2238,7 +2268,8 @@ impl JavascriptExecutionEngine {
             heap_limit_mb,
             cpu_time_limit_ms,
             wall_clock_limit_ms,
-            |frame| v8_host.send_frame(frame),
+            warm_hint,
+            |command| v8_host.create_session_from_command(command),
         )?;
         record_js_start_phase("js_start_v8_session_register", phase_start.elapsed());
 
@@ -2363,11 +2394,7 @@ impl JavascriptExecutionEngine {
                 guest_entrypoint.clone(),
                 V8RuntimeHost::bridge_code().to_owned(),
                 String::new(),
-                request
-                    .guest_runtime
-                    .snapshot_userland_code
-                    .clone()
-                    .unwrap_or_default(),
+                snapshot_userland_code,
                 request.guest_runtime.high_resolution_time,
                 user_code,
             )
@@ -7499,15 +7526,16 @@ mod tests {
                 .as_nanos()
         );
 
-        let error = match register_v8_session(&host, session_id.clone(), 0, 0, 0, |_frame| {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::BrokenPipe,
-                "simulated CreateSession send failure",
-            ))
-        }) {
-            Ok(_) => panic!("register_v8_session should surface create-session send failures"),
-            Err(error) => error,
-        };
+        let error =
+            match register_v8_session(&host, session_id.clone(), 0, 0, 0, None, |_command| {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "simulated CreateSession send failure",
+                ))
+            }) {
+                Ok(_) => panic!("register_v8_session should surface create-session send failures"),
+                Err(error) => error,
+            };
 
         match error {
             JavascriptExecutionError::Spawn(inner) => {

--- a/crates/execution/src/javascript.rs
+++ b/crates/execution/src/javascript.rs
@@ -2136,6 +2136,43 @@ impl JavascriptExecutionEngine {
         self.start_execution_with_module_reader(request, None, None)
     }
 
+    fn ensure_v8_host(&mut self) -> Result<(), JavascriptExecutionError> {
+        let should_spawn_v8_host = match self.v8_host.as_mut() {
+            Some(v8_host) => !v8_host
+                .is_alive()
+                .map_err(JavascriptExecutionError::Spawn)?,
+            None => true,
+        };
+        if should_spawn_v8_host {
+            self.v8_host = Some(V8RuntimeHost::spawn().map_err(JavascriptExecutionError::Spawn)?);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn snapshot_userland_ready(
+        &mut self,
+        userland_code: &str,
+    ) -> Result<bool, JavascriptExecutionError> {
+        self.ensure_v8_host()?;
+        Ok(self
+            .v8_host
+            .as_ref()
+            .expect("V8 host initialized")
+            .snapshot_ready(userland_code))
+    }
+
+    pub(crate) fn pre_warm_snapshot(
+        &mut self,
+        userland_code: &str,
+    ) -> Result<(), JavascriptExecutionError> {
+        self.ensure_v8_host()?;
+        self.v8_host
+            .as_ref()
+            .expect("V8 host initialized")
+            .pre_warm_snapshot(userland_code)
+            .map_err(JavascriptExecutionError::Spawn)
+    }
+
     /// Like [`start_execution`](Self::start_execution) but with an optional
     /// read-only VFS reader over the mounted `node_modules` tree. When supplied,
     /// the bridge thread resolves module-resolution RPCs inline against this
@@ -2179,16 +2216,7 @@ impl JavascriptExecutionEngine {
         let sync_rpc_timeout = javascript_sync_rpc_timeout(&request);
 
         let phase_start = Instant::now();
-        // Lazily spawn the V8 runtime host, or replace a dead shared host.
-        let should_spawn_v8_host = match self.v8_host.as_mut() {
-            Some(v8_host) => !v8_host
-                .is_alive()
-                .map_err(JavascriptExecutionError::Spawn)?,
-            None => true,
-        };
-        if should_spawn_v8_host {
-            self.v8_host = Some(V8RuntimeHost::spawn().map_err(JavascriptExecutionError::Spawn)?);
-        }
+        self.ensure_v8_host()?;
         let v8_host = self.v8_host.as_ref().unwrap();
         record_js_start_phase("js_start_v8_host_ready", phase_start.elapsed());
 

--- a/crates/execution/src/v8_host.rs
+++ b/crates/execution/src/v8_host.rs
@@ -105,6 +105,38 @@ impl V8RuntimeHost {
         })
     }
 
+    /// True when the process-wide snapshot cache already has this userland
+    /// bundle. This is a lookup only; it never creates a snapshot.
+    pub fn snapshot_ready(&self, userland_code: &str) -> bool {
+        self.shared
+            .runtime
+            .snapshot_ready(Self::bridge_code(), userland_code)
+    }
+
+    /// Kick a process-wide async warm for the wasm runner snapshot. At most one
+    /// warm thread is spawned per process; blocking callers should use
+    /// [`pre_warm_snapshot`](Self::pre_warm_snapshot).
+    pub fn warm_snapshot_async(userland_code: String) {
+        if userland_code.is_empty() {
+            return;
+        }
+        static WASM_RUNNER_WARM_STARTED: OnceLock<()> = OnceLock::new();
+        let _ = WASM_RUNNER_WARM_STARTED.get_or_init(|| {
+            let _ = thread::Builder::new()
+                .name(String::from("secure-exec-wasm-snapshot-warm"))
+                .spawn(move || {
+                    let Ok(host) = V8RuntimeHost::spawn() else {
+                        return;
+                    };
+                    if let Err(error) = host.pre_warm_snapshot(&userland_code) {
+                        eprintln!(
+                            "secure-exec-v8-runtime: wasm runner snapshot warm failed: {error}"
+                        );
+                    }
+                });
+        });
+    }
+
     /// Create a session handle for sending session-scoped frames and cleanup.
     pub fn session_handle(&self, session_id: String) -> V8SessionHandle {
         V8SessionHandle::new(session_id, Arc::clone(&self.shared.runtime))

--- a/crates/execution/src/v8_host.rs
+++ b/crates/execution/src/v8_host.rs
@@ -5,7 +5,7 @@ use secure_exec_bridge::queue_tracker::{tracked_sync_channel, TrackedLimit, Trac
 use secure_exec_v8_runtime::embedded_runtime::{
     shared_embedded_runtime, EmbeddedV8Runtime, EmbeddedV8SessionHandle,
 };
-use secure_exec_v8_runtime::runtime_protocol::{RuntimeCommand, RuntimeEvent};
+use secure_exec_v8_runtime::runtime_protocol::{RuntimeCommand, RuntimeEvent, WarmSessionHint};
 use std::io::{self, Cursor};
 use std::sync::{Arc, OnceLock};
 use std::thread;
@@ -80,6 +80,27 @@ impl V8RuntimeHost {
         self.shared.runtime.unregister_session(session_id);
     }
 
+    pub fn create_session(
+        &self,
+        session_id: String,
+        heap_limit_mb: u32,
+        cpu_time_limit_ms: u32,
+        wall_clock_limit_ms: u32,
+        warm_hint: Option<WarmSessionHint>,
+    ) -> io::Result<()> {
+        self.shared.runtime.dispatch(RuntimeCommand::CreateSession {
+            session_id,
+            heap_limit_mb: non_zero_option(heap_limit_mb),
+            cpu_time_limit_ms: non_zero_option(cpu_time_limit_ms),
+            wall_clock_limit_ms: non_zero_option(wall_clock_limit_ms),
+            warm_hint,
+        })
+    }
+
+    pub fn create_session_from_command(&self, command: RuntimeCommand) -> io::Result<()> {
+        self.shared.runtime.dispatch(command)
+    }
+
     /// Send a frame to the V8 runtime.
     pub fn send_frame(&self, frame: &BinaryFrame) -> io::Result<()> {
         self.shared.runtime.dispatch(to_runtime_command(frame)?)
@@ -103,6 +124,32 @@ impl V8RuntimeHost {
             bridge_code: Self::bridge_code().to_owned(),
             userland_code: userland_code.to_owned(),
         })
+    }
+
+    pub fn pre_warm_workers(&self, userland_code: &str, heap_limit_mb: u32, count: usize) {
+        self.shared.runtime.pre_warm_workers(
+            Self::bridge_code().to_owned(),
+            userland_code.to_owned(),
+            non_zero_option(heap_limit_mb),
+            count,
+        );
+    }
+
+    pub fn seed_default_warm_workers_async(&self) {
+        static DEFAULT_WARM_STARTED: OnceLock<()> = OnceLock::new();
+        let runtime = Arc::clone(&self.shared.runtime);
+        let _ = DEFAULT_WARM_STARTED.get_or_init(|| {
+            let _ = thread::Builder::new()
+                .name(String::from("secure-exec-v8-default-warm"))
+                .spawn(move || {
+                    runtime.pre_warm_workers(
+                        V8_BRIDGE_CODE.to_owned(),
+                        String::new(),
+                        None,
+                        warm_worker_count(),
+                    );
+                });
+        });
     }
 
     /// True when the process-wide snapshot cache already has this userland
@@ -132,6 +179,7 @@ impl V8RuntimeHost {
                         eprintln!(
                             "secure-exec-v8-runtime: wasm runner snapshot warm failed: {error}"
                         );
+                        return;
                     }
                 });
         });
@@ -154,6 +202,17 @@ impl V8RuntimeHost {
     fn runtime_ptr(&self) -> usize {
         Arc::as_ptr(&self.shared.runtime) as usize
     }
+}
+
+fn non_zero_option(value: u32) -> Option<u32> {
+    (value > 0).then_some(value)
+}
+
+fn warm_worker_count() -> usize {
+    std::env::var("AGENTOS_V8_WARM_ISOLATES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(2)
 }
 
 /// A handle to a single V8 session within the shared runtime.

--- a/crates/execution/src/wasm.rs
+++ b/crates/execution/src/wasm.rs
@@ -9,21 +9,21 @@ use crate::javascript::{
 use crate::node_import_cache::NodeImportCache;
 use crate::runtime_support::{env_flag_enabled, file_fingerprint, warmup_marker_path};
 use crate::signal::{NodeSignalDispositionAction, NodeSignalHandlerRegistration};
-use crate::v8_host::V8SessionHandle;
+use crate::v8_host::{V8RuntimeHost, V8SessionHandle};
 use crate::v8_runtime;
 use base64::Engine as _;
 use secure_exec_bridge::queue_tracker::{
     register_limit, warn_limit_exhausted, QueueGauge, TrackedLimit,
 };
 use serde_json::{json, Value};
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fmt;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::os::unix::fs::{FileExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 const WASM_MODULE_PATH_ENV: &str = "AGENTOS_WASM_MODULE_PATH";
@@ -92,6 +92,9 @@ const MAX_SYNC_WASM_PREWARM_MODULE_BYTES: u64 = 16 * 1024 * 1024;
 const WASM_CAPTURED_OUTPUT_LIMIT_BYTES: usize = 16 * 1024 * 1024;
 const WASM_SYNC_READ_LIMIT_BYTES: usize = 16 * 1024 * 1024;
 const WASM_INLINE_RUNNER_ENTRYPOINT: &str = "./__agentos_wasm_runner__.mjs";
+const WASM_SNAPSHOT_RUNNER_ENV: &str = "AGENTOS_WASM_SNAPSHOT_RUNNER";
+const WASM_RUNNER_NO_CACHE_ENV: &str = "AGENTOS_WASM_RUNNER_NO_CACHE";
+const WASM_MODULE_BASE64_CACHE_CAPACITY: usize = 64;
 const NODE_WASI_MODULE_SOURCE: &str = include_str!("../assets/runners/wasi-module.js");
 const WASM_SIDECAR_ROUTED_FS_SYNC_METHODS: &[&str] = &[
     "fs.accessSync",
@@ -1068,6 +1071,20 @@ fn handle_internal_wasm_sync_rpc_request(
 
     if wasm_sync_rpc_method_routes_through_sidecar_kernel(request, internal_sync_rpc) {
         return Ok(false);
+    }
+
+    if request.method == "__kernel_isatty" {
+        execution
+            .respond_sync_rpc_success(request.id, Value::Bool(false))
+            .map_err(map_javascript_error)?;
+        return Ok(true);
+    }
+
+    if request.method == "__kernel_tty_size" {
+        execution
+            .respond_sync_rpc_success(request.id, json!([80, 24]))
+            .map_err(map_javascript_error)?;
+        return Ok(true);
     }
 
     if request.method == "fs.openSync" {
@@ -2158,6 +2175,29 @@ struct WasmJavascriptExecutionOptions<'a> {
     warmup_metrics: Option<&'a [u8]>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WasmSnapshotRunnerMode {
+    Auto,
+    Block,
+    Off,
+}
+
+fn wasm_snapshot_runner_mode() -> WasmSnapshotRunnerMode {
+    match std::env::var(WASM_SNAPSHOT_RUNNER_ENV) {
+        Ok(value) if value.eq_ignore_ascii_case("block") => WasmSnapshotRunnerMode::Block,
+        Ok(value) if value.eq_ignore_ascii_case("off") => WasmSnapshotRunnerMode::Off,
+        Ok(value) if value.eq_ignore_ascii_case("auto") => WasmSnapshotRunnerMode::Auto,
+        Ok(value) => {
+            tracing::warn!(
+                value,
+                "{WASM_SNAPSHOT_RUNNER_ENV} must be auto, block, or off; using auto"
+            );
+            WasmSnapshotRunnerMode::Auto
+        }
+        Err(_) => WasmSnapshotRunnerMode::Auto,
+    }
+}
+
 fn start_wasm_javascript_execution(
     javascript_engine: &mut JavascriptExecutionEngine,
     import_cache: &NodeImportCache,
@@ -2171,16 +2211,71 @@ fn start_wasm_javascript_execution(
         request,
         options.frozen_time_ms,
         options.prewarm_only,
-    );
-    let inline_code =
-        build_wasm_runner_module_source(import_cache, &internal_env, options.warmup_metrics)?;
+    )?;
+    let snapshot_mode = wasm_snapshot_runner_mode();
     let mut env = request.env.clone();
-    env.extend(
-        internal_env
-            .iter()
-            .filter(|(key, _)| key.as_str() != "AGENTOS_WASM_MODULE_BASE64")
-            .map(|(key, value)| (key.clone(), value.clone())),
-    );
+    let mut guest_runtime = request.guest_runtime.clone();
+
+    let inline_code = match snapshot_mode {
+        WasmSnapshotRunnerMode::Off => {
+            env.extend(
+                internal_env
+                    .iter()
+                    .filter(|(key, _)| key.as_str() != "AGENTOS_WASM_MODULE_BASE64")
+                    .map(|(key, value)| (key.clone(), value.clone())),
+            );
+            build_wasm_runner_module_source(import_cache, &internal_env, options.warmup_metrics)?
+        }
+        WasmSnapshotRunnerMode::Auto | WasmSnapshotRunnerMode::Block => {
+            let userland_bundle = build_wasm_runner_userland_bundle(import_cache)?;
+            V8RuntimeHost::warm_snapshot_async(userland_bundle.clone());
+            let use_snapshot = match snapshot_mode {
+                WasmSnapshotRunnerMode::Block => {
+                    if !javascript_engine
+                        .snapshot_userland_ready(&userland_bundle)
+                        .map_err(map_javascript_error)?
+                    {
+                        javascript_engine
+                            .pre_warm_snapshot(&userland_bundle)
+                            .map_err(map_javascript_error)?;
+                    }
+                    true
+                }
+                WasmSnapshotRunnerMode::Auto => javascript_engine
+                    .snapshot_userland_ready(&userland_bundle)
+                    .unwrap_or(false),
+                WasmSnapshotRunnerMode::Off => false,
+            };
+
+            if use_snapshot {
+                env = request
+                    .env
+                    .iter()
+                    .filter(|(key, _)| !is_internal_wasm_guest_env_key(key))
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect();
+                env.extend(
+                    internal_env
+                        .iter()
+                        .map(|(key, value)| (key.clone(), value.clone())),
+                );
+                guest_runtime.snapshot_userland_code = Some(userland_bundle);
+                build_wasm_snapshot_runner_inline_code(options.warmup_metrics)
+            } else {
+                env.extend(
+                    internal_env
+                        .iter()
+                        .filter(|(key, _)| key.as_str() != "AGENTOS_WASM_MODULE_BASE64")
+                        .map(|(key, value)| (key.clone(), value.clone())),
+                );
+                build_wasm_runner_module_source(
+                    import_cache,
+                    &internal_env,
+                    options.warmup_metrics,
+                )?
+            }
+        }
+    };
 
     javascript_engine
         .start_execution(StartJavascriptExecutionRequest {
@@ -2200,10 +2295,69 @@ fn start_wasm_javascript_execution(
             },
             // Forward the guest-runtime identity so the runner's shim sets
             // process.* from typed config rather than env.
-            guest_runtime: request.guest_runtime.clone(),
+            guest_runtime,
             inline_code: Some(inline_code),
         })
         .map_err(map_javascript_error)
+}
+
+struct WasmModuleBase64Cache {
+    entries: HashMap<PathBuf, (String, Arc<String>)>,
+}
+
+fn wasm_module_base64_cache() -> &'static Mutex<WasmModuleBase64Cache> {
+    static CACHE: OnceLock<Mutex<WasmModuleBase64Cache>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        Mutex::new(WasmModuleBase64Cache {
+            entries: HashMap::new(),
+        })
+    })
+}
+
+fn cached_wasm_module_base64(path: &Path) -> Result<Arc<String>, WasmExecutionError> {
+    let current_fingerprint = file_fingerprint(path);
+    {
+        let cache = wasm_module_base64_cache()
+            .lock()
+            .expect("wasm module base64 cache lock poisoned");
+        if let Some((fingerprint, encoded)) = cache.entries.get(path) {
+            if fingerprint == &current_fingerprint {
+                return Ok(Arc::clone(encoded));
+            }
+        }
+    }
+
+    let module_bytes = fs::read(path).map_err(WasmExecutionError::PrepareWarmPath)?;
+    let encoded = Arc::new(v8_runtime::base64_encode_pub(&module_bytes));
+    let fingerprint = file_fingerprint(path);
+    let mut cache = wasm_module_base64_cache()
+        .lock()
+        .expect("wasm module base64 cache lock poisoned");
+    if !cache.entries.contains_key(path) && cache.entries.len() >= WASM_MODULE_BASE64_CACHE_CAPACITY
+    {
+        if let Some(evicted_path) = cache.entries.keys().next().cloned() {
+            cache.entries.remove(&evicted_path);
+            tracing::warn!(
+                path = %evicted_path.display(),
+                "evicting cached wasm module base64 entry"
+            );
+        }
+    }
+    cache
+        .entries
+        .insert(path.to_path_buf(), (fingerprint, Arc::clone(&encoded)));
+    let cumulative_bytes: usize = cache
+        .entries
+        .values()
+        .map(|(_, encoded)| encoded.len())
+        .sum();
+    tracing::debug!(
+        path = %path.display(),
+        encoded_bytes = encoded.len(),
+        cumulative_bytes,
+        "cached wasm module base64 entry"
+    );
+    Ok(encoded)
 }
 
 fn build_wasm_internal_env(
@@ -2211,7 +2365,7 @@ fn build_wasm_internal_env(
     request: &StartWasmExecutionRequest,
     frozen_time_ms: u128,
     prewarm_only: bool,
-) -> BTreeMap<String, String> {
+) -> Result<BTreeMap<String, String>, WasmExecutionError> {
     let guest_path_mappings = wasm_guest_path_mappings(request);
     let mut internal_env = request
         .env
@@ -2230,12 +2384,11 @@ fn build_wasm_internal_env(
         String::from("AGENTOS_FORWARD_KERNEL_STDIN_RPC"),
         String::from("1"),
     );
-    if let Ok(module_bytes) = fs::read(&resolved_module.resolved_path) {
-        internal_env.insert(
-            String::from("AGENTOS_WASM_MODULE_BASE64"),
-            v8_runtime::base64_encode_pub(&module_bytes),
-        );
-    }
+    let module_base64 = cached_wasm_module_base64(&resolved_module.resolved_path)?;
+    internal_env.insert(
+        String::from("AGENTOS_WASM_MODULE_BASE64"),
+        module_base64.as_ref().clone(),
+    );
     internal_env.insert(
         WASM_GUEST_ARGV_ENV.to_string(),
         encode_json_string_array(&warmup_guest_argv(resolved_module, request)),
@@ -2267,7 +2420,7 @@ fn build_wasm_internal_env(
     } else {
         internal_env.remove(WASM_PREWARM_ONLY_ENV);
     }
-    internal_env
+    Ok(internal_env)
 }
 
 fn insert_optional_u64_env(env: &mut BTreeMap<String, String>, key: &str, value: Option<u64>) {
@@ -2309,14 +2462,100 @@ fn build_wasm_runner_module_source(
     internal_env: &BTreeMap<String, String>,
     warmup_metrics: Option<&[u8]>,
 ) -> Result<String, WasmExecutionError> {
-    let runner_source = fs::read_to_string(import_cache.wasm_runner_path())
-        .map_err(WasmExecutionError::PrepareWarmPath)?;
-    let runner_source = runner_source.replace(
-        "import { WASI } from 'node:wasi';\n",
-        "const { WASI } = globalThis.__agentOSWasiModule;\n",
-    );
+    let runner_source = transformed_wasm_runner_source(import_cache)?;
     let bootstrap = build_wasm_runner_bootstrap(internal_env, warmup_metrics);
     Ok(insert_wasm_runner_bootstrap(&runner_source, &bootstrap))
+}
+
+fn transformed_wasm_runner_source(
+    import_cache: &NodeImportCache,
+) -> Result<String, WasmExecutionError> {
+    if std::env::var(WASM_RUNNER_NO_CACHE_ENV).as_deref() == Ok("1") {
+        return read_transformed_wasm_runner_source(import_cache);
+    }
+
+    static RUNNER_SOURCE: OnceLock<Result<Arc<str>, Arc<str>>> = OnceLock::new();
+    RUNNER_SOURCE
+        .get_or_init(|| {
+            read_transformed_wasm_runner_source(import_cache)
+                .map(Arc::<str>::from)
+                .map_err(|error| Arc::<str>::from(error.to_string()))
+        })
+        .as_ref()
+        .map(|source| source.to_string())
+        .map_err(|message| {
+            WasmExecutionError::PrepareWarmPath(std::io::Error::other(message.to_string()))
+        })
+}
+
+fn read_transformed_wasm_runner_source(
+    import_cache: &NodeImportCache,
+) -> Result<String, WasmExecutionError> {
+    let runner_source = fs::read_to_string(import_cache.wasm_runner_path())
+        .map_err(WasmExecutionError::PrepareWarmPath)?;
+    Ok(runner_source.replace(
+        "import { WASI } from 'node:wasi';\n",
+        "const { WASI } = globalThis.__agentOSWasiModule;\n",
+    ))
+}
+
+fn build_wasm_runner_userland_bundle(
+    import_cache: &NodeImportCache,
+) -> Result<String, WasmExecutionError> {
+    if std::env::var(WASM_RUNNER_NO_CACHE_ENV).as_deref() == Ok("1") {
+        return build_wasm_runner_userland_bundle_uncached(import_cache);
+    }
+
+    static USERLAND_BUNDLE: OnceLock<Result<Arc<str>, Arc<str>>> = OnceLock::new();
+    USERLAND_BUNDLE
+        .get_or_init(|| {
+            build_wasm_runner_userland_bundle_uncached(import_cache)
+                .map(Arc::<str>::from)
+                .map_err(|error| Arc::<str>::from(error.to_string()))
+        })
+        .as_ref()
+        .map(|bundle| bundle.to_string())
+        .map_err(|message| {
+            WasmExecutionError::PrepareWarmPath(std::io::Error::other(message.to_string()))
+        })
+}
+
+fn build_wasm_runner_userland_bundle_uncached(
+    import_cache: &NodeImportCache,
+) -> Result<String, WasmExecutionError> {
+    let runner_source = transformed_wasm_runner_source(import_cache)?;
+    if runner_source
+        .lines()
+        .any(|line| line.trim_start().starts_with("import "))
+    {
+        return Err(WasmExecutionError::PrepareWarmPath(std::io::Error::other(
+            "transformed wasm runner still contains an ESM import statement",
+        )));
+    }
+
+    let mut bundle = build_wasm_runner_snapshot_prelude();
+    bundle.push_str("\nglobalThis.__agentOSWasmRunnerRun = async function () {\n");
+    bundle.push_str(&runner_source);
+    bundle.push_str("\n};\n");
+    Ok(bundle)
+}
+
+fn build_wasm_runner_snapshot_prelude() -> String {
+    let bootstrap = build_wasm_runner_bootstrap(&BTreeMap::new(), None);
+    let bootstrap = bootstrap
+        .strip_prefix("const __agentOSWasmInternalEnv = {};\n")
+        .unwrap_or(&bootstrap);
+    bootstrap.replace(wasm_internal_env_merge_source(), "")
+}
+
+fn build_wasm_snapshot_runner_inline_code(warmup_metrics: Option<&[u8]>) -> String {
+    let warmup_emit = wasm_warmup_metrics_emit_source(warmup_metrics);
+    format!(
+        r#"{warmup_emit}if (typeof process !== "undefined" && typeof globalThis.__agentOSProcessConfigEnv === "object") {{
+  process.env = {{ ...(process.env || {{}}), ...globalThis.__agentOSProcessConfigEnv }};
+}}
+await globalThis.__agentOSWasmRunnerRun();"#
+    )
 }
 
 fn build_wasm_runner_bootstrap(
@@ -2325,18 +2564,9 @@ fn build_wasm_runner_bootstrap(
 ) -> String {
     let internal_env_json =
         serde_json::to_string(internal_env).unwrap_or_else(|_| String::from("{}"));
-    let warmup_metrics_json = warmup_metrics.map(|bytes| {
-        serde_json::to_string(&String::from_utf8_lossy(bytes).to_string())
-            .unwrap_or_else(|_| String::from("\"\""))
-    });
-    let warmup_emit = warmup_metrics_json
-		.map(|metrics| {
-			format!(
-				"if (typeof process?.stderr?.write === \"function\") {{\n  process.stderr.write({metrics});\n}}\n"
-			)
-		})
-		.unwrap_or_default();
+    let warmup_emit = wasm_warmup_metrics_emit_source(warmup_metrics);
     let wasi_module_source = render_native_wasi_module_source();
+    let env_merge_source = wasm_internal_env_merge_source();
 
     format!(
         r#"const __agentOSWasmInternalEnv = {internal_env_json};
@@ -2350,10 +2580,8 @@ const __agentOSRequireBuiltin = (specifier) => {{
   throw new Error(`secure-exec WASM bootstrap cannot load ${{specifier}}`);
 }};
 {wasi_module_source}
-if (typeof process !== "undefined") {{
-  process.env = {{ ...(process.env || {{}}), ...__agentOSWasmInternalEnv }};
-}}
-if (typeof globalThis !== "undefined" && typeof globalThis.__agentOSSyncRpc === "undefined") {{
+{env_merge_source}
+if (typeof globalThis !== "undefined") {{
   const __agentOSNormalizeBytes = (value) => {{
     if (value == null) {{
       return value;
@@ -2611,11 +2839,35 @@ if (typeof globalThis !== "undefined" && typeof globalThis.__agentOSSyncRpc === 
     )
 }
 
-fn render_native_wasi_module_source() -> String {
-    NODE_WASI_MODULE_SOURCE.replace(
-        "__SECURE_EXEC_WASM_SYNC_READ_LIMIT_BYTES__",
-        &WASM_SYNC_READ_LIMIT_BYTES.to_string(),
-    )
+fn wasm_warmup_metrics_emit_source(warmup_metrics: Option<&[u8]>) -> String {
+    let warmup_metrics_json = warmup_metrics.map(|bytes| {
+        serde_json::to_string(&String::from_utf8_lossy(bytes).to_string())
+            .unwrap_or_else(|_| String::from("\"\""))
+    });
+    warmup_metrics_json
+        .map(|metrics| {
+            format!(
+                "if (typeof process?.stderr?.write === \"function\") {{\n  process.stderr.write({metrics});\n}}\n"
+            )
+        })
+        .unwrap_or_default()
+}
+
+fn wasm_internal_env_merge_source() -> &'static str {
+    r#"if (typeof process !== "undefined") {
+  process.env = { ...(process.env || {}), ...__agentOSWasmInternalEnv };
+}
+"#
+}
+
+fn render_native_wasi_module_source() -> &'static str {
+    static SOURCE: OnceLock<String> = OnceLock::new();
+    SOURCE.get_or_init(|| {
+        NODE_WASI_MODULE_SOURCE.replace(
+            "__SECURE_EXEC_WASM_SYNC_READ_LIMIT_BYTES__",
+            &WASM_SYNC_READ_LIMIT_BYTES.to_string(),
+        )
+    })
 }
 
 fn insert_wasm_runner_bootstrap(source: &str, bootstrap: &str) -> String {

--- a/crates/execution/src/wasm.rs
+++ b/crates/execution/src/wasm.rs
@@ -2228,6 +2228,7 @@ fn start_wasm_javascript_execution(
         }
         WasmSnapshotRunnerMode::Auto | WasmSnapshotRunnerMode::Block => {
             let userland_bundle = build_wasm_runner_userland_bundle(import_cache)?;
+            let runner_heap_limit_mb = wasm_runner_heap_limit_mb(request);
             V8RuntimeHost::warm_snapshot_async(userland_bundle.clone());
             let use_snapshot = match snapshot_mode {
                 WasmSnapshotRunnerMode::Block => {
@@ -2239,6 +2240,16 @@ fn start_wasm_javascript_execution(
                             .pre_warm_snapshot(&userland_bundle)
                             .map_err(map_javascript_error)?;
                     }
+                    javascript_engine
+                        .pre_warm_workers(
+                            &userland_bundle,
+                            runner_heap_limit_mb,
+                            v8_warm_worker_count(),
+                        )
+                        .map_err(map_javascript_error)?;
+                    javascript_engine
+                        .pre_warm_workers("", 0, v8_warm_worker_count())
+                        .map_err(map_javascript_error)?;
                     true
                 }
                 WasmSnapshotRunnerMode::Auto => javascript_engine
@@ -3497,6 +3508,13 @@ fn wasm_runner_heap_limit_mb(request: &StartWasmExecutionRequest) -> u32 {
         .and_then(|value| value.parse::<u32>().ok())
         .filter(|value| *value > 0)
         .unwrap_or(DEFAULT_WASM_RUNNER_HEAP_LIMIT_MB)
+}
+
+fn v8_warm_worker_count() -> usize {
+    std::env::var("AGENTOS_V8_WARM_ISOLATES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(2)
 }
 
 fn wasm_limit_u64(

--- a/crates/execution/tests/wasm.rs
+++ b/crates/execution/tests/wasm.rs
@@ -46,6 +46,16 @@ impl EnvVarGuard {
         }
         Self { key, previous }
     }
+
+    fn set_value(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        // SAFETY: The wasm suite runs these env-sensitive cases serially inside
+        // one libtest entry.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
 }
 
 impl Drop for EnvVarGuard {
@@ -919,6 +929,116 @@ fn wasm_execution_runs_guest_module_through_v8() {
 
     let stdout = String::from_utf8(result.stdout).expect("stdout utf8");
     assert!(stdout.contains("stdout:wasm-smoke"));
+}
+
+fn wasm_snapshot_runner_block_round_trips_twice() {
+    assert_node_available();
+    let _mode = EnvVarGuard::set_value("AGENTOS_WASM_SNAPSHOT_RUNNER", "block");
+
+    let temp = tempdir().expect("create temp dir");
+    write_fixture(
+        &temp.path().join("guest.wasm"),
+        &wasm_stdout_chunks_module(&["hello\n"]),
+    );
+
+    let mut engine = WasmExecutionEngine::default();
+    let context = engine.create_context(CreateWasmContextRequest {
+        vm_id: String::from("vm-wasm"),
+        module_path: Some(String::from("./guest.wasm")),
+    });
+
+    let (first_stdout, first_stderr, first_exit) = run_wasm_execution(
+        &mut engine,
+        context.context_id.clone(),
+        temp.path(),
+        Vec::new(),
+        BTreeMap::new(),
+        WasmPermissionTier::Full,
+    );
+    assert_eq!(first_exit, 0, "stderr={first_stderr}");
+    assert_eq!(first_stdout, "hello\n");
+
+    let (second_stdout, second_stderr, second_exit) = run_wasm_execution(
+        &mut engine,
+        context.context_id,
+        temp.path(),
+        Vec::new(),
+        BTreeMap::new(),
+        WasmPermissionTier::Full,
+    );
+    assert_eq!(second_exit, 0, "stderr={second_stderr}");
+    assert_eq!(second_stdout, "hello\n");
+}
+
+fn wasm_snapshot_runner_off_fallback_matches_inline() {
+    assert_node_available();
+    let _mode = EnvVarGuard::set_value("AGENTOS_WASM_SNAPSHOT_RUNNER", "off");
+
+    let temp = tempdir().expect("create temp dir");
+    write_fixture(
+        &temp.path().join("guest.wasm"),
+        &wasm_stdout_chunks_module(&["hello\n"]),
+    );
+
+    let mut engine = WasmExecutionEngine::default();
+    let context = engine.create_context(CreateWasmContextRequest {
+        vm_id: String::from("vm-wasm"),
+        module_path: Some(String::from("./guest.wasm")),
+    });
+
+    let (stdout, stderr, exit_code) = run_wasm_execution(
+        &mut engine,
+        context.context_id,
+        temp.path(),
+        Vec::new(),
+        BTreeMap::new(),
+        WasmPermissionTier::Full,
+    );
+
+    assert_eq!(exit_code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "hello\n");
+}
+
+fn wasm_module_base64_cache_invalidates_when_file_changes() {
+    assert_node_available();
+    let _mode = EnvVarGuard::set_value("AGENTOS_WASM_SNAPSHOT_RUNNER", "block");
+
+    let temp = tempdir().expect("create temp dir");
+    let module_path = temp.path().join("guest.wasm");
+    write_fixture(&module_path, &wasm_stdout_chunks_module(&["first\n"]));
+
+    let mut engine = WasmExecutionEngine::default();
+    let context = engine.create_context(CreateWasmContextRequest {
+        vm_id: String::from("vm-wasm"),
+        module_path: Some(String::from("./guest.wasm")),
+    });
+
+    let (first_stdout, first_stderr, first_exit) = run_wasm_execution(
+        &mut engine,
+        context.context_id.clone(),
+        temp.path(),
+        Vec::new(),
+        BTreeMap::new(),
+        WasmPermissionTier::Full,
+    );
+    assert_eq!(first_exit, 0, "stderr={first_stderr}");
+    assert_eq!(first_stdout, "first\n");
+
+    write_fixture(
+        &module_path,
+        &wasm_stdout_chunks_module(&["second-output\n"]),
+    );
+
+    let (second_stdout, second_stderr, second_exit) = run_wasm_execution(
+        &mut engine,
+        context.context_id,
+        temp.path(),
+        Vec::new(),
+        BTreeMap::new(),
+        WasmPermissionTier::Full,
+    );
+    assert_eq!(second_exit, 0, "stderr={second_stderr}");
+    assert_eq!(second_stdout, "second-output\n");
 }
 
 fn wasm_execution_supports_fd_fdstat_set_flags() {
@@ -2491,6 +2611,9 @@ fn wasm_suite() {
     wasm_contexts_preserve_vm_and_module_configuration();
     wasm_execution_stays_inside_v8_runtime_without_host_node_launches();
     wasm_execution_runs_guest_module_through_v8();
+    wasm_snapshot_runner_block_round_trips_twice();
+    wasm_snapshot_runner_off_fallback_matches_inline();
+    wasm_module_base64_cache_invalidates_when_file_changes();
     wasm_execution_supports_fd_fdstat_set_flags();
     wasm_execution_ignores_guest_overrides_for_internal_node_env();
     wasm_execution_freezes_wasi_clock_time();

--- a/crates/execution/tests/wasm.rs
+++ b/crates/execution/tests/wasm.rs
@@ -970,6 +970,132 @@ fn wasm_snapshot_runner_block_round_trips_twice() {
     assert_eq!(second_stdout, "hello\n");
 }
 
+fn phase_calls(path: &Path, stage: &str) -> u64 {
+    let contents = fs::read_to_string(path).unwrap_or_default();
+    contents
+        .lines()
+        .find(|line| line.starts_with(&format!("stage={stage} ")))
+        .and_then(|line| {
+            line.split_whitespace()
+                .find_map(|field| field.strip_prefix("calls="))
+        })
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(0)
+}
+
+fn wasm_snapshot_runner_warm_worker_pool_hits() {
+    assert_node_available();
+    let _mode = EnvVarGuard::set_value("AGENTOS_WASM_SNAPSHOT_RUNNER", "block");
+    let _warm = EnvVarGuard::set_value("AGENTOS_V8_WARM_ISOLATES", "2");
+    let _phases = EnvVarGuard::set_value("AGENTOS_V8_SESSION_PHASES", "1");
+    let phases_dir = tempdir().expect("create phases temp dir");
+    let phases_file = phases_dir.path().join("v8-phases.txt");
+    let _phases_file = EnvVarGuard::set("AGENTOS_V8_SESSION_PHASES_FILE", &phases_file);
+
+    let temp = tempdir().expect("create temp dir");
+    write_fixture(
+        &temp.path().join("guest.wasm"),
+        &wasm_stdout_chunks_module(&["pool-hit\n"]),
+    );
+
+    let mut engine = WasmExecutionEngine::default();
+    let context = engine.create_context(CreateWasmContextRequest {
+        vm_id: String::from("vm-wasm"),
+        module_path: Some(String::from("./guest.wasm")),
+    });
+
+    for _ in 0..2 {
+        let (stdout, stderr, exit_code) = run_wasm_execution(
+            &mut engine,
+            context.context_id.clone(),
+            temp.path(),
+            Vec::new(),
+            BTreeMap::new(),
+            WasmPermissionTier::Full,
+        );
+        assert_eq!(exit_code, 0, "stderr={stderr}");
+        assert_eq!(stdout, "pool-hit\n");
+    }
+
+    assert!(
+        phase_calls(&phases_file, "warm_worker_hit") >= 1,
+        "expected at least one warm worker pool hit; phases={}",
+        fs::read_to_string(&phases_file).unwrap_or_default()
+    );
+}
+
+fn wasm_snapshot_runner_warm_worker_pool_disabled_falls_back() {
+    assert_node_available();
+    let _mode = EnvVarGuard::set_value("AGENTOS_WASM_SNAPSHOT_RUNNER", "block");
+    let _warm = EnvVarGuard::set_value("AGENTOS_V8_WARM_ISOLATES", "0");
+
+    let temp = tempdir().expect("create temp dir");
+    write_fixture(
+        &temp.path().join("guest.wasm"),
+        &wasm_stdout_chunks_module(&["pool-disabled\n"]),
+    );
+
+    let mut engine = WasmExecutionEngine::default();
+    let context = engine.create_context(CreateWasmContextRequest {
+        vm_id: String::from("vm-wasm"),
+        module_path: Some(String::from("./guest.wasm")),
+    });
+    let (stdout, stderr, exit_code) = run_wasm_execution(
+        &mut engine,
+        context.context_id,
+        temp.path(),
+        Vec::new(),
+        BTreeMap::new(),
+        WasmPermissionTier::Full,
+    );
+
+    assert_eq!(exit_code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "pool-disabled\n");
+}
+
+fn wasm_snapshot_runner_warm_hint_mismatch_falls_back() {
+    assert_node_available();
+    let _warm = EnvVarGuard::set_value("AGENTOS_V8_WARM_ISOLATES", "2");
+
+    let temp = tempdir().expect("create temp dir");
+    write_fixture(
+        &temp.path().join("guest.wasm"),
+        &wasm_stdout_chunks_module(&["mismatch\n"]),
+    );
+
+    let mut engine = WasmExecutionEngine::default();
+    let context = engine.create_context(CreateWasmContextRequest {
+        vm_id: String::from("vm-wasm"),
+        module_path: Some(String::from("./guest.wasm")),
+    });
+
+    {
+        let _mode = EnvVarGuard::set_value("AGENTOS_WASM_SNAPSHOT_RUNNER", "block");
+        let (stdout, stderr, exit_code) = run_wasm_execution(
+            &mut engine,
+            context.context_id.clone(),
+            temp.path(),
+            Vec::new(),
+            BTreeMap::new(),
+            WasmPermissionTier::Full,
+        );
+        assert_eq!(exit_code, 0, "stderr={stderr}");
+        assert_eq!(stdout, "mismatch\n");
+    }
+
+    let _mode = EnvVarGuard::set_value("AGENTOS_WASM_SNAPSHOT_RUNNER", "off");
+    let (stdout, stderr, exit_code) = run_wasm_execution(
+        &mut engine,
+        context.context_id,
+        temp.path(),
+        Vec::new(),
+        BTreeMap::new(),
+        WasmPermissionTier::Full,
+    );
+    assert_eq!(exit_code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "mismatch\n");
+}
+
 fn wasm_snapshot_runner_off_fallback_matches_inline() {
     assert_node_available();
     let _mode = EnvVarGuard::set_value("AGENTOS_WASM_SNAPSHOT_RUNNER", "off");
@@ -2612,6 +2738,9 @@ fn wasm_suite() {
     wasm_execution_stays_inside_v8_runtime_without_host_node_launches();
     wasm_execution_runs_guest_module_through_v8();
     wasm_snapshot_runner_block_round_trips_twice();
+    wasm_snapshot_runner_warm_worker_pool_hits();
+    wasm_snapshot_runner_warm_worker_pool_disabled_falls_back();
+    wasm_snapshot_runner_warm_hint_mismatch_falls_back();
     wasm_snapshot_runner_off_fallback_matches_inline();
     wasm_module_base64_cache_invalidates_when_file_changes();
     wasm_execution_supports_fd_fdstat_set_flags();

--- a/crates/v8-runtime/src/embedded_runtime.rs
+++ b/crates/v8-runtime/src/embedded_runtime.rs
@@ -117,6 +117,19 @@ impl EmbeddedV8Runtime {
             .is_some()
     }
 
+    pub fn pre_warm_workers(
+        &self,
+        bridge_code: String,
+        userland_code: String,
+        heap_limit_mb: Option<u32>,
+        count: usize,
+    ) {
+        self.session_mgr
+            .lock()
+            .expect("embedded runtime session manager lock poisoned")
+            .pre_warm_workers(bridge_code, userland_code, heap_limit_mb, count);
+    }
+
     pub fn register_session(&self, session_id: &str) -> io::Result<mpsc::Receiver<RuntimeEvent>> {
         self.register_session_with_output_registration(session_id)
             .map(|(receiver, _registration)| receiver)
@@ -215,6 +228,7 @@ impl EmbeddedV8Runtime {
                 heap_limit_mb,
                 cpu_time_limit_ms,
                 wall_clock_limit_ms,
+                warm_hint,
             } => {
                 let output_generation = self
                     .session_outputs
@@ -232,6 +246,7 @@ impl EmbeddedV8Runtime {
                     cpu_time_limit_ms,
                     wall_clock_limit_ms,
                     output_generation,
+                    warm_hint,
                 )
                 .map_err(other_io_error)
             }
@@ -594,13 +609,16 @@ fn dispatch_runtime_command(
             heap_limit_mb,
             cpu_time_limit_ms,
             wall_clock_limit_ms,
+            warm_hint,
         } => {
             let mut mgr = session_mgr.lock().expect("session manager lock poisoned");
-            mgr.create_session(
+            mgr.create_session_with_output_generation(
                 session_id,
                 heap_limit_mb,
                 cpu_time_limit_ms,
                 wall_clock_limit_ms,
+                None,
+                warm_hint,
             )
             .map_err(other_io_error)
         }
@@ -835,6 +853,7 @@ mod tests {
                     heap_limit_mb: None,
                     cpu_time_limit_ms: None,
                     wall_clock_limit_ms: None,
+                    warm_hint: None,
                 })
                 .expect("create session");
             assert_eq!(
@@ -1192,6 +1211,7 @@ mod tests {
                 heap_limit_mb: None,
                 cpu_time_limit_ms: None,
                 wall_clock_limit_ms: None,
+                warm_hint: None,
             })
             .expect("create first session");
         runtime
@@ -1208,6 +1228,7 @@ mod tests {
                 heap_limit_mb: None,
                 cpu_time_limit_ms: None,
                 wall_clock_limit_ms: None,
+                warm_hint: None,
             })
             .expect("create reused session");
 
@@ -1234,12 +1255,26 @@ mod tests {
         let session_mgr = test_session_manager();
         {
             let mut mgr = session_mgr.lock().expect("session manager");
-            mgr.create_session_with_output_generation("reused".into(), None, None, None, Some(1))
-                .expect("create first session");
+            mgr.create_session_with_output_generation(
+                "reused".into(),
+                None,
+                None,
+                None,
+                Some(1),
+                None,
+            )
+            .expect("create first session");
             mgr.destroy_session("reused")
                 .expect("destroy first session");
-            mgr.create_session_with_output_generation("reused".into(), None, None, None, Some(2))
-                .expect("create reused session");
+            mgr.create_session_with_output_generation(
+                "reused".into(),
+                None,
+                None,
+                None,
+                Some(2),
+                None,
+            )
+            .expect("create reused session");
 
             assert!(
                 !mgr.destroy_session_if_output_generation("reused", 1)
@@ -1291,6 +1326,7 @@ mod tests {
                 None,
                 None,
                 Some(output_generation),
+                None,
             )
             .expect("create test session");
         session_mgr

--- a/crates/v8-runtime/src/embedded_runtime.rs
+++ b/crates/v8-runtime/src/embedded_runtime.rs
@@ -51,7 +51,9 @@ impl EmbeddedV8Runtime {
         bridge::acquire_embedded_cbor_codec();
         isolate::init_v8_platform();
 
-        let snapshot_cache = Arc::new(SnapshotCache::new(4));
+        // Keep bridge-only, agent-SDK, and wasm-runner userland variants warm
+        // without immediately evicting each other.
+        let snapshot_cache = Arc::new(SnapshotCache::new(8));
         let (event_tx, event_rx) = crossbeam_channel::bounded::<RuntimeEventEnvelope>(1024);
         let (dispatch_shutdown_tx, dispatch_shutdown_rx) = crossbeam_channel::bounded::<()>(1);
         let call_id_router: CallIdRouter = Arc::new(Mutex::new(HashMap::new()));
@@ -104,6 +106,15 @@ impl EmbeddedV8Runtime {
 
     pub fn is_alive(&self) -> bool {
         self.alive.load(Ordering::Acquire)
+    }
+
+    pub fn snapshot_ready(&self, bridge_code: &str, userland_code: &str) -> bool {
+        if userland_code.is_empty() {
+            return true;
+        }
+        self.snapshot_cache
+            .try_get_with_userland(bridge_code, Some(userland_code))
+            .is_some()
     }
 
     pub fn register_session(&self, session_id: &str) -> io::Result<mpsc::Receiver<RuntimeEvent>> {
@@ -468,7 +479,9 @@ fn default_max_concurrency() -> usize {
 }
 
 fn run_embedded_runtime(stream: UnixStream, max_concurrency: usize) {
-    let snapshot_cache = Arc::new(SnapshotCache::new(4));
+    // Keep bridge-only, agent-SDK, and wasm-runner userland variants warm
+    // without immediately evicting each other.
+    let snapshot_cache = Arc::new(SnapshotCache::new(8));
     let writer_stream = match stream.try_clone() {
         Ok(writer_stream) => writer_stream,
         Err(error) => {

--- a/crates/v8-runtime/src/runtime_protocol.rs
+++ b/crates/v8-runtime/src/runtime_protocol.rs
@@ -1,6 +1,13 @@
 use crate::ipc_binary::{BinaryFrame, ExecutionErrorBin};
 use std::io;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WarmSessionHint {
+    pub bridge_code: String,
+    pub userland_code: String,
+    pub heap_limit_mb: Option<u32>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum RuntimeCommand {
     CreateSession {
@@ -8,6 +15,7 @@ pub enum RuntimeCommand {
         heap_limit_mb: Option<u32>,
         cpu_time_limit_ms: Option<u32>,
         wall_clock_limit_ms: Option<u32>,
+        warm_hint: Option<WarmSessionHint>,
     },
     DestroySession {
         session_id: String,
@@ -145,6 +153,7 @@ impl TryFrom<BinaryFrame> for RuntimeCommand {
                 heap_limit_mb: non_zero_option(heap_limit_mb),
                 cpu_time_limit_ms: non_zero_option(cpu_time_limit_ms),
                 wall_clock_limit_ms: non_zero_option(wall_clock_limit_ms),
+                warm_hint: None,
             }),
             BinaryFrame::DestroySession { session_id } => {
                 Ok(RuntimeCommand::DestroySession { session_id })

--- a/crates/v8-runtime/src/session.rs
+++ b/crates/v8-runtime/src/session.rs
@@ -1,11 +1,11 @@
 // Session management: create/destroy sessions with V8 isolates on dedicated threads
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::thread;
 #[cfg(not(test))]
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crossbeam_channel::{Receiver, Sender};
 #[cfg(not(test))]
@@ -58,6 +58,57 @@ const DEFERRED_COMMAND_LIMIT_ERROR_CODE: &str = "ERR_SESSION_DEFERRED_COMMAND_LI
 const SESSION_COMMAND_CHANNEL_CAPACITY: usize = 256;
 const MAX_DEFERRED_SESSION_COMMANDS: usize = SESSION_COMMAND_CHANNEL_CAPACITY;
 const MAX_DEFERRED_SYNC_MESSAGES: usize = SESSION_COMMAND_CHANNEL_CAPACITY;
+
+#[cfg(not(test))]
+#[derive(Default)]
+struct V8SessionPhaseStats {
+    calls: u64,
+    total_ns: u128,
+    max_ns: u128,
+}
+
+#[cfg(not(test))]
+static V8_SESSION_PHASES: OnceLock<Mutex<BTreeMap<String, V8SessionPhaseStats>>> = OnceLock::new();
+
+#[cfg(not(test))]
+fn v8_session_phases_enabled() -> bool {
+    std::env::var("AGENTOS_V8_SESSION_PHASES").as_deref() == Ok("1")
+}
+
+#[cfg(not(test))]
+fn record_v8_session_phase(stage: &str, elapsed: Duration) {
+    if !v8_session_phases_enabled() {
+        return;
+    }
+    let phases = V8_SESSION_PHASES.get_or_init(|| Mutex::new(BTreeMap::new()));
+    let Ok(mut phases) = phases.lock() else {
+        return;
+    };
+    let stats = phases.entry(stage.to_string()).or_default();
+    stats.calls += 1;
+    let elapsed_ns = elapsed.as_nanos();
+    stats.total_ns += elapsed_ns;
+    stats.max_ns = stats.max_ns.max(elapsed_ns);
+
+    let Some(path) = std::env::var_os("AGENTOS_V8_SESSION_PHASES_FILE") else {
+        return;
+    };
+    let mut output = String::new();
+    for (stage, stats) in phases.iter() {
+        let total_us = stats.total_ns / 1_000;
+        let avg_us = if stats.calls == 0 {
+            0
+        } else {
+            total_us / u128::from(stats.calls)
+        };
+        let max_us = stats.max_ns / 1_000;
+        output.push_str(&format!(
+            "stage={stage} calls={} total_us={total_us} avg_us={avg_us} max_us={max_us}\n",
+            stats.calls
+        ));
+    }
+    let _ = std::fs::write(path, output);
+}
 
 /// Normalize an opt-in CPU-time budget: `Some(0)` means "disabled" and folds to
 /// `None` so the CPU-budget watchdog is NOT armed. There is no default — when the
@@ -926,6 +977,7 @@ fn session_thread(
                             // The snapshot captures the bridge AND (when present) the
                             // agent-SDK userland bundle, keyed process-wide by both, so
                             // the SDK is evaluated once per sidecar and reused here.
+                            let phase_start = Instant::now();
                             let snapshot_blob = match snapshot_cache.get_or_create_with_userland(
                                 &effective_bridge_code,
                                 (!effective_userland_code.is_empty())
@@ -944,20 +996,33 @@ fn session_thread(
                                     None
                                 }
                             };
+                            record_v8_session_phase("snapshot_get", phase_start.elapsed());
                             let mut iso = match snapshot_blob {
                                 Some(blob) => {
                                     from_snapshot = true;
                                     eprintln!(
                                         "secure-exec-v8-runtime: restored session isolate from_snapshot=true"
                                     );
-                                    snapshot::create_isolate_from_snapshot(
-                                        (*blob).clone(),
+                                    let phase_start = Instant::now();
+                                    // rusty_v8 0.130's CreateParams::snapshot_blob
+                                    // takes owned 'static data, so this copy remains
+                                    // per exec until the API can accept cached bytes.
+                                    let snapshot_blob = (*blob).clone();
+                                    record_v8_session_phase("blob_clone", phase_start.elapsed());
+                                    let phase_start = Instant::now();
+                                    let isolate = snapshot::create_isolate_from_snapshot(
+                                        snapshot_blob,
                                         heap_limit_mb,
-                                    )
+                                    );
+                                    record_v8_session_phase("isolate_new", phase_start.elapsed());
+                                    isolate
                                 }
                                 None => {
                                     from_snapshot = false;
-                                    isolate::create_isolate(heap_limit_mb)
+                                    let phase_start = Instant::now();
+                                    let isolate = isolate::create_isolate(heap_limit_mb);
+                                    record_v8_session_phase("isolate_new", phase_start.elapsed());
+                                    isolate
                                 }
                             };
                             iso.set_host_import_module_dynamically_callback(
@@ -1234,6 +1299,7 @@ fn session_thread(
                         } else {
                             Some(file_path.as_str())
                         };
+                        let phase_start = Instant::now();
                         let (mut code, mut exports, mut error) = if mode == 0 {
                             let scope = &mut v8::HandleScope::new(iso);
                             let ctx = v8::Local::new(scope, &exec_context);
@@ -1276,6 +1342,7 @@ fn session_thread(
                                 error = next_error;
                             }
                         }
+                        record_v8_session_phase("user_code_execute", phase_start.elapsed());
 
                         // Run event loop while bridge work or async ESM
                         // evaluation is still pending. For ESM modules (mode != 0),

--- a/crates/v8-runtime/src/session.rs
+++ b/crates/v8-runtime/src/session.rs
@@ -1,6 +1,8 @@
 // Session management: create/destroy sessions with V8 isolates on dedicated threads
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+#[cfg(not(test))]
+use std::collections::BTreeMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::thread;
@@ -19,8 +21,10 @@ use crate::host_call::{CallIdRouter, SharedCallIdCounter};
 use crate::ipc::ExecutionError;
 #[cfg(not(test))]
 use crate::ipc_binary::ExecutionErrorBin;
-use crate::runtime_protocol::{BridgeResponse, RuntimeEvent, SessionMessage, StreamEvent};
-use crate::snapshot::SnapshotCache;
+use crate::runtime_protocol::{
+    BridgeResponse, RuntimeEvent, SessionMessage, StreamEvent, WarmSessionHint,
+};
+use crate::snapshot::{snapshot_cache_key, SnapshotCache, SnapshotCacheKey};
 #[cfg(not(test))]
 use crate::{bridge, isolate, snapshot};
 
@@ -58,6 +62,56 @@ const DEFERRED_COMMAND_LIMIT_ERROR_CODE: &str = "ERR_SESSION_DEFERRED_COMMAND_LI
 const SESSION_COMMAND_CHANNEL_CAPACITY: usize = 256;
 const MAX_DEFERRED_SESSION_COMMANDS: usize = SESSION_COMMAND_CHANNEL_CAPACITY;
 const MAX_DEFERRED_SYNC_MESSAGES: usize = SESSION_COMMAND_CHANNEL_CAPACITY;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct WarmPoolKey {
+    snapshot_key_digest: SnapshotCacheKey,
+    heap_limit_mb: u32,
+}
+
+struct ParkedWorker {
+    assignment_tx: Sender<SessionAssignment>,
+    join_handle: thread::JoinHandle<()>,
+}
+
+#[derive(Default)]
+struct WarmWorkerPoolState {
+    workers: HashMap<WarmPoolKey, Vec<ParkedWorker>>,
+    refilling: HashSet<WarmPoolKey>,
+}
+
+#[derive(Default)]
+struct WarmWorkerPool {
+    state: Mutex<WarmWorkerPoolState>,
+}
+
+struct SessionAssignment {
+    heap_limit_mb: Option<u32>,
+    cpu_time_limit_ms: Option<u32>,
+    wall_clock_limit_ms: Option<u32>,
+    rx: Receiver<SessionCommand>,
+    slot_control: SlotControl,
+    max_concurrency: usize,
+    event_tx: RuntimeEventSender,
+    call_id_router: CallIdRouter,
+    shared_call_id: SharedCallIdCounter,
+    snapshot_cache: Arc<SnapshotCache>,
+    isolate_handle: SharedIsolateHandle,
+    execution_abort: SharedExecutionAbort,
+    session_id: String,
+    output_generation: Option<u64>,
+}
+
+#[cfg(not(test))]
+struct PrecreatedIsolate {
+    isolate: v8::OwnedIsolate,
+    context: v8::Global<v8::Context>,
+    bridge_code: String,
+    userland_code: String,
+}
+
+#[cfg(test)]
+struct PrecreatedIsolate;
 
 #[cfg(not(test))]
 #[derive(Default)]
@@ -108,6 +162,299 @@ fn record_v8_session_phase(stage: &str, elapsed: Duration) {
         ));
     }
     let _ = std::fs::write(path, output);
+}
+
+#[cfg(not(test))]
+fn record_warm_worker_hit() {
+    record_v8_session_phase("warm_worker_hit", Duration::ZERO);
+}
+
+#[cfg(test)]
+fn record_warm_worker_hit() {}
+
+#[cfg(not(test))]
+fn record_warm_worker_miss() {
+    record_v8_session_phase("warm_worker_miss", Duration::ZERO);
+}
+
+#[cfg(test)]
+fn record_warm_worker_miss() {}
+
+fn warm_worker_capacity_per_key() -> usize {
+    std::env::var("AGENTOS_V8_WARM_ISOLATES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(2)
+}
+
+fn effective_heap_limit_mb(heap_limit_mb: Option<u32>) -> u32 {
+    heap_limit_mb.unwrap_or(crate::isolate::DEFAULT_HEAP_LIMIT_MB)
+}
+
+fn warm_pool_key(
+    bridge_code: &str,
+    userland_code: &str,
+    heap_limit_mb: Option<u32>,
+) -> WarmPoolKey {
+    WarmPoolKey {
+        snapshot_key_digest: snapshot_cache_key(
+            bridge_code,
+            (!userland_code.is_empty()).then_some(userland_code),
+        ),
+        heap_limit_mb: effective_heap_limit_mb(heap_limit_mb),
+    }
+}
+
+fn warm_key_prefix(key: &WarmPoolKey) -> String {
+    key.snapshot_key_digest[..4]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+impl WarmWorkerPool {
+    fn claim(&self, key: &WarmPoolKey) -> Option<ParkedWorker> {
+        let mut state = self.state.lock().expect("warm worker pool lock poisoned");
+        state.workers.get_mut(key).and_then(Vec::pop)
+    }
+
+    fn shutdown_handles(&self) -> Vec<thread::JoinHandle<()>> {
+        let mut state = self.state.lock().expect("warm worker pool lock poisoned");
+        state.refilling.clear();
+        state
+            .workers
+            .drain()
+            .flat_map(|(_, workers)| workers)
+            .map(|worker| {
+                drop(worker.assignment_tx);
+                worker.join_handle
+            })
+            .collect()
+    }
+
+    fn ensure_count(
+        self: &Arc<Self>,
+        snapshot_cache: Arc<SnapshotCache>,
+        slot_control: SlotControl,
+        bridge_code: String,
+        userland_code: String,
+        heap_limit_mb: Option<u32>,
+        requested_count: usize,
+    ) {
+        let capacity = warm_worker_capacity_per_key();
+        if capacity == 0 || requested_count == 0 {
+            return;
+        }
+
+        let target_count = requested_count.min(capacity);
+        let key = warm_pool_key(&bridge_code, &userland_code, heap_limit_mb);
+        {
+            let mut state = self.state.lock().expect("warm worker pool lock poisoned");
+            let current = state.workers.get(&key).map_or(0, Vec::len);
+            if current >= target_count || state.refilling.contains(&key) {
+                return;
+            }
+            state.refilling.insert(key.clone());
+        }
+
+        let pool = Arc::clone(self);
+        let spawn_key = key.clone();
+        let _ = thread::Builder::new()
+            .name(String::from("secure-exec-v8-warm-refill"))
+            .spawn(move || {
+                pool.refill_until(
+                    snapshot_cache,
+                    slot_control,
+                    spawn_key,
+                    bridge_code,
+                    userland_code,
+                    heap_limit_mb,
+                    target_count,
+                );
+            })
+            .map_err(|error| {
+                eprintln!("secure-exec-v8-runtime: warm worker refill spawn failed: {error}");
+                self.state
+                    .lock()
+                    .expect("warm worker pool lock poisoned")
+                    .refilling
+                    .remove(&key);
+            });
+    }
+
+    fn refill_until(
+        &self,
+        snapshot_cache: Arc<SnapshotCache>,
+        slot_control: SlotControl,
+        key: WarmPoolKey,
+        bridge_code: String,
+        userland_code: String,
+        heap_limit_mb: Option<u32>,
+        target_count: usize,
+    ) {
+        loop {
+            let capacity = warm_worker_capacity_per_key();
+            if capacity == 0 {
+                break;
+            }
+            let desired = target_count.min(capacity);
+            {
+                let state = self.state.lock().expect("warm worker pool lock poisoned");
+                if state.workers.get(&key).map_or(0, Vec::len) >= desired {
+                    break;
+                }
+            }
+
+            let Some(worker) = spawn_warm_worker(
+                Arc::clone(&snapshot_cache),
+                Arc::clone(&slot_control),
+                key.clone(),
+                bridge_code.clone(),
+                userland_code.clone(),
+                heap_limit_mb,
+            ) else {
+                break;
+            };
+
+            let mut state = self.state.lock().expect("warm worker pool lock poisoned");
+            let workers = state.workers.entry(key.clone()).or_default();
+            if workers.len() >= desired {
+                drop(worker.assignment_tx);
+                let _ = worker.join_handle.join();
+                break;
+            }
+            workers.push(worker);
+            eprintln!(
+                "secure-exec-v8-runtime: warm worker refilled key={} heap={} pool_size={}",
+                warm_key_prefix(&key),
+                key.heap_limit_mb,
+                workers.len()
+            );
+        }
+
+        self.state
+            .lock()
+            .expect("warm worker pool lock poisoned")
+            .refilling
+            .remove(&key);
+    }
+}
+
+#[cfg(not(test))]
+fn spawn_warm_worker(
+    snapshot_cache: Arc<SnapshotCache>,
+    slot_control: SlotControl,
+    key: WarmPoolKey,
+    bridge_code: String,
+    userland_code: String,
+    heap_limit_mb: Option<u32>,
+) -> Option<ParkedWorker> {
+    let (assignment_tx, assignment_rx) = crossbeam_channel::bounded::<SessionAssignment>(1);
+    let (ready_tx, ready_rx) = crossbeam_channel::bounded::<Result<(), String>>(1);
+    let worker_bridge_code = bridge_code.clone();
+    let worker_userland_code = userland_code.clone();
+    let join_handle = match thread::Builder::new()
+        .name(String::from("secure-exec-v8-warm-worker"))
+        .spawn(move || {
+            let precreated = precreate_warm_isolate(
+                snapshot_cache,
+                slot_control,
+                worker_bridge_code,
+                worker_userland_code,
+                heap_limit_mb,
+            );
+            match precreated {
+                Ok(precreated) => {
+                    let _ = ready_tx.send(Ok(()));
+                    if let Ok(assignment) = assignment_rx.recv() {
+                        session_thread(assignment, Some(precreated));
+                    }
+                }
+                Err(error) => {
+                    let _ = ready_tx.send(Err(error));
+                }
+            }
+        }) {
+        Ok(handle) => handle,
+        Err(error) => {
+            eprintln!("secure-exec-v8-runtime: warm worker spawn failed: {error}");
+            return None;
+        }
+    };
+
+    match ready_rx.recv() {
+        Ok(Ok(())) => Some(ParkedWorker {
+            assignment_tx,
+            join_handle,
+        }),
+        Ok(Err(error)) => {
+            eprintln!(
+                "secure-exec-v8-runtime: warm worker refill failed key={} heap={}: {error}",
+                warm_key_prefix(&key),
+                key.heap_limit_mb
+            );
+            let _ = join_handle.join();
+            None
+        }
+        Err(error) => {
+            eprintln!(
+                "secure-exec-v8-runtime: warm worker refill failed key={} heap={}: {error}",
+                warm_key_prefix(&key),
+                key.heap_limit_mb
+            );
+            let _ = join_handle.join();
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+fn spawn_warm_worker(
+    _snapshot_cache: Arc<SnapshotCache>,
+    _slot_control: SlotControl,
+    _key: WarmPoolKey,
+    _bridge_code: String,
+    _userland_code: String,
+    _heap_limit_mb: Option<u32>,
+) -> Option<ParkedWorker> {
+    None
+}
+
+#[cfg(not(test))]
+fn precreate_warm_isolate(
+    snapshot_cache: Arc<SnapshotCache>,
+    slot_control: SlotControl,
+    bridge_code: String,
+    userland_code: String,
+    heap_limit_mb: Option<u32>,
+) -> Result<PrecreatedIsolate, String> {
+    isolate::init_v8_platform();
+    let snapshot_blob = snapshot_cache.get_or_create_with_userland(
+        &bridge_code,
+        (!userland_code.is_empty()).then_some(userland_code.as_str()),
+    )?;
+    let snapshot_blob = (*snapshot_blob).clone();
+    let _idle_slots = lock_idle_slots(&slot_control);
+    let mut isolate = snapshot::create_isolate_from_snapshot(snapshot_blob, heap_limit_mb);
+    isolate.set_host_import_module_dynamically_callback(execution::dynamic_import_callback);
+    isolate.set_host_initialize_import_meta_object_callback(execution::import_meta_object_callback);
+    let context = isolate::create_context(&mut isolate);
+    Ok(PrecreatedIsolate {
+        isolate,
+        context,
+        bridge_code,
+        userland_code,
+    })
+}
+
+#[cfg(not(test))]
+fn lock_idle_slots(slot_control: &SlotControl) -> std::sync::MutexGuard<'_, usize> {
+    let (lock, cvar) = &**slot_control;
+    let mut count = lock.lock().unwrap();
+    while *count != 0 {
+        count = cvar.wait(count).unwrap();
+    }
+    count
 }
 
 /// Normalize an opt-in CPU-time budget: `Some(0)` means "disabled" and folds to
@@ -268,6 +615,8 @@ pub struct SessionManager {
     shared_call_id: SharedCallIdCounter,
     /// Shared snapshot cache for fast isolate creation from pre-compiled bridge code
     snapshot_cache: Arc<SnapshotCache>,
+    /// Ready-to-claim isolate workers keyed by snapshot digest and heap cap.
+    warm_pool: Arc<WarmWorkerPool>,
 }
 
 impl SessionManager {
@@ -285,6 +634,7 @@ impl SessionManager {
             call_id_router,
             shared_call_id: Arc::new(AtomicU64::new(1)),
             snapshot_cache,
+            warm_pool: Arc::new(WarmWorkerPool::default()),
         }
     }
 
@@ -292,6 +642,23 @@ impl SessionManager {
     #[allow(dead_code)]
     pub fn snapshot_cache(&self) -> &Arc<SnapshotCache> {
         &self.snapshot_cache
+    }
+
+    pub fn pre_warm_workers(
+        &self,
+        bridge_code: String,
+        userland_code: String,
+        heap_limit_mb: Option<u32>,
+        count: usize,
+    ) {
+        self.warm_pool.ensure_count(
+            Arc::clone(&self.snapshot_cache),
+            Arc::clone(&self.slot_control),
+            bridge_code,
+            userland_code,
+            heap_limit_mb,
+            count,
+        );
     }
 
     /// Create a new session.
@@ -310,6 +677,7 @@ impl SessionManager {
             cpu_time_limit_ms,
             wall_clock_limit_ms,
             None,
+            None,
         )
     }
 
@@ -320,6 +688,7 @@ impl SessionManager {
         cpu_time_limit_ms: Option<u32>,
         wall_clock_limit_ms: Option<u32>,
         output_generation: Option<u64>,
+        warm_hint: Option<WarmSessionHint>,
     ) -> Result<(), String> {
         if self.sessions.contains_key(&session_id) {
             return Err(format!("session {} already exists", session_id));
@@ -328,44 +697,43 @@ impl SessionManager {
         let cpu_time_limit_ms = normalize_cpu_time_limit_ms(cpu_time_limit_ms);
         let wall_clock_limit_ms = normalize_wall_clock_limit_ms(wall_clock_limit_ms);
         let (tx, rx) = crossbeam_channel::bounded(SESSION_COMMAND_CHANNEL_CAPACITY);
-        let slot_control = Arc::clone(&self.slot_control);
-        let max = self.max_concurrency;
-        let event_tx = self.event_tx.clone();
-        let router = Arc::clone(&self.call_id_router);
-        let shared_call_id = Arc::clone(&self.shared_call_id);
-        let snap_cache = Arc::clone(&self.snapshot_cache);
         let isolate_handle = Arc::new(Mutex::new(None));
         let execution_abort = new_execution_abort();
-        let isolate_handle_for_thread = Arc::clone(&isolate_handle);
-        let execution_abort_for_thread = execution_abort.clone();
-        let session_id_for_thread = session_id.clone();
-
-        let name_prefix = if session_id.len() > 8 {
-            &session_id[..8]
-        } else {
-            &session_id
+        let assignment = SessionAssignment {
+            heap_limit_mb,
+            cpu_time_limit_ms,
+            wall_clock_limit_ms,
+            rx,
+            slot_control: Arc::clone(&self.slot_control),
+            max_concurrency: self.max_concurrency,
+            event_tx: self.event_tx.clone(),
+            call_id_router: Arc::clone(&self.call_id_router),
+            shared_call_id: Arc::clone(&self.shared_call_id),
+            snapshot_cache: Arc::clone(&self.snapshot_cache),
+            isolate_handle: Arc::clone(&isolate_handle),
+            execution_abort: execution_abort.clone(),
+            session_id: session_id.clone(),
+            output_generation,
         };
-        let join_handle = thread::Builder::new()
-            .name(format!("session-{}", name_prefix))
-            .spawn(move || {
-                session_thread(
-                    heap_limit_mb,
-                    cpu_time_limit_ms,
-                    wall_clock_limit_ms,
-                    rx,
-                    slot_control,
-                    max,
-                    event_tx,
-                    router,
-                    shared_call_id,
-                    snap_cache,
-                    isolate_handle_for_thread,
-                    execution_abort_for_thread,
-                    session_id_for_thread,
-                    output_generation,
-                );
-            })
-            .map_err(|e| format!("failed to spawn session thread: {}", e))?;
+
+        let join_handle = match self.claim_warm_worker(warm_hint.as_ref(), assignment) {
+            Ok((join_handle, true)) => {
+                if let Some(hint) = warm_hint {
+                    self.warm_pool.ensure_count(
+                        Arc::clone(&self.snapshot_cache),
+                        Arc::clone(&self.slot_control),
+                        hint.bridge_code,
+                        hint.userland_code,
+                        hint.heap_limit_mb,
+                        warm_worker_capacity_per_key(),
+                    );
+                }
+                join_handle
+            }
+            Ok((join_handle, false)) => join_handle,
+            Err(assignment) => spawn_session_thread(assignment)
+                .map_err(|e| format!("failed to spawn session thread: {}", e))?,
+        };
 
         self.sessions.insert(
             session_id,
@@ -379,6 +747,48 @@ impl SessionManager {
         );
 
         Ok(())
+    }
+
+    fn claim_warm_worker(
+        &self,
+        warm_hint: Option<&WarmSessionHint>,
+        assignment: SessionAssignment,
+    ) -> Result<(thread::JoinHandle<()>, bool), SessionAssignment> {
+        let Some(hint) = warm_hint else {
+            return Err(assignment);
+        };
+        if warm_worker_capacity_per_key() == 0 {
+            record_warm_worker_miss();
+            return Err(assignment);
+        }
+
+        let key = warm_pool_key(&hint.bridge_code, &hint.userland_code, hint.heap_limit_mb);
+        let Some(worker) = self.warm_pool.claim(&key) else {
+            record_warm_worker_miss();
+            eprintln!(
+                "secure-exec-v8-runtime: warm worker pool-empty key={} heap={}",
+                warm_key_prefix(&key),
+                key.heap_limit_mb
+            );
+            return Err(assignment);
+        };
+
+        match worker.assignment_tx.send(assignment) {
+            Ok(()) => {
+                record_warm_worker_hit();
+                eprintln!(
+                    "secure-exec-v8-runtime: warm worker claimed key={} heap={}",
+                    warm_key_prefix(&key),
+                    key.heap_limit_mb
+                );
+                Ok((worker.join_handle, true))
+            }
+            Err(error) => {
+                record_warm_worker_miss();
+                let _ = worker.join_handle.join();
+                Err(error.0)
+            }
+        }
     }
 
     pub fn destroy_session_if_output_generation(
@@ -504,7 +914,8 @@ impl SessionManager {
             .expect("call_id router lock poisoned")
             .clear();
 
-        self.sessions
+        let mut handles: Vec<_> = self
+            .sessions
             .drain()
             .filter_map(|(_, mut entry)| {
                 #[cfg(not(test))]
@@ -521,7 +932,9 @@ impl SessionManager {
                 drop(entry.tx);
                 entry.join_handle.take()
             })
-            .collect()
+            .collect();
+        handles.extend(self.warm_pool.shutdown_handles());
+        handles
     }
 
     pub(crate) fn clear_call_route(&self, call_id: u64) {
@@ -749,23 +1162,50 @@ fn defer_session_command_before_slot(
 /// Session thread: acquires a concurrency slot, defers V8 isolate creation
 /// to first Execute (when bridge code is known for snapshot lookup), and
 /// processes commands until shutdown.
+fn spawn_session_thread(assignment: SessionAssignment) -> std::io::Result<thread::JoinHandle<()>> {
+    let name_prefix = if assignment.session_id.len() > 8 {
+        assignment.session_id[..8].to_string()
+    } else {
+        assignment.session_id.clone()
+    };
+    thread::Builder::new()
+        .name(format!("session-{}", name_prefix))
+        .spawn(move || session_thread(assignment, None))
+}
+
 #[allow(clippy::too_many_arguments)]
 fn session_thread(
-    #[cfg_attr(test, allow(unused_variables))] heap_limit_mb: Option<u32>,
-    #[cfg_attr(test, allow(unused_variables))] cpu_time_limit_ms: Option<u32>,
-    #[cfg_attr(test, allow(unused_variables))] wall_clock_limit_ms: Option<u32>,
-    rx: Receiver<SessionCommand>,
-    slot_control: SlotControl,
-    max_concurrency: usize,
-    #[cfg_attr(test, allow(unused_variables))] event_tx: RuntimeEventSender,
-    #[cfg_attr(test, allow(unused_variables))] call_id_router: CallIdRouter,
-    #[cfg_attr(test, allow(unused_variables))] shared_call_id: SharedCallIdCounter,
-    #[cfg_attr(test, allow(unused_variables))] snapshot_cache: Arc<SnapshotCache>,
-    #[cfg_attr(test, allow(unused_variables))] isolate_handle: SharedIsolateHandle,
-    #[cfg_attr(test, allow(unused_variables))] execution_abort: SharedExecutionAbort,
-    #[cfg_attr(test, allow(unused_variables))] session_id: String,
-    #[cfg_attr(test, allow(unused_variables))] output_generation: Option<u64>,
+    assignment: SessionAssignment,
+    #[cfg_attr(test, allow(unused_variables))] precreated_isolate: Option<PrecreatedIsolate>,
 ) {
+    let SessionAssignment {
+        heap_limit_mb,
+        cpu_time_limit_ms,
+        wall_clock_limit_ms,
+        rx,
+        slot_control,
+        max_concurrency,
+        event_tx,
+        call_id_router,
+        shared_call_id,
+        snapshot_cache,
+        isolate_handle,
+        execution_abort,
+        session_id,
+        output_generation,
+    } = assignment;
+    #[cfg(test)]
+    let _ = (
+        heap_limit_mb,
+        cpu_time_limit_ms,
+        wall_clock_limit_ms,
+        call_id_router,
+        shared_call_id,
+        snapshot_cache,
+        isolate_handle,
+        execution_abort,
+    );
+
     // Acquire concurrency slot, but keep polling the session channel so a queued
     // session can still shut down cleanly before it ever gets a slot.
     let mut deferred_commands = VecDeque::new();
@@ -818,20 +1258,26 @@ fn session_thread(
     #[cfg(all(not(test), not(unix)))]
     let exec_thread_cpu_clock: Option<crate::timeout::ThreadCpuClock> = None;
 
-    // Isolate creation is deferred to first Execute (when bridge code is known
-    // for snapshot cache lookup). This avoids creating an isolate that may never
-    // be used and enables snapshot-based fast creation.
+    // Isolate creation is normally deferred to first Execute (when bridge code is
+    // known for snapshot cache lookup). A claimed warm worker enters here with
+    // the snapshot isolate already created on this same thread.
     #[cfg(not(test))]
-    let mut v8_isolate: Option<v8::OwnedIsolate> = None;
-    #[cfg(not(test))]
-    let mut _v8_context: Option<v8::Global<v8::Context>> = None;
-
-    // Whether the isolate was created from a context snapshot.
-    // When true, Execute uses the snapshot's default context (bridge IIFE
-    // already executed) and skips re-running the bridge code. Bridge function
-    // stubs in the snapshot are replaced with real session-local functions.
-    #[cfg(not(test))]
-    let mut from_snapshot = false;
+    let (
+        mut v8_isolate,
+        mut _v8_context,
+        mut from_snapshot,
+        mut isolate_bridge_code,
+        mut isolate_userland_code,
+    ) = match precreated_isolate {
+        Some(precreated) => (
+            Some(precreated.isolate),
+            Some(precreated.context),
+            true,
+            Some(precreated.bridge_code),
+            Some(precreated.userland_code),
+        ),
+        None => (None, None, false, None, None),
+    };
 
     #[cfg(not(test))]
     let mut pending = bridge::PendingPromises::new();
@@ -855,15 +1301,16 @@ fn session_thread(
     // bridge code stays the same. Fresh contexts cloned from a snapshot inherit
     // the snapshot's bridge IIFE, so a bridge-code change must rebuild the
     // isolate before the next execution or the session will keep restoring the
-    // old snapshot forever.
-    #[cfg(not(test))]
-    let mut isolate_bridge_code: Option<String> = None;
-    // The userland bundle baked into the current isolate's snapshot — a change
-    // must rebuild the isolate for the same reason as a bridge-code change.
-    #[cfg(not(test))]
-    let mut isolate_userland_code: Option<String> = None;
+    // old snapshot forever. The userland bundle is part of the same guard.
     #[cfg(not(test))]
     let mut high_resolution_time_origin = Instant::now();
+
+    #[cfg(not(test))]
+    if let Some(iso) = v8_isolate.as_mut() {
+        *isolate_handle
+            .lock()
+            .expect("session isolate handle lock poisoned") = Some(iso.thread_safe_handle());
+    }
 
     // Process commands until shutdown or channel close
     loop {
@@ -2319,6 +2766,7 @@ mod tests {
             None,
             None,
             Some(7),
+            None,
         )
         .expect("create session");
         mgr.call_id_router()

--- a/crates/v8-runtime/src/snapshot.rs
+++ b/crates/v8-runtime/src/snapshot.rs
@@ -137,6 +137,11 @@ fn run_snapshot_script(scope: &mut v8::HandleScope, code: &str, label: &str) -> 
         Some(source) => source,
         None => return Err(format!("failed to create V8 string for {label}")),
     };
+    // NOTE(perf, measured 2026-07-02): do NOT switch this to
+    // script_compiler::compile(EagerCompile) to bake function bytecode into the
+    // blob. It moves cost instead of removing it: user_code_execute dropped
+    // 8.9ms -> 7.9ms on the wasm-runner floor, but the fatter blob made
+    // isolate_new 4.0ms -> 7.4ms per exec (net wash).
     let Some(script) = v8::Script::compile(try_catch, source, None) else {
         let message = try_catch
             .exception()
@@ -611,6 +616,25 @@ impl SnapshotCache {
     /// prevents duplicate snapshot creation for the same bridge code.
     pub fn get_or_create(&self, bridge_code: &str) -> Result<Arc<Vec<u8>>, String> {
         self.get_or_create_with_userland(bridge_code, None)
+    }
+
+    /// Return a cached snapshot if present. This never creates a snapshot or
+    /// waits on in-flight creation.
+    pub fn try_get_with_userland(
+        &self,
+        bridge_code: &str,
+        userland_code: Option<&str>,
+    ) -> Option<Arc<Vec<u8>>> {
+        let key = snapshot_cache_key(bridge_code, userland_code);
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(pos) = inner.entries.iter().position(|e| e.key == key) {
+            let entry = inner.entries.remove(pos);
+            let blob = Arc::clone(&entry.blob);
+            inner.entries.push(entry);
+            Some(blob)
+        } else {
+            None
+        }
     }
 
     /// Like [`get_or_create`], but the snapshot also captures an evaluated userland

--- a/crates/v8-runtime/src/snapshot.rs
+++ b/crates/v8-runtime/src/snapshot.rs
@@ -131,18 +131,49 @@ const SNAPSHOT_USERLAND_PREP: &str = r#"
 /// Compile and run a Script in the snapshot-creation context, returning a
 /// descriptive error (with the V8 exception message) on failure. `label`
 /// identifies the phase (e.g. "bridge code" / "userland code") in error text.
-fn run_snapshot_script(scope: &mut v8::HandleScope, code: &str, label: &str) -> Result<(), String> {
+fn run_snapshot_script(
+    scope: &mut v8::HandleScope,
+    code: &str,
+    label: &str,
+    eager: bool,
+) -> Result<(), String> {
     let try_catch = &mut v8::TryCatch::new(scope);
     let source = match v8::String::new(try_catch, code) {
         Some(source) => source,
         None => return Err(format!("failed to create V8 string for {label}")),
     };
-    // NOTE(perf, measured 2026-07-02): do NOT switch this to
-    // script_compiler::compile(EagerCompile) to bake function bytecode into the
-    // blob. It moves cost instead of removing it: user_code_execute dropped
+    // NOTE(perf, measured 2026-07-02): EagerCompile was a wash while isolate
+    // creation stayed on the per-exec critical path: user_code_execute dropped
     // 8.9ms -> 7.9ms on the wasm-runner floor, but the fatter blob made
-    // isolate_new 4.0ms -> 7.4ms per exec (net wash).
-    let Some(script) = v8::Script::compile(try_catch, source, None) else {
+    // isolate_new 4.0ms -> 7.4ms per exec. Warm workers now prepay snapshot
+    // deserialization off-path, so only userland-bearing snapshots opt into
+    // eager compilation to cut user_code_execute.
+    let script = if eager {
+        let resource_name = v8::String::new(try_catch, label).unwrap();
+        let origin = v8::ScriptOrigin::new(
+            try_catch,
+            resource_name.into(),
+            0,
+            0,
+            false,
+            0,
+            None,
+            false,
+            false,
+            false,
+            None,
+        );
+        let mut source = v8::script_compiler::Source::new(source, Some(&origin));
+        v8::script_compiler::compile(
+            try_catch,
+            &mut source,
+            v8::script_compiler::CompileOptions::EagerCompile,
+            v8::script_compiler::NoCacheReason::NoReason,
+        )
+    } else {
+        v8::Script::compile(try_catch, source, None)
+    };
+    let Some(script) = script else {
         let message = try_catch
             .exception()
             .map(|exception| exception.to_rust_string_lossy(try_catch))
@@ -239,15 +270,15 @@ fn create_snapshot_inner_in_process(
             // Then, if present, run the userland (agent-SDK) IIFE in the SAME context so
             // its evaluated graph is captured alongside the bridge.
             let result = (|| -> Result<(), String> {
-                run_snapshot_script(scope, bridge_code, "bridge code")?;
+                run_snapshot_script(scope, bridge_code, "bridge code", false)?;
                 if let Some(userland_code) = userland_code {
                     // Some bridge-backed globals (e.g. `process.versions`) are lazy
                     // getters that dispatch a host bridge call on first access. During
                     // snapshot creation the bridge fns are stubs, so an agent SDK that
                     // reads them at module-init would fail. Freeze them to static values
                     // first; per-session config is still injected post-restore.
-                    run_snapshot_script(scope, SNAPSHOT_USERLAND_PREP, "userland prep")?;
-                    run_snapshot_script(scope, userland_code, "userland code")?;
+                    run_snapshot_script(scope, SNAPSHOT_USERLAND_PREP, "userland prep", false)?;
+                    run_snapshot_script(scope, userland_code, "userland code", true)?;
                 }
                 Ok(())
             })();
@@ -563,7 +594,7 @@ where
     isolate
 }
 
-type SnapshotCacheKey = [u8; 32];
+pub type SnapshotCacheKey = [u8; 32];
 
 /// Thread-safe snapshot cache keyed by bridge code digest.
 ///
@@ -717,7 +748,7 @@ impl SnapshotCache {
 /// Cache key over bridge + optional userland code. With no userland this is just
 /// the sha256 of the bridge code (a NUL separator is only added when userland is
 /// present), so existing bridge-only entries keep their historical keys.
-fn snapshot_cache_key(bridge_code: &str, userland_code: Option<&str>) -> SnapshotCacheKey {
+pub fn snapshot_cache_key(bridge_code: &str, userland_code: Option<&str>) -> SnapshotCacheKey {
     match userland_code {
         None => {
             let mut hasher = Sha256::new();

--- a/crates/v8-runtime/tests/embedded_runtime_session.rs
+++ b/crates/v8-runtime/tests/embedded_runtime_session.rs
@@ -26,6 +26,7 @@ fn register_and_create_session(
         heap_limit_mb: None,
         cpu_time_limit_ms: None,
         wall_clock_limit_ms: None,
+        warm_hint: None,
     })?;
     Ok(receiver)
 }
@@ -41,6 +42,7 @@ fn register_and_create_session_with_cpu_time_limit(
         heap_limit_mb: None,
         cpu_time_limit_ms,
         wall_clock_limit_ms: None,
+        warm_hint: None,
     })?;
     Ok(receiver)
 }
@@ -158,6 +160,7 @@ fn assert_create_destroy_reuses_session_ids() -> io::Result<()> {
             heap_limit_mb: None,
             cpu_time_limit_ms: None,
             wall_clock_limit_ms: None,
+            warm_hint: None,
         })
         .expect_err("duplicate sessions should be rejected");
     assert_eq!(duplicate_error.kind(), io::ErrorKind::Other);

--- a/packages/core/src/kernel-proxy.ts
+++ b/packages/core/src/kernel-proxy.ts
@@ -308,6 +308,7 @@ interface TrackedProcessEntry {
 	waitWithFallbackPromise: Promise<number> | null;
 	hostExitObservedAt: number | null;
 	outputGeneration: number;
+	exitViaEvent: boolean;
 }
 
 interface NativeSidecarKernelProxyOptions {
@@ -649,6 +650,7 @@ export class NativeSidecarKernelProxy {
 			waitWithFallbackPromise: null,
 			hostExitObservedAt: null,
 			outputGeneration: 0,
+			exitViaEvent: false,
 		};
 		this.trackedProcesses.set(pid, entry);
 		this.trackedProcessesById.set(processId, entry);
@@ -1463,6 +1465,16 @@ export class NativeSidecarKernelProxy {
 			return;
 		}
 
+		if (entry.exitViaEvent) {
+			// The sidecar drains process output before it emits `process_exited`,
+			// the stdio frame stream is FIFO, and this pump dispatches events in
+			// order. Once the exit event reaches this entry, no trailing output can
+			// follow it; one zero-delay turn is cheap insurance for same-tick
+			// listener scheduling.
+			await drainTrailingProcessOutputTurn(0);
+			return;
+		}
+
 		let observedGeneration = entry.outputGeneration;
 		let quietTurns = 0;
 		let delayMs = 0;
@@ -1499,7 +1511,10 @@ export class NativeSidecarKernelProxy {
 		entry.started = true;
 		this.updateTrackedProcessSnapshot(entry);
 		void this.refreshProcessSnapshot().catch(() => {});
-		await this.refreshSignalState(entry);
+		this.signalRefreshes.set(
+			entry.pid,
+			this.refreshSignalState(entry).catch(() => {}),
+		);
 
 		void this.flushPendingStdin(entry).catch((error) => {
 			this.handleBackgroundProcessError(entry, error);
@@ -1533,8 +1548,10 @@ export class NativeSidecarKernelProxy {
 					entry.outputGeneration += 1;
 					void this.refreshProcessSnapshot().catch(() => {});
 					if (!this.signalRefreshes.has(entry.pid)) {
-						this.signalRefreshes.set(entry.pid, this.refreshSignalState(entry));
-						await this.signalRefreshes.get(entry.pid);
+						this.signalRefreshes.set(
+							entry.pid,
+							this.refreshSignalState(entry).catch(() => {}),
+						);
 					}
 					const chunk = event.payload.chunk;
 					const listeners =
@@ -1553,7 +1570,7 @@ export class NativeSidecarKernelProxy {
 						continue;
 					}
 					void this.refreshProcessSnapshot().catch(() => {});
-					this.signalRefreshes.delete(entry.pid);
+					entry.exitViaEvent = true;
 					this.finishProcess(entry, event.payload.exit_code);
 				}
 			} catch (error) {
@@ -1583,6 +1600,10 @@ export class NativeSidecarKernelProxy {
 		if (entry.exitCode !== null) {
 			return;
 		}
+		// Every started process now parks a signal-state refresh here, so clean
+		// up on the shared exit path — the snapshot-poll fallback exits never
+		// pass through the event pump's `process_exited` branch.
+		this.signalRefreshes.delete(entry.pid);
 		entry.exitCode = exitCode;
 		entry.exitTime = Date.now();
 		this.updateTrackedProcessSnapshot(entry);
@@ -1658,6 +1679,7 @@ export class NativeSidecarKernelProxy {
 		entry: TrackedProcessEntry,
 		signal: number,
 	): Promise<void> {
+		await this.signalRefreshes.get(entry.pid);
 		try {
 			await this.client.killProcess(
 				this.session,

--- a/packages/core/tests/node-runtime-exec-output.test.ts
+++ b/packages/core/tests/node-runtime-exec-output.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { NodeRuntime } from "../src/index.js";
+
+describe("NodeRuntime execCommand output capture", () => {
+	test(
+		"captures complete stdout when a fast process exits immediately",
+		async () => {
+			const runtime = await NodeRuntime.create();
+			const expected = "x".repeat(64 * 1024);
+			const script = [
+				'const fs = require("node:fs");',
+				"const chunk = Buffer.alloc(4096, 120);",
+				"for (let i = 0; i < 16; i += 1) fs.writeSync(1, chunk);",
+				"process.exit(0);",
+			].join(" ");
+
+			try {
+				for (let i = 0; i < 10; i += 1) {
+					const result = await runtime.execCommand("node", ["-e", script]);
+
+					expect(result.exitCode).toBe(0);
+					expect(result.stdout).toBe(expected);
+					expect(result.stderr).toBe("");
+				}
+			} finally {
+				await runtime.dispose();
+			}
+		},
+		120_000,
+	);
+});

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,8 @@
 [toolchain]
 channel = "1.96.0"
 components = ["clippy", "rustfmt"]
+# wasm32-wasip1 is a first-class build target (native-baseline wasm lane, the
+# registry command builds); declaring it here makes rustup provision it for the
+# pinned toolchain everywhere, instead of each CI workflow's toolchain action
+# only adding it to a different (stable) toolchain.
+targets = ["wasm32-wasip1"]


### PR DESCRIPTION
Pre-created V8 session workers (thread + snapshot-restored isolate, keyed by
snapshot digest + heap limit) are claimed at session create via a warm hint,
taking isolate_new (~4.2ms) and blob_clone off the per-exec critical path.
Workers are never reused across guests (each exec still gets a virgin
isolate); a wrong hint falls back to the existing lazy-create path. Capacity
per key via AGENTOS_V8_WARM_ISOLATES (default 2, 0 disables); refill after
claim; pool transitions logged; warm_worker_hit/miss counters in the session
phases output.

Seeding is deliberately conservative: auto mode stays snapshot-only and only
AGENTOS_WASM_SNAPSHOT_RUNNER=block seeds workers (wasm-runner key + default
node key). Reason: creating isolates on background threads while other
isolates execute guest WebAssembly deterministically SIGSEGVs the pinned V8
130 (WasmCodePointerTable::AllocateUninitializedEntry inside Isolate::New,
even under the isolate lifecycle lock — the race is against V8-internal wasm
threads). Backtraces + notes in the rusty-v8-upgrade todo; enabling default
seeding rides that upgrade.

Warm floors (block, this host): node -e '' 17 -> 14.4ms p50, wasm true
33 -> ~30ms (warm_worker_hit 64/67, isolate_new down to 3 background calls);
pwd 42.6 -> 37.5ms, printf-0b 44.7 -> 40.2ms, date 115 -> 111ms. wasm suite
8.9s (was 96s, pool+snapshot amortize debug isolates); v8-runtime tests and
bench:gate green.