### PR TITLE
chore: burn down the workspace clippy backlog (-D warnings now passes)

### DIFF
--- a/crates/execution/src/javascript.rs
+++ b/crates/execution/src/javascript.rs
@@ -218,11 +218,7 @@ fn record_sync_bridge_phase(method: &str, stage: &str, elapsed: Duration) {
             let Some((method, stage)) = key.split_once(':') else {
                 continue;
             };
-            let avg_us = if value.calls == 0 {
-                0
-            } else {
-                value.total_us / value.calls
-            };
+            let avg_us = value.total_us.checked_div(value.calls).unwrap_or(0);
             lines.push_str(&format!(
                 "method={method} stage={stage} calls={} total_us={} avg_us={} max_us={}\n",
                 value.calls, value.total_us, avg_us, value.max_us
@@ -922,7 +918,7 @@ impl TimerWheel {
         state.next_seq = state.next_seq.wrapping_add(1);
         state.heap.push(Reverse((deadline, seq)));
         state.entries.insert(seq, action);
-        if old_earliest.map_or(true, |old| deadline < old) {
+        if old_earliest.is_none_or(|old| deadline < old) {
             self.ready.notify_one();
         }
     }

--- a/crates/execution/src/v8_host.rs
+++ b/crates/execution/src/v8_host.rs
@@ -179,7 +179,6 @@ impl V8RuntimeHost {
                         eprintln!(
                             "secure-exec-v8-runtime: wasm runner snapshot warm failed: {error}"
                         );
-                        return;
                     }
                 });
         });
@@ -262,6 +261,7 @@ impl V8SessionHandle {
 
     /// Execute bridge code + user code in this V8 session without routing through
     /// the legacy binary frame encode/decode path.
+    #[allow(clippy::too_many_arguments)] // mirrors the CreateSession frame
     pub fn execute(
         &self,
         mode: u8,

--- a/crates/kernel/src/kernel.rs
+++ b/crates/kernel/src/kernel.rs
@@ -873,7 +873,7 @@ impl<F: VirtualFileSystem + 'static> KernelVm<F> {
             let umask = self.processes.get_umask(pid)?;
             let mode = mode.unwrap_or(0o777);
             for created_path in &created_paths {
-                self.apply_creation_mode(&created_path, mode, umask)?;
+                self.apply_creation_mode(created_path, mode, umask)?;
             }
         }
         self.update_filesystem_usage_cache_for_inode_creates(created_paths.len());

--- a/crates/sidecar-browser/src/service.rs
+++ b/crates/sidecar-browser/src/service.rs
@@ -1976,6 +1976,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)] // browser_worker_identity below is shared with the worker shim
 mod tests {
     use super::*;
     use secure_exec_bridge::{

--- a/crates/sidecar-browser/src/wire_dispatch.rs
+++ b/crates/sidecar-browser/src/wire_dispatch.rs
@@ -1049,15 +1049,12 @@ where
 
     fn pump_execution_events(&mut self) {
         for vm_id in self.active_vms.iter().cloned().collect::<Vec<_>>() {
-            loop {
-                let event = match self
-                    .sidecar
+            while let Ok(Some(event)) =
+                self.sidecar
                     .poll_execution_event(PollExecutionEventRequest {
                         vm_id: vm_id.clone(),
-                    }) {
-                    Ok(Some(event)) => event,
-                    Ok(None) | Err(_) => break,
-                };
+                    })
+            {
                 if let Some(frame) = self.execution_event_to_frame(event) {
                     self.pending_events.push_back(frame);
                 }

--- a/crates/sidecar-core/src/router.rs
+++ b/crates/sidecar-core/src/router.rs
@@ -21,6 +21,9 @@ pub enum RequestDispatchMode {
     Async,
 }
 
+// Request payload variants intentionally vary widely in size (small acks next
+// to bulky create/exec payloads); boxing is a wire-adjacent refactor.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum RequestRoute {
     Authenticate(AuthenticateRequest),

--- a/crates/sidecar-protocol/src/lib.rs
+++ b/crates/sidecar-protocol/src/lib.rs
@@ -1,4 +1,7 @@
 #![forbid(unsafe_code)]
+// Wire enums intentionally have wide size variance (small acks next to bulky
+// payload variants); boxing them is a wire-adjacent refactor tracked separately.
+#![allow(clippy::large_enum_variant, clippy::result_large_err)]
 
 //! Shared Secure Exec sidecar wire protocol surface.
 

--- a/crates/sidecar/src/crypto_cipher.rs
+++ b/crates/sidecar/src/crypto_cipher.rs
@@ -206,6 +206,7 @@ pub(crate) struct StreamCipherSession {
 impl StreamCipherSession {
     /// Construct a cipher session. `pad` controls PKCS#7 auto-padding for CBC
     /// (Node's `setAutoPadding`). `aad`/`auth_tag` apply to AEAD (GCM) modes.
+    #[allow(clippy::too_many_arguments)] // mirrors Node's createCipheriv surface
     pub(crate) fn new(
         algorithm: &str,
         key: &[u8],
@@ -423,7 +424,7 @@ enum GcmAead {
 }
 
 impl GcmAead {
-    fn encrypt_detached(&self, nonce: &[u8], aad: &[u8], buffer: &mut Vec<u8>) -> Result<Vec<u8>> {
+    fn encrypt_detached(&self, nonce: &[u8], aad: &[u8], buffer: &mut [u8]) -> Result<Vec<u8>> {
         let nonce = GenericArray::from_slice(nonce);
         let tag = match self {
             GcmAead::A128(c) => c.encrypt_in_place_detached(nonce, aad, buffer),
@@ -438,7 +439,7 @@ impl GcmAead {
         &self,
         nonce: &[u8],
         aad: &[u8],
-        buffer: &mut Vec<u8>,
+        buffer: &mut [u8],
         tag: &[u8],
     ) -> Result<()> {
         let nonce = GenericArray::from_slice(nonce);

--- a/crates/sidecar/src/execution.rs
+++ b/crates/sidecar/src/execution.rs
@@ -5919,7 +5919,7 @@ where
         process_id: &str,
         request: PythonVfsRpcRequest,
     ) -> Result<(), SidecarError> {
-        if self.vms.get(vm_id).is_none() {
+        if !self.vms.contains_key(vm_id) {
             return Ok(());
         }
         let response = self.python_socket_op(vm_id, process_id, &request);
@@ -15866,13 +15866,13 @@ pub(crate) fn mark_execute_exit_event_queued(vm_id: &str, process_id: &str) {
     let queued = EXECUTE_EXIT_EVENT_QUEUED.get_or_init(|| Mutex::new(BTreeMap::new()));
     if let Ok(mut queued) = queued.lock() {
         let key = execute_phase_key(vm_id, process_id);
-        if !queued.contains_key(&key) {
+        if let std::collections::btree_map::Entry::Vacant(entry) = queued.entry(key) {
             record_execute_response_to_exit_milestone(
                 "execute_response_to_exit_event_queued",
                 vm_id,
                 process_id,
             );
-            queued.insert(key, Instant::now());
+            entry.insert(Instant::now());
         }
     }
 }
@@ -18475,10 +18475,10 @@ fn javascript_crypto_call_ecdh_session(
                 })?,
                 "ECDH private key",
             )?;
-            let mut ctx = BigNumContext::new().map_err(javascript_crypto_openssl_error)?;
+            let ctx = BigNumContext::new().map_err(javascript_crypto_openssl_error)?;
             let mut public_key = EcPoint::new(&group).map_err(javascript_crypto_openssl_error)?;
             public_key
-                .mul_generator(&group, &private_key, &mut ctx)
+                .mul_generator(&group, &private_key, &ctx)
                 .map_err(javascript_crypto_openssl_error)?;
             session.key_pair = Some(
                 EcKey::from_private_components(&group, &private_key, &public_key)

--- a/crates/sidecar/src/stdio.rs
+++ b/crates/sidecar/src/stdio.rs
@@ -490,13 +490,11 @@ fn extension_interrupt_response(
 ) -> Option<ExtensionInterruptDispatch> {
     match frame {
         ProtocolFrame::RequestFrame(request) => {
-            let Some(interrupt) = generated_wire_blocking_extension_interrupt(
+            let interrupt = generated_wire_blocking_extension_interrupt(
                 active_request,
                 &blocking_request.namespace,
                 request,
-            ) else {
-                return None;
-            };
+            )?;
             let interrupt = blocking_request.extension.interrupt_blocking_request(
                 &blocking_request.payload,
                 match interrupt {

--- a/crates/sidecar/tests/service.rs
+++ b/crates/sidecar/tests/service.rs
@@ -1406,6 +1406,7 @@ ykAheWCsAteSEWVc0w==\n\
                 .expect("configure registry command mount");
         }
 
+        #[allow(clippy::too_many_arguments)] // test helper mirroring the exec surface
         fn run_guest_command(
             sidecar: &mut NativeSidecar<RecordingBridge>,
             vm_id: &str,
@@ -17356,7 +17357,7 @@ console.log(JSON.stringify(summary));
             let cwd = temp_dir("secure-exec-sidecar-js-http-external-cwd");
             write_fixture(
                 &cwd.join("entry.mjs"),
-                &format!(
+                format!(
                     r#"
 import http from "node:http";
 

--- a/crates/v8-runtime/src/embedded_runtime.rs
+++ b/crates/v8-runtime/src/embedded_runtime.rs
@@ -296,6 +296,8 @@ pub struct EmbeddedV8SessionHandle {
 }
 
 impl EmbeddedV8SessionHandle {
+    // In-process runtime protocol call; the arg list mirrors the Execute frame.
+    #[allow(clippy::too_many_arguments)]
     pub fn execute(
         &self,
         mode: u8,

--- a/crates/v8-runtime/src/host_call.rs
+++ b/crates/v8-runtime/src/host_call.rs
@@ -88,11 +88,7 @@ pub(crate) fn record_sync_bridge_host_phase(method: &str, stage: &str, elapsed: 
             let Some((method, stage)) = key.split_once(':') else {
                 continue;
             };
-            let avg_us = if value.calls == 0 {
-                0
-            } else {
-                value.total_us / value.calls
-            };
+            let avg_us = value.total_us.checked_div(value.calls).unwrap_or(0);
             lines.push_str(&format!(
                 "method={method} stage={stage} calls={} total_us={} avg_us={} max_us={}\n",
                 value.calls, value.total_us, avg_us, value.max_us

--- a/crates/v8-runtime/src/session.rs
+++ b/crates/v8-runtime/src/session.rs
@@ -282,6 +282,8 @@ impl WarmWorkerPool {
             });
     }
 
+    // Internal pool-refill plumbing; args mirror the parked-worker construction.
+    #[allow(clippy::too_many_arguments)]
     fn refill_until(
         &self,
         snapshot_cache: Arc<SnapshotCache>,
@@ -749,6 +751,9 @@ impl SessionManager {
         Ok(())
     }
 
+    // The Err variant intentionally carries the whole SessionAssignment back to
+    // the caller for the fallback spawn path — it is moved, not copied.
+    #[allow(clippy::result_large_err)]
     fn claim_warm_worker(
         &self,
         warm_hint: Option<&WarmSessionHint>,

--- a/crates/v8-runtime/src/snapshot.rs
+++ b/crates/v8-runtime/src/snapshot.rs
@@ -715,8 +715,7 @@ impl SnapshotCache {
         }
 
         // Phase 2: create snapshot without holding the cache lock
-        let creation_result =
-            create_snapshot_inner(bridge_code, userland_code).map(|blob| Arc::new(blob));
+        let creation_result = create_snapshot_inner(bridge_code, userland_code).map(Arc::new);
 
         // Phase 3: short lock — insert result, notify waiters, clean up
         {

--- a/crates/vm-config/src/lib.rs
+++ b/crates/vm-config/src/lib.rs
@@ -131,10 +131,6 @@ pub struct JsRuntimeConfig {
     pub snapshot_userland_code: Option<String>,
 }
 
-fn is_false(value: &bool) -> bool {
-    !*value
-}
-
 impl JsRuntimeConfig {
     fn validate(&self) -> Result<(), VmConfigError> {
         if let Some(allowed) = &self.allowed_builtins {


### PR DESCRIPTION
First-ever full main CI runs (post 0.5 install fix) reached the clippy gate
and found the accumulated backlog. Real fixes: checked_div for two manual
divisions, map_or->is_none_or, entry-API insert, needless borrows/mut/return,
while-let rewrite, &mut Vec->&mut [u8] on the GCM helpers, redundant closure,
dead is_false helper removed. Documented allows where the lint fights the
architecture: wire enums with intentionally wide variant sizes
(sidecar-protocol crate-level, router RequestRoute), arg lists mirroring
protocol frames (session/embedded-runtime/crypto constructor/test helper),
claim_warm_worker's move-back Err. cargo clippy --workspace --all-targets
-D warnings: 0 errors; fmt green; touched-area suites green.