### PR TITLE
fix(ci): resolve nightly baseline --from path relative to the benchmarks package

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Write CI candidate baseline
         env:
           SECURE_EXEC_SIDECAR_BIN: ${{ github.workspace }}/target/release/secure-exec-sidecar
-        run: pnpm --dir packages/benchmarks bench:baseline -- --ci --from packages/benchmarks/results/latency-matrix.json
+        run: pnpm --dir packages/benchmarks bench:baseline -- --ci --from results/latency-matrix.json
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
bench:baseline runs with cwd packages/benchmarks (pnpm --dir), so the
repo-root-relative --from path double-prefixed and failed with ENOENT.
The matrix output path is package-anchored, so the package-relative
path is stable.