### PR TITLE
fix(runtime): restore undici keepalive pooling and drop late socket wake hints

### DIFF
--- a/crates/v8-runtime/src/session.rs
+++ b/crates/v8-runtime/src/session.rs
@@ -1115,7 +1115,11 @@ fn handle_late_session_message(
             event_type,
             payload,
         }) => {
-            if event_type == "timer" {
+            // Timer and socket-readiness events are wake hints, not data; both
+            // race execution completion by design (edge-triggered readiness can
+            // fire as the guest finishes) and carry nothing to lose, so drop
+            // them silently instead of warning.
+            if event_type == "timer" || event_type == "net_socket" {
                 return;
             }
             send_late_message_warning(

--- a/packages/build-tools/bridge-src/builtins/fetch.ts
+++ b/packages/build-tools/bridge-src/builtins/fetch.ts
@@ -1,4 +1,4 @@
-import { createSecureExecUndiciDispatcher, undiciFetch } from "./undici.js";
+import { getSecureExecUndiciDispatcher, undiciFetch } from "./undici.js";
 import { exposeCustomGlobal } from "../global-exposure.js";
 import { undiciHeadersModule, undiciRequestModule, undiciResponseModule } from "../prelude.js";
 import { isFlatHeaderList, onUpgradeSocketEnd } from "./http.js";
@@ -106,7 +106,11 @@ async function fetch(input, options = {}) {
   if (handleId) {
     _registerHandle?.(handleId, `fetch ${requestLabel}`);
   }
-  const fetchDispatcher = normalizedOptions.dispatcher == null && typeof createSecureExecUndiciDispatcher === "function" ? createSecureExecUndiciDispatcher() : null;
+  // Shared bounded dispatcher (see undici.ts): keepalive pooling across fetch()
+  // calls. Per-call dispatchers (the 4f470c61 workaround for pooled clients
+  // going stale against released sockets) are no longer needed now that
+  // host->guest socket event push keeps pooled connections live.
+  const fetchDispatcher = normalizedOptions.dispatcher == null && typeof getSecureExecUndiciDispatcher === "function" ? getSecureExecUndiciDispatcher() : null;
   try {
     return await undiciFetch(
       resolvedInput,


### PR DESCRIPTION
- fetch() uses the shared bounded dispatcher again instead of a fresh
  Agent per call. The per-call dispatcher (4f470c61's workaround for
  pooled clients going stale against released sockets) opened one
  connection per request — the keepalive_no_listener_leak regression
  test caught 160 connections for 160 requests. Host->guest socket
  event push has since landed, which keeps pooled connections live;
  all fetch_via_undici cases pass including the churn/slot-release
  regression.
- Late net_socket StreamEvents (edge-triggered readiness racing
  execution completion) are wake hints carrying no data; drop them
  silently like late timer events instead of warning on stderr.