### PR TITLE
test(registry): track the codex package's delegated export shape

### DIFF
--- a/registry/agent/codex/tests/package.test.mjs
+++ b/registry/agent/codex/tests/package.test.mjs
@@ -13,7 +13,8 @@ test("codex package does not advertise an ACP adapter until the real agent is wi
 	);
 
 	assert.equal(manifest.bin, undefined);
-	assert.equal(codex.name, "codex");
-	assert.equal(typeof codex.dir, "string");
+	// The package now re-exports the @agentos-software/codex-cli toolchain
+	// package descriptor ({ packageDir }) instead of a bespoke shape.
+	assert.equal(typeof codex.packageDir, "string");
 	assert.equal(codex.agent, undefined);
 });


### PR DESCRIPTION
The toolchain overhaul re-exports @agentos-software/codex-cli's package
descriptor ({ packageDir }) instead of the bespoke { name, dir } shape;
keep asserting no bin and no ACP adapter are advertised.