### PR TITLE
fix(wasm): only precreate-and-retry path_open on NOENT

### DIFF
--- a/crates/execution/assets/runners/wasm-runner.mjs
+++ b/crates/execution/assets/runners/wasm-runner.mjs
@@ -4391,8 +4391,12 @@ if (delegatePathOpen) {
       ),
     );
 
+    // Precreate-and-retry exists for creatable targets the delegate reports
+    // as missing (e.g. `>>` append redirect targets). Only retry on NOENT:
+    // retrying on permission errors would mask the real errno and attempt to
+    // create a file the kernel just denied.
     if (
-      result !== WASI_ERRNO_SUCCESS &&
+      result === WASI_ERRNO_NOENT &&
       mayCreateTarget
     ) {
       try {


### PR DESCRIPTION
The external-redirect fix (cd4683cc) dropped the standalone-only gate on
the precreate+retry block, so a sidecar-managed path_open that failed
with EACCES got a precreate attempt and its errno replaced by the
retry's result — a deny-write guest saw the wrong errno (caught by
wasm_path_open_write_goes_through_kernel_filesystem_permissions when a
warm runner was reused). Precreate-and-retry exists for creatable
targets reported missing (`>>` append redirect targets), so gate it on
the delegate returning NOENT; permission errors propagate untouched.
Redirect regressions (wasm_shell_) and the wasm suite stay green.