### PR TITLE
test(core): run vitest files sequentially

### DIFF
--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -3,5 +3,11 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	test: {
 		include: ["tests/**/*.test.ts"],
+		// Many test files each spawn a debug sidecar + V8 warm isolates;
+		// running files in parallel thrashes small CI runners until frame
+		// waits exceed their 120s timeout (mount-fs-custom-vfs and
+		// node-runtime-exec-output timed out deterministically on 4-core
+		// GitHub runners, and passed serially). Keep files sequential.
+		fileParallelism: false,
 	},
 });


### PR DESCRIPTION
Many core test files each spawn a debug sidecar plus V8 warm isolates;
parallel files thrash small CI runners until wire-frame waits exceed
the 120s timeout (mount-fs-custom-vfs and node-runtime-exec-output
timed out deterministically on 4-core GitHub runners and passed
serially; verified via an instrumented draft run). Sequential files
keep the suite deterministic; locally it still finishes in ~5s.