### PR TITLE
fix(sidecar): skip unreadable entries in the host shadow sync

### DIFF
--- a/crates/execution/assets/runners/wasm-runner.mjs
+++ b/crates/execution/assets/runners/wasm-runner.mjs
@@ -4391,8 +4391,12 @@ if (delegatePathOpen) {
       ),
     );
 
+    // Precreate-and-retry exists for creatable targets the delegate reports
+    // as missing (e.g. `>>` append redirect targets). Only retry on NOENT:
+    // retrying on permission errors would mask the real errno and attempt to
+    // create a file the kernel just denied.
     if (
-      result !== WASI_ERRNO_SUCCESS &&
+      result === WASI_ERRNO_NOENT &&
       mayCreateTarget
     ) {
       try {

--- a/crates/sidecar/src/execution.rs
+++ b/crates/sidecar/src/execution.rs
@@ -9837,6 +9837,16 @@ fn sync_host_directory_tree_to_kernel_inner(
     let entries = match fs::read_dir(current_host_dir) {
         Ok(entries) => entries,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+            // Host dirs the sidecar user cannot read (e.g. root-owned
+            // /lost+found under a host-root mount) are skipped rather than
+            // failing the whole shadow sync; the guest just won't see them.
+            tracing::warn!(
+                path = %current_host_dir.display(),
+                "skipping unreadable host shadow directory"
+            );
+            return Ok(());
+        }
         Err(error) => {
             return Err(SidecarError::Io(format!(
                 "failed to read host shadow directory {}: {error}",
@@ -9976,6 +9986,19 @@ fn sync_host_directory_tree_to_kernel_inner(
                 // temp files). Skipping matches native semantics; failing
                 // here would poison EVERY subsequent fs op on the VM.
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                // Same tolerance for entries the sidecar user cannot read
+                // (root-owned files under a host-root mount): skip them
+                // rather than poisoning the whole sync.
+                Err(error)
+                    if error.kind() == std::io::ErrorKind::PermissionDenied
+                        || error.raw_os_error() == Some(libc::EPERM) =>
+                {
+                    tracing::warn!(
+                        path = %host_path.display(),
+                        "skipping unreadable host shadow file"
+                    );
+                    continue;
+                }
                 Err(error) => {
                     return Err(SidecarError::Io(format!(
                         "failed to read host shadow file {}: {error}",


### PR DESCRIPTION
Root-owned directories (/lost+found) or EPERM-protected files under a
host mount failed the entire recursive shadow sync, poisoning every
subsequent fs op on the VM. Skip them with a warning — the guest simply
does not see entries the sidecar user cannot read.