### PR TITLE
test(sidecar): accept either denial-surface code in the fs audit test

### DIFF
--- a/crates/sidecar/tests/security_audit.rs
+++ b/crates/sidecar/tests/security_audit.rs
@@ -181,7 +181,14 @@ fn filesystem_permission_denials_emit_security_audit_events() {
         .expect("dispatch denied read");
     match read.response.payload {
         ResponsePayload::RejectedResponse(rejected) => {
-            assert_eq!(rejected.code, "invalid_state");
+            // Which layer surfaces the denial (a POSIX-coded kernel error ->
+            // "kernel_error", any other message -> "invalid_state") depends on
+            // the host environment; the audit event below is the contract.
+            assert!(
+                rejected.code == "invalid_state" || rejected.code == "kernel_error",
+                "unexpected rejection code: {}",
+                rejected.code
+            );
             assert!(rejected.message.contains("EACCES"));
         }
         other => panic!("unexpected read response: {other:?}"),


### PR DESCRIPTION
Whether the denied read surfaces as a POSIX-coded kernel error
(kernel_error) or a wrapped message (invalid_state) depends on the
host environment; the security.permission.denied audit event is the
contract this test guards.