### PR TITLE
fix(bench): tolerate pnpm's forwarded -- separator in baseline.ts args

### DIFF
--- a/packages/benchmarks/src/baseline.ts
+++ b/packages/benchmarks/src/baseline.ts
@@ -177,6 +177,10 @@ function parseArgs(argv: string[]): {
 	let from: string | undefined;
 	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i];
+		if (arg === "--") {
+			// pnpm run forwards the `--` separator itself; ignore it.
+			continue;
+		}
 		if (arg === "--ci") {
 			kind = "ci";
 		} else if (arg === "--local") {


### PR DESCRIPTION
The nightly's final step (pnpm bench:baseline -- --ci --from ...) died with
'unknown baseline.ts argument: --' AFTER a fully successful 25-minute matrix
run — pnpm forwards the literal -- separator to the script. baseline.ts now
skips it.