### PR TITLE
fix(toolchain): commit a bin shim so pnpm links agentos-toolchain on fresh installs

### DIFF
--- a/packages/agentos-toolchain/bin/agentos-toolchain.mjs
+++ b/packages/agentos-toolchain/bin/agentos-toolchain.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+// Committed bin shim: pnpm links workspace bins at install time and silently
+// skips missing targets, so pointing `bin` at generated dist/cli.js meant a
+// fresh checkout never got the `agentos-toolchain` shim (CI: "agentos-toolchain:
+// not found"). This file always exists; dist/cli.js is built before dependents
+// run via turbo's ^build ordering.
+await import("../dist/cli.js");

--- a/packages/agentos-toolchain/package.json
+++ b/packages/agentos-toolchain/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "bin": {
-    "agentos-toolchain": "./dist/cli.js"
+    "agentos-toolchain": "./bin/agentos-toolchain.mjs"
   },
   "exports": {
     ".": {
@@ -16,6 +16,7 @@
     }
   },
   "files": [
+    "bin",
     "dist",
     "package.json",
     "README.md"


### PR DESCRIPTION
pnpm creates workspace bin links at install time and silently skips
missing targets, so pointing bin at the generated dist/cli.js left
fresh checkouts (CI) without the shim: every @agentos-software/*
build died with 'agentos-toolchain: not found'. The committed shim
always exists and defers to dist/cli.js, which turbo's ^build ordering
builds before dependents.