### PR TITLE
feat(registry): uniform per-binary build entry point (make cmd/<name>)

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,13 +23,18 @@ docs-verify:
 # --- Registry (@agentos-software/* packages) -------------------------------
 # Full flow + package format: registry/README.md.
 
-# Compile ALL native wasm command binaries (slow; needed once per checkout)
+# Compile ALL native wasm command binaries — Rust + codex + opted-in C
+# (slow; needed once per checkout)
 registry-native:
-	make -C registry/native wasm
+	make -C registry/native commands
 
-# Recompile ONE command binary (cargo package cmd-<CMD>), e.g. `just registry-native-cmd sh`
+# Build everything end to end: all native binaries, then all registry packages
+registry-all: registry-native (registry-build "")
+
+# Build/recompile ONE command binary, whatever its toolchain (Rust crate, C
+# program, codex fork, or external drop zone), e.g. `just registry-native-cmd sh`
 registry-native-cmd CMD:
-	make -C registry/native wasm-cmd CMD="{{ CMD }}"
+	make -C registry/native "cmd/{{ CMD }}"
 
 # Build one registry package (stage bin/ + tsc + assemble dist/package), or all when PKG is empty.
 # Bootstrap note: on a fresh checkout the `agentos-toolchain` bin symlinks are

--- a/registry/README.md
+++ b/registry/README.md
@@ -57,12 +57,22 @@ All recipes run from the repo root (see `justfile`):
 
 ```bash
 just registry-native            # compile ALL native wasm command binaries (slow, once per checkout)
-just registry-native-cmd sh     # recompile ONE command (cargo package cmd-sh)
+just registry-native-cmd <name> # build ONE command binary, whatever its toolchain
 just registry-build             # stage + assemble every registry package
 just registry-build coreutils   # ... or just one
 just registry-status            # per-package state; --remote adds npm dist-tags
 just registry-test              # registry integration tests (registry/tests)
 ```
+
+`registry-native-cmd` (= `make -C registry/native cmd/<name>`) is the uniform
+per-binary entry point; it dispatches to whichever toolchain owns the command:
+
+| kind | commands | what it runs |
+|---|---|---|
+| Rust | any `crates/commands/<name>` (sh, ls, rg, git, …) | `cargo build -p cmd-<name>` (build-std) + `wasm-opt` |
+| C | `zip unzip envsubst sqlite3 curl wget duckdb` | `make -C c sysroot build/<src>` + per-command install |
+| codex | `codex`, `codex-exec` | the codex fork build (needs the fork checkout) |
+| external | `vim`, `vix` | validates the hand-built binary is in the drop zone; errors with instructions otherwise |
 
 The native build (`registry/native`) compiles each `crates/commands/<name>`
 (cargo package `cmd-<name>`) to `wasm32-wasip1` with a patched std
@@ -80,8 +90,12 @@ Exceptions:
 - `software/codex/wasm/` is the install target of the codex fork's build
   (`make -C registry/native codex`); `software/codex-cli` stages from it.
 - C-built commands (sqlite3, zip, unzip, wget, duckdb) need the patched
-  sysroot (`make -C registry/native/c`); without it those packages stay
-  empty placeholders.
+  sysroot; `just registry-native-cmd <name>` builds it on demand. Without it
+  those packages stay empty placeholders.
+- `vim`/`vix` have no source pipeline yet: drop the hand-built wasm binaries
+  into `registry/native/target/wasm32-wasip1/release/commands/` and
+  `just registry-build vim` does the rest (vim's runtime tree is staged by its
+  package `scripts/stage-runtime.mjs` and applied via manifest `provides`).
 
 ## Publishing
 

--- a/registry/native/Makefile
+++ b/registry/native/Makefile
@@ -37,9 +37,17 @@ STUB_COMMANDS := \
 	pinky who users uptime \
 	stty sync tty
 
-.PHONY: all wasm wasm-opt-check host test clean patch-std patch-check vendor patch-vendor vendor-patch-check size-report install c-wasm codex
+.PHONY: all commands wasm wasm-opt-check host test clean patch-std patch-check vendor patch-vendor vendor-patch-check size-report install c-wasm codex
 
 all: wasm host
+
+# Build EVERYTHING that lands in COMMANDS_DIR: all Rust commands (+ codex when
+# the fork is present), then the opted-in C commands (curl, wget, sqlite3, zip,
+# unzip, envsubst, duckdb). C runs second so a C port wins over a Rust crate of
+# the same name (e.g. curl). Binaries with no source pipeline here (vim, vix)
+# must still be dropped into COMMANDS_DIR by hand.
+commands: wasm
+	$(MAKE) -C c programs install
 
 # Build the real wasm32-wasip1 `codex-exec` agent engine from the codex fork
 # (branch wasi-port-codex-core). The fork ships a committed, idempotent, self-prepping build script
@@ -187,6 +195,40 @@ wasm: vendor patch-vendor patch-std wasm-opt-check
 	echo "=== Build complete ==="
 	@# Also produce the real codex-exec engine from the fork when present (skips with a notice if not).
 	@$(MAKE) --no-print-directory codex
+
+# ---------------------------------------------------------------------------
+# Uniform per-binary entry point: `make cmd/<name>` builds ONE command binary
+# into $(COMMANDS_DIR), dispatching to the toolchain that owns it:
+#   Rust      crates/commands/<name>  (cargo package cmd-<name>, via wasm-cmd)
+#   C         the C opt-in set below  (registry/native/c, patched sysroot)
+#   codex     the codex fork build    (codex, codex-exec)
+#   external  hand-built drop-zone binaries with no source pipeline yet
+# `just registry-native-cmd <name>` calls this. `make wasm` still builds the
+# whole Rust set; `make -C c programs install` still builds the whole C set.
+C_COMMANDS := zip unzip envsubst sqlite3 curl wget duckdb
+EXTERNAL_COMMANDS := vim vix
+
+.PHONY: cmd/%
+cmd/%:
+	@name="$*"; \
+	if [ -d "crates/commands/$$name" ]; then \
+		$(MAKE) wasm-cmd CMD=$$name; \
+	elif echo " $(C_COMMANDS) " | grep -q " $$name "; then \
+		src=$$name; [ "$$name" = "sqlite3" ] && src=sqlite3_cli; \
+		$(MAKE) -C c sysroot "build/$$src" && $(MAKE) -C c install COMMANDS="$$name"; \
+	elif [ "$$name" = "codex" ] || [ "$$name" = "codex-exec" ]; then \
+		$(MAKE) codex-required; \
+	elif echo " $(EXTERNAL_COMMANDS) " | grep -q " $$name "; then \
+		if [ -f "$(COMMANDS_DIR)/$$name" ]; then \
+			echo "cmd/$$name: external hand-built binary present at $(COMMANDS_DIR)/$$name"; \
+		else \
+			echo "ERROR: '$$name' has no source pipeline yet — place the hand-built wasm binary at $(COMMANDS_DIR)/$$name (see registry/README.md)"; \
+			exit 1; \
+		fi; \
+	else \
+		echo "ERROR: unknown command '$$name' (no crates/commands/$$name; not in C_COMMANDS, codex, or EXTERNAL_COMMANDS)"; \
+		exit 1; \
+	fi
 
 # Build ONE command binary (cargo package cmd-$(CMD) -> $(COMMANDS_DIR)/$(CMD)).
 # Usage: make wasm-cmd CMD=sh


### PR DESCRIPTION
- Add `make -C registry/native cmd/<name>` — one entry point that builds a single command binary into the commands dir, dispatching to the toolchain that owns it: Rust crates (`cargo build -p cmd-<name>` + wasm-opt), the C opt-in set (patched sysroot + per-command install), the codex fork build, or the external drop-zone set (vim/vix — validates presence, errors with instructions)
- `just registry-native-cmd <name>` now uses the dispatcher instead of the Rust-only path
- Document the per-binary matrix and the vim/vix drop-zone flow in `registry/README.md`