### PR TITLE
chore(registry): delete dead native Makefile targets, make patch-vendor failure-idempotent

### DIFF
--- a/registry/native/Makefile
+++ b/registry/native/Makefile
@@ -39,7 +39,7 @@ STUB_COMMANDS := \
 
 .PHONY: all commands wasm wasm-opt-check host test clean patch-std patch-check vendor patch-vendor vendor-patch-check size-report install c-wasm codex
 
-all: wasm host
+all: wasm
 
 # Build EVERYTHING that lands in COMMANDS_DIR: all Rust commands (+ codex when
 # the fork is present), then the opted-in C commands (curl, wget, sqlite3, zip,
@@ -295,37 +295,12 @@ size-report:
 	echo "Unique crates: $$TOTAL"
 
 # Install standalone binaries to a custom directory
-install:
-	@if [ -z "$(DESTDIR)" ]; then \
-		echo "Usage: make install DESTDIR=/path/to/commands"; \
-		exit 1; \
-	fi
-	@if [ ! -d "$(COMMANDS_DIR)" ]; then \
-		echo "Error: $(COMMANDS_DIR) not found. Run 'make wasm' first."; \
-		exit 1; \
-	fi
-	@mkdir -p $(DESTDIR)
-	@cp -a $(COMMANDS_DIR)/* $(DESTDIR)/
-	@echo "Installed to $(DESTDIR)"
 
 # Build C programs to WASM (downloads wasi-sdk if needed)
-c-wasm:
-	$(MAKE) -C c programs
 
-host:
-	@if [ -f host/package.json ]; then \
-		echo "Building JS host runtime..."; \
-		cd host && npm run build; \
-	else \
-		echo "Error: host/package.json not found"; \
-		exit 1; \
-	fi
 
 test:
 	cargo test --workspace
-	@if [ -f host/package.json ]; then \
-		cd host && npm test; \
-	fi
 
 clean:
 	cargo clean

--- a/registry/native/scripts/patch-vendor.sh
+++ b/registry/native/scripts/patch-vendor.sh
@@ -117,8 +117,16 @@ for CRATE_DIR in $CRATE_DIRS; do
                     patch -p1 -d "$VENDOR_CRATE" < "$PATCH" > /dev/null 2>&1
                     echo "reapplied"
                 else
-                    echo "FAIL (does not apply)"
-                    FAILED=$((FAILED + 1))
+                    # Mixed state (e.g. an interrupted earlier run left some
+                    # hunks applied): apply the remaining hunks, tolerating
+                    # already-applied ones; fail only on genuine rejects.
+                    OUT=$(patch -p1 -N -r /dev/null -d "$VENDOR_CRATE" < "$PATCH" 2>&1); RC=$?
+                    if [ $RC -le 1 ] && ! echo "$OUT" | grep -q "FAILED"; then
+                        echo "converged (mixed state)"
+                    else
+                        echo "FAIL (does not apply)"
+                        FAILED=$((FAILED + 1))
+                    fi
                 fi
                 ;;
             reverse)


### PR DESCRIPTION
- Delete dead `registry/native/Makefile` targets: `host` (referenced a deleted `host/` dir — `make all` errored), `install DESTDIR=` and `c-wasm` (zero callers); `all` is now just `wasm`, `test` is `cargo test --workspace`
- Make `scripts/patch-vendor.sh` converge after an interrupted run: a mixed-state crate (some hunks applied) now applies the remaining hunks with `patch -N`, failing only on genuine rejects — previously the half-patched vendor/ could never recover without `rm -rf vendor`