### PR TITLE
test(execution): track the wasi-module preopen restructure in bootstrap assertions

### DIFF
--- a/crates/execution/src/wasm.rs
+++ b/crates/execution/src/wasm.rs
@@ -4591,8 +4591,10 @@ mod tests {
     fn wasm_runner_bootstrap_reports_dot_preopen_to_wasi() {
         let bootstrap = build_wasm_runner_bootstrap(&BTreeMap::new(), None);
 
-        assert!(bootstrap.contains("const cwdMount = guestCwd || '/workspace';"));
-        assert!(bootstrap.contains("preopens[cwdMount] = createPreopen(HOST_CWD, cwdReadOnly);"));
+        // The dot preopen must resolve through the guest cwd, never surface as a
+        // literal "." (restructured into _currentGuestCwd/_descriptorPreopenName
+        // by the wasi-shim stat-path rework).
+        assert!(bootstrap.contains("_currentGuestCwd()"));
         assert!(!bootstrap.contains("preopens['.'] = createPreopen(HOST_CWD, cwdReadOnly);"));
         assert!(bootstrap.contains("_descriptorPreopenName(entry)"));
         assert!(bootstrap.contains(


### PR DESCRIPTION
wasm_runner_bootstrap_reports_dot_preopen_to_wasi asserted source fragments
(cwdMount/preopens[cwdMount]) that the wasi-shim stat-path rework (PR #226)
restructured into _currentGuestCwd/_descriptorPreopenName. The behavioral
intent — the dot preopen resolves through the guest cwd and never surfaces
as a literal '.' — is asserted against the new markers; surfaced by the
first full main CI cargo-test run.