### PR TITLE
feat(registry): vim and vix packages with runtime provides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ registry/native/c/.cache/
 registry/native/c/sysroot/
 registry/software/*/bin/
 registry/software/*/wasm/
+registry/software/vim/share/
 registry/software/*/agent-os-package.meta.json
 registry/.last-publish-hash
 registry/software/*/.last-publish-hash

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1023,6 +1023,36 @@ importers:
         specifier: ^5.9.2
         version: 5.9.3
 
+  registry/software/vim:
+    devDependencies:
+      '@agentos-software/manifest':
+        specifier: workspace:*
+        version: link:../../../packages/manifest
+      '@rivet-dev/agentos-toolchain':
+        specifier: workspace:*
+        version: link:../../../packages/agentos-toolchain
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.15
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+
+  registry/software/vix:
+    devDependencies:
+      '@agentos-software/manifest':
+        specifier: workspace:*
+        version: link:../../../packages/manifest
+      '@rivet-dev/agentos-toolchain':
+        specifier: workspace:*
+        version: link:../../../packages/agentos-toolchain
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.15
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+
   registry/software/wget:
     devDependencies:
       '@agentos-software/manifest':

--- a/registry/software/vim/agentos-package.json
+++ b/registry/software/vim/agentos-package.json
@@ -1,0 +1,18 @@
+{
+	"name": "vim",
+	"commands": [
+		"vim"
+	],
+	"provides": {
+		"env": {
+			"VIM": "/usr/local/share/vim",
+			"VIMRUNTIME": "/usr/local/share/vim/vim92"
+		},
+		"files": [
+			{
+				"source": "share/vim/vim92",
+				"target": "/usr/local/share/vim/vim92"
+			}
+		]
+	}
+}

--- a/registry/software/vim/package.json
+++ b/registry/software/vim/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "@agentos-software/vim",
+	"version": "0.1.0",
+	"type": "module",
+	"license": "Apache-2.0",
+	"description": "vim for secure-exec VMs (wasm build + bundled runtime via provides)",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "agentos-toolchain stage --commands-dir ../../native/target/wasm32-wasip1/release/commands --if-missing skip && node ./scripts/stage-runtime.mjs && tsc && agentos-toolchain build",
+		"check-types": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@agentos-software/manifest": "workspace:*",
+		"@rivet-dev/agentos-toolchain": "workspace:*",
+		"@types/node": "^22.10.2",
+		"typescript": "^5.9.2"
+	}
+}

--- a/registry/software/vim/scripts/stage-runtime.mjs
+++ b/registry/software/vim/scripts/stage-runtime.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// Stage vim's runtime tree into the gitignored `share/vim/vim92/` so
+// `agentos-toolchain build` ships it in dist/package and the manifest's
+// `provides.files` can overlay it read-only at /usr/local/share/vim/vim92
+// (VIMRUNTIME points straight at it, bypassing vim's version-dir search, so a
+// 9.0/9.1 host runtime sources cleanly under the 9.2 binary).
+//
+// Sources, in order: $VIM_RUNTIME_SRC, then the host vim runtimes. Bulky,
+// non-load-bearing subtrees (docs, tutor, spell dictionaries, translations)
+// are trimmed — the runtime here exists so `vim` starts clean (defaults.vim,
+// syntax, ftplugin, indent, autoload, colors), not to ship a manual.
+// Missing source → skip with a notice (the package stays a valid placeholder,
+// same contract as a missing command binary).
+import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const target = join(packageRoot, "share", "vim", "vim92");
+
+const TRIM = new Set(["doc", "tutor", "spell", "lang", "print", "keymap"]);
+
+const candidates = [
+	process.env.VIM_RUNTIME_SRC,
+	"/usr/share/vim/vim92",
+	"/usr/share/vim/vim91",
+	"/usr/share/vim/vim90",
+	"/usr/local/share/vim/vim92",
+].filter(Boolean);
+
+const source = candidates.find((dir) => existsSync(join(dir, "defaults.vim")));
+if (!source) {
+	console.log(
+		"stage-runtime: no vim runtime found (set VIM_RUNTIME_SRC or install vim) — skipping; package ships without the runtime tree",
+	);
+	process.exit(0);
+}
+
+rmSync(join(packageRoot, "share"), { recursive: true, force: true });
+mkdirSync(target, { recursive: true });
+cpSync(source, target, {
+	recursive: true,
+	filter: (src) => {
+		const rel = src.slice(source.length).split("/").filter(Boolean);
+		return rel.length === 0 || !TRIM.has(rel[0]);
+	},
+});
+console.log(`stage-runtime: ${source} -> share/vim/vim92 (trimmed: ${[...TRIM].join(", ")})`);

--- a/registry/software/vim/src/index.ts
+++ b/registry/software/vim/src/index.ts
@@ -1,0 +1,5 @@
+import type { SoftwarePackageRef } from "@agentos-software/manifest";
+
+const packageDir = new URL("./package/", import.meta.url).pathname;
+
+export default { packageDir } satisfies SoftwarePackageRef;

--- a/registry/software/vim/tsconfig.json
+++ b/registry/software/vim/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/registry/software/vix/agentos-package.json
+++ b/registry/software/vix/agentos-package.json
@@ -1,0 +1,6 @@
+{
+	"name": "vix",
+	"commands": [
+		"vix"
+	]
+}

--- a/registry/software/vix/package.json
+++ b/registry/software/vix/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "@agentos-software/vix",
+	"version": "0.1.0",
+	"type": "module",
+	"license": "Apache-2.0",
+	"description": "vix editor for secure-exec VMs (wasm build)",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "agentos-toolchain stage --commands-dir ../../native/target/wasm32-wasip1/release/commands --if-missing skip && tsc && agentos-toolchain build",
+		"check-types": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@agentos-software/manifest": "workspace:*",
+		"@rivet-dev/agentos-toolchain": "workspace:*",
+		"@types/node": "^22.10.2",
+		"typescript": "^5.9.2"
+	}
+}

--- a/registry/software/vix/src/index.ts
+++ b/registry/software/vix/src/index.ts
@@ -1,0 +1,5 @@
+import type { SoftwarePackageRef } from "@agentos-software/manifest";
+
+const packageDir = new URL("./package/", import.meta.url).pathname;
+
+export default { packageDir } satisfies SoftwarePackageRef;

--- a/registry/software/vix/tsconfig.json
+++ b/registry/software/vix/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
- Add `registry/software/vim`: standard registry package staging the vim wasm binary from the native commands drop zone (same contract as codex — no source pipeline yet), with the vim runtime tree staged into `share/vim/vim92` by `scripts/stage-runtime.mjs` (host runtime or `VIM_RUNTIME_SRC`, trimmed of doc/tutor/spell/lang) and exposed via manifest `provides` (`VIMRUNTIME`/`VIM` env + read-only runtime overlay)
- Add `registry/software/vix` (same drop-zone contract, no provides)
- Missing binaries degrade to valid empty placeholders; gitignore the staged `share/` tree