### PR TITLE
test(execution): allow dead_code on quarantined live-stdin/tty test fns

### DIFF
--- a/crates/execution/tests/javascript_v8.rs
+++ b/crates/execution/tests/javascript_v8.rs
@@ -1106,6 +1106,7 @@ console.log(JSON.stringify({ formatted }));
     );
 }
 
+#[allow(dead_code)] // quarantined: see the live-stdin/tty harness note above
 fn javascript_execution_stream_consumers_text_reads_live_stdin() {
     let temp = tempdir().expect("create temp dir");
     let mut engine = JavascriptExecutionEngine::default();
@@ -1154,6 +1155,7 @@ console.log(JSON.stringify({ body }));
     assert_eq!(output, json!({ "body": "alpha\nbeta\n" }));
 }
 
+#[allow(dead_code)] // quarantined: see the live-stdin/tty harness note above
 fn javascript_execution_process_stdin_async_iterator_finishes_with_live_stdin() {
     let temp = tempdir().expect("create temp dir");
     let mut engine = JavascriptExecutionEngine::default();
@@ -1203,6 +1205,7 @@ console.log(JSON.stringify({ body }));
     assert_eq!(output, json!({ "body": "{\"request_id\":\"init1\"}\n" }));
 }
 
+#[allow(dead_code)] // quarantined: see the live-stdin/tty harness note above
 fn javascript_execution_process_exit_from_live_stdin_listener_exits_without_waiting_for_eof() {
     let temp = tempdir().expect("create temp dir");
     let mut engine = JavascriptExecutionEngine::default();
@@ -1373,6 +1376,7 @@ Promise.resolve()
     assert!(!stdout.contains("catch handler ran"), "stdout:\n{stdout}");
 }
 
+#[allow(dead_code)] // quarantined: see the live-stdin/tty harness note above
 fn javascript_execution_live_stdin_replays_end_after_late_listener_registration() {
     let temp = tempdir().expect("create temp dir");
     let mut engine = JavascriptExecutionEngine::default();
@@ -3784,6 +3788,7 @@ if (!(file instanceof bufferModule.Blob)) {
     assert!(stderr.is_empty(), "unexpected stderr: {stderr}");
 }
 
+#[allow(dead_code)] // quarantined: see the live-stdin/tty harness note above
 fn javascript_execution_v8_tty_module_is_backed_by_live_process() {
     let temp = tempdir().expect("create temp dir");
     write_fixture(

--- a/website/src/generated/routes.json
+++ b/website/src/generated/routes.json
@@ -44,30 +44,6 @@
       "title": "Secure Exec vs Container Sandbox",
       "description": "When to use a container sandbox versus Secure Exec for running untrusted code."
     },
-    "/docs/docs/sdks/rust": {
-      "title": "Rust SDK",
-      "description": "Install the Secure Exec Rust client and find its generated docs.rs reference."
-    },
-    "/docs/docs/sdks/typescript": {
-      "title": "TypeScript SDK",
-      "description": "Install the Secure Exec TypeScript SDK and find its generated API reference."
-    },
-    "/docs/docs/use-cases/ai-agent-code-exec": {
-      "title": "AI Agent Code Exec",
-      "description": "Give AI agents a secure code-execution tool that runs untrusted code in a sandbox and returns structured results."
-    },
-    "/docs/docs/use-cases/code-mode": {
-      "title": "Code Mode (MCP)",
-      "description": "Give AI agents a single code-execution tool instead of individual MCP tools. The LLM writes code that chains binding calls, executed safely in Secure Exec."
-    },
-    "/docs/docs/use-cases/dev-servers": {
-      "title": "Dev Servers",
-      "description": "Run user-provided server-style code (HTTP servers, request handlers) inside a secure isolate."
-    },
-    "/docs/docs/use-cases/plugin-systems": {
-      "title": "Plugin Systems",
-      "description": "Run user-authored plugins in isolation with explicit permissions."
-    },
     "/docs/docs/features/bindings": {
       "title": "Bindings",
       "description": "Give sandboxed guest code a narrow, curated set of host-backed capabilities."
@@ -115,6 +91,30 @@
     "/docs/docs/features/typescript": {
       "title": "TypeScript",
       "description": "Compiling and type-checking TypeScript inside the sandbox."
+    },
+    "/docs/docs/sdks/rust": {
+      "title": "Rust SDK",
+      "description": "Install the Secure Exec Rust client and find its generated docs.rs reference."
+    },
+    "/docs/docs/sdks/typescript": {
+      "title": "TypeScript SDK",
+      "description": "Install the Secure Exec TypeScript SDK and find its generated API reference."
+    },
+    "/docs/docs/use-cases/ai-agent-code-exec": {
+      "title": "AI Agent Code Exec",
+      "description": "Give AI agents a secure code-execution tool that runs untrusted code in a sandbox and returns structured results."
+    },
+    "/docs/docs/use-cases/code-mode": {
+      "title": "Code Mode (MCP)",
+      "description": "Give AI agents a single code-execution tool instead of individual MCP tools. The LLM writes code that chains binding calls, executed safely in Secure Exec."
+    },
+    "/docs/docs/use-cases/dev-servers": {
+      "title": "Dev Servers",
+      "description": "Run user-provided server-style code (HTTP servers, request handlers) inside a secure isolate."
+    },
+    "/docs/docs/use-cases/plugin-systems": {
+      "title": "Plugin Systems",
+      "description": "Run user-authored plugins in isolation with explicit permissions."
     }
   }
 }


### PR DESCRIPTION
The quarantined subtests tripped -D warnings (dead-code) on CI; keep the
fns compiled for easy re-enable.