### PR TITLE
fix(execution): resolve adapter entrypoint symlink for module-mode detection

### DIFF
--- a/crates/execution/src/javascript.rs
+++ b/crates/execution/src/javascript.rs
@@ -2628,9 +2628,15 @@ fn build_v8_user_code(entrypoint: &str, env: &BTreeMap<String, String>) -> Strin
 }
 
 fn host_entrypoint_uses_module_mode(entrypoint: &Path) -> bool {
-    match entrypoint.extension().and_then(|ext| ext.to_str()) {
+    // Agent adapters are launched via an extensionless `/opt/agentos/bin/<cmd>`
+    // symlink into the packed package's `node_modules/<name>/<entry>`. Resolve it
+    // to the real file so the extension check and the nearest-`package.json` walk
+    // reflect the package (which carries `"type": "module"`), not the symlink farm
+    // (which has neither an extension nor a package.json).
+    let resolved = fs::canonicalize(entrypoint).unwrap_or_else(|_| entrypoint.to_path_buf());
+    match resolved.extension().and_then(|ext| ext.to_str()) {
         Some("mjs" | "mts") => true,
-        Some("js") => nearest_package_json_type(entrypoint).as_deref() == Some("module"),
+        Some("js") => nearest_package_json_type(&resolved).as_deref() == Some("module"),
         _ => false,
     }
 }


### PR DESCRIPTION
- Agent ACP adapters launch via an extensionless `/opt/agentos/bin/<cmd>` symlink into the packed package's `node_modules/<name>/<entry>`
- `host_entrypoint_uses_module_mode` matched on the (missing) file extension and fell through to CommonJS, so ESM adapters crashed at `initialize` with `Cannot use import statement outside a module`
- Canonicalize the entrypoint before the extension + nearest-`package.json` check so it resolves to the real adapter file (whose `package.json` retains `"type":"module"`) and runs in ESM mode
- Verified: the pi ACP adapter now boots and dispatches tool calls inside the VM (previously failed at startup)