### PR TITLE
release: Dynamic Apps 0.12.0

### DIFF
--- a/benchmarks/dynamic-apps/package.json
+++ b/benchmarks/dynamic-apps/package.json
@@ -16,8 +16,8 @@
 	},
 	"dependencies": {
 		"@hono/node-server": "^2.0.11",
-		"@rivet-dev/agentos-core": "0.2.16-rc.3",
-		"@rivet-dev/agentos-toolchain": "0.2.16-rc.3",
+		"@rivet-dev/agentos-core": "0.2.17",
+		"@rivet-dev/agentos-toolchain": "0.2.17",
 		"@rivet-dev/dynamic-apps": "workspace:*",
 		"@rivet-dev/dynamic-apps-core": "workspace:*",
 		"hono": "^4.12.9",

--- a/packages/dynamic-apps-builder/package.json
+++ b/packages/dynamic-apps-builder/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivet-dev/dynamic-apps-builder",
-	"version": "0.12.0-rc.2",
+	"version": "0.12.0",
 	"type": "module",
 	"license": "Apache-2.0",
 	"description": "Platform-owned Dynamic Apps release bundler",
@@ -39,8 +39,8 @@
 		"rivetkit": "2.3.11"
 	},
 	"devDependencies": {
-		"@rivet-dev/agentos-core": "0.2.16-rc.3",
-		"@rivet-dev/agentos-toolchain": "0.2.16-rc.3",
+		"@rivet-dev/agentos-core": "0.2.17",
+		"@rivet-dev/agentos-toolchain": "0.2.17",
 		"@types/node": "^22.19.15",
 		"typescript": "^5.7.3",
 		"vitest": "^2.1.9"

--- a/packages/dynamic-apps-core/package.json
+++ b/packages/dynamic-apps-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivet-dev/dynamic-apps-core",
-	"version": "0.12.0-rc.2",
+	"version": "0.12.0",
 	"description": "Build and serve isolated dynamic applications with user-defined release storage.",
 	"license": "Apache-2.0",
 	"repository": {
@@ -32,11 +32,11 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@agentos-software/sh": "0.2.16-rc.3",
+		"@agentos-software/sh": "0.2.17",
 		"@agentos-software/tar": "0.3.5",
-		"@rivet-dev/agentos-core": "0.2.16-rc.3",
-		"@rivet-dev/agentos-toolchain": "0.2.16-rc.3",
-		"@rivet-dev/dynamic-apps-builder": "workspace:0.12.0-rc.2",
+		"@rivet-dev/agentos-core": "0.2.17",
+		"@rivet-dev/agentos-toolchain": "0.2.17",
+		"@rivet-dev/dynamic-apps-builder": "workspace:0.12.0",
 		"hono": "^4.7.0"
 	},
 	"devDependencies": {

--- a/packages/dynamic-apps/package.json
+++ b/packages/dynamic-apps/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivet-dev/dynamic-apps",
-	"version": "0.12.0-rc.2",
+	"version": "0.12.0",
 	"description": "Build and run user-generated HTTP applications in agentOS with durable Rivet state.",
 	"license": "Apache-2.0",
 	"repository": {
@@ -31,13 +31,13 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@rivet-dev/dynamic-apps-core": "workspace:0.12.0-rc.2",
+		"@rivet-dev/agentos-core": "0.2.17",
+		"@rivet-dev/dynamic-apps-core": "workspace:0.12.0",
 		"hono": "^4.7.0",
 		"rivetkit": "2.3.11"
 	},
 	"devDependencies": {
-		"@rivet-dev/agentos-core": "0.2.16-rc.3",
-		"@rivet-dev/agentos-toolchain": "0.2.16-rc.3",
+		"@rivet-dev/agentos-toolchain": "0.2.17",
 		"@types/node": "^22.19.15",
 		"tsup": "^8.4.0",
 		"typescript": "^5.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@rivet-dev/agentos-core': 0.2.16-rc.3
+  '@rivet-dev/agentos-core': 0.2.17
   '@rivetkit/engine-cli': 2.3.11
   '@rivetkit/react': 2.3.11
   '@rivetkit/rivetkit-wasm': 2.3.11
@@ -34,11 +34,11 @@ importers:
         specifier: ^2.0.11
         version: 2.1.1(hono@4.13.3)
       '@rivet-dev/agentos-core':
-        specifier: 0.2.16-rc.3
-        version: 0.2.16-rc.3(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)
+        specifier: 0.2.17
+        version: 0.2.17(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)
       '@rivet-dev/agentos-toolchain':
-        specifier: 0.2.16-rc.3
-        version: 0.2.16-rc.3
+        specifier: 0.2.17
+        version: 0.2.17
       '@rivet-dev/dynamic-apps':
         specifier: workspace:*
         version: link:../../packages/dynamic-apps
@@ -239,8 +239,11 @@ importers:
 
   packages/dynamic-apps:
     dependencies:
+      '@rivet-dev/agentos-core':
+        specifier: 0.2.17
+        version: 0.2.17(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)
       '@rivet-dev/dynamic-apps-core':
-        specifier: workspace:0.12.0-rc.2
+        specifier: workspace:0.12.0
         version: link:../dynamic-apps-core
       hono:
         specifier: ^4.7.0
@@ -249,12 +252,9 @@ importers:
         specifier: 2.3.11
         version: 2.3.11(better-sqlite3@12.11.1)(ws@8.21.3)
     devDependencies:
-      '@rivet-dev/agentos-core':
-        specifier: 0.2.16-rc.3
-        version: 0.2.16-rc.3(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)
       '@rivet-dev/agentos-toolchain':
-        specifier: 0.2.16-rc.3
-        version: 0.2.16-rc.3
+        specifier: 0.2.17
+        version: 0.2.17
       '@types/node':
         specifier: ^22.19.15
         version: 22.20.1
@@ -281,11 +281,11 @@ importers:
         version: 2.3.11(better-sqlite3@12.11.1)(ws@8.21.3)
     devDependencies:
       '@rivet-dev/agentos-core':
-        specifier: 0.2.16-rc.3
-        version: 0.2.16-rc.3(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)
+        specifier: 0.2.17
+        version: 0.2.17(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)
       '@rivet-dev/agentos-toolchain':
-        specifier: 0.2.16-rc.3
-        version: 0.2.16-rc.3
+        specifier: 0.2.17
+        version: 0.2.17
       '@types/node':
         specifier: ^22.19.15
         version: 22.20.1
@@ -299,19 +299,19 @@ importers:
   packages/dynamic-apps-core:
     dependencies:
       '@agentos-software/sh':
-        specifier: 0.2.16-rc.3
-        version: 0.2.16-rc.3
+        specifier: 0.2.17
+        version: 0.2.17
       '@agentos-software/tar':
         specifier: 0.3.5
         version: 0.3.5
       '@rivet-dev/agentos-core':
-        specifier: 0.2.16-rc.3
-        version: 0.2.16-rc.3(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)
+        specifier: 0.2.17
+        version: 0.2.17(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)
       '@rivet-dev/agentos-toolchain':
-        specifier: 0.2.16-rc.3
-        version: 0.2.16-rc.3
+        specifier: 0.2.17
+        version: 0.2.17
       '@rivet-dev/dynamic-apps-builder':
-        specifier: workspace:0.12.0-rc.2
+        specifier: workspace:0.12.0
         version: link:../dynamic-apps-builder
       hono:
         specifier: ^4.7.0
@@ -343,8 +343,8 @@ importers:
         version: 2.3.11(better-sqlite3@12.11.1)(ws@8.21.3)
     devDependencies:
       '@rivet-dev/agentos-toolchain':
-        specifier: 0.2.16-rc.3
-        version: 0.2.16-rc.3
+        specifier: 0.2.17
+        version: 0.2.17
       '@rivetkit/engine-cli':
         specifier: 2.3.11
         version: 2.3.11
@@ -375,8 +375,8 @@ packages:
   '@agentos-software/codex-cli@0.3.4':
     resolution: {integrity: sha512-SAw3EOTa90dJLgEVVoE7JJIxHwticzdD9cEM9v00gpxhxC9vdLkeBva6rgWIUB9+qD1JEYBvUCyNkIpD2kT5YQ==}
 
-  '@agentos-software/common@0.2.16-rc.3':
-    resolution: {integrity: sha512-2+8ui1qqMKj8kDvnNz27334tC84He0YViF+3g0O+/dMiF+sPvayCjqpfiqX9BqvlT2+5mWzFWSMzVV4Gg9aBLQ==}
+  '@agentos-software/common@0.2.17':
+    resolution: {integrity: sha512-ddEhmHIfrSAXucogbLvbDTl9IofW4dpwdrW3iL5d/vygtiE08EU6Vcp2qv8MGtdhYXiSfX0cL/1ChjOJzGMqjQ==}
 
   '@agentos-software/coreutils@0.3.4':
     resolution: {integrity: sha512-tGd0gQjUjHnm+5KgOBwidwUtlkKnl9biQuD7X2sZl15VOhYqUJpnyLF33h/nF3r9WtOTclSiLj/dc2xCxmAXnw==}
@@ -396,8 +396,8 @@ packages:
   '@agentos-software/gzip@0.3.4':
     resolution: {integrity: sha512-l7Y/Vwiwsqgna68yYwdNCnUBPGBg5zdmtjEFeG3hnDDFLe/02h17q0gUIqJmDBIAy1q9GoizqcFi7zXO2xygKg==}
 
-  '@agentos-software/manifest@0.2.16-rc.3':
-    resolution: {integrity: sha512-gJwJ85o3K7TFDK6RQjw+cjMUauxHOMGypoR/JDiytP1nHbp/thHVaXc95U7gSEt94sy2nh6KUK+W0Wict/sspQ==}
+  '@agentos-software/manifest@0.2.17':
+    resolution: {integrity: sha512-BIXzzjtJwC/FWqLYgxbRlyFQL6o42QzK0wPDLimU2yoMwbU/NjPy4JhzsXL2rNVNIJslz0HOYcq6haNNCsFw7g==}
 
   '@agentos-software/opencode@0.2.7':
     resolution: {integrity: sha512-lZspCiMgM0+kPAA08CEvyNy8lfBx463wObKpAwbYyaVvc0KfGvbAPS6VmnuZQWmaBmJJuRMtSo14nmb8XCD16g==}
@@ -410,8 +410,8 @@ packages:
   '@agentos-software/sed@0.3.4':
     resolution: {integrity: sha512-J10nZnZmme2SvXK5WMK2unQlOVncMQVUCS20GZB579a2gNoayLJYHGvfJ9a4+42wOHgDKL1u74byWlydCkEyOQ==}
 
-  '@agentos-software/sh@0.2.16-rc.3':
-    resolution: {integrity: sha512-ho2diVXYd/L9YaXVievU0/8ecD3r/kQZ5EiM5SLoIvwi7OWdZpAc/zi2AdGHV8MRbM8mSiSRM3dPFhRDGb/krA==}
+  '@agentos-software/sh@0.2.17':
+    resolution: {integrity: sha512-oc/8OPhv6Hxx2HsmfEXIIgbrMP0pjg+ybnNdaL2UD7HuCO+OvVmH+Q2qRfCylOk3334HmN/cTHK98OX8n3JVAQ==}
 
   '@agentos-software/tar@0.3.5':
     resolution: {integrity: sha512-hSf6PY4q1luIomFSDgVHxVDDIPdAVZxdgwrQFEYH4aIE6TXX9qatVmzR36uYLWpnFGAZTR6srREGoTnmOGV4Lg==}
@@ -1386,64 +1386,70 @@ packages:
       pyodide:
         optional: true
 
-  '@rivet-dev/agentos-core@0.2.16-rc.3':
-    resolution: {integrity: sha512-EUFOUBa3YWhiZBTGhb4Vpv+tG6978KW2I+2JFWqB3fjSbG/82MYhbjxfxoCc3idQEGfCKtm9IOQSzpdb6Q6ufw==}
+  '@rivet-dev/agentos-core@0.2.17':
+    resolution: {integrity: sha512-0PoLDk9Op0pC6CAs2zQchKa7bhwN4zp8XXGxbItHN19DFV55uJEPqqNPyeUSgywvoqW6iFbaG54htVqLoCKWaw==}
 
-  '@rivet-dev/agentos-runtime-core@0.2.16-rc.3':
-    resolution: {integrity: sha512-4n4w5dCmOTcy4UhIYEy2xCZFXlBtYFeh2CA5B0WjB1QGs2cFcIB3Jpg7FAz6wBO5GX968/tsUGJ1Ut5J8L3fKw==}
+  '@rivet-dev/agentos-runtime-core@0.2.17':
+    resolution: {integrity: sha512-S9Ztzug+kxaVoXyIzq2hMOffy+Z6AWNpUioc1ZpL1ijbH/9R7EBzlGXYl5KO6jm8c1En23L25a+sOCwijdxvNA==}
 
-  '@rivet-dev/agentos-runtime-sidecar-darwin-arm64@0.2.16-rc.3':
-    resolution: {integrity: sha512-fy0IpWgMwdJujwqNAY6Y+AhYw4b/+4v+0CYxeeUF1peCrIEPCPlaF2V6Xpc5ljcW8mpxiVumbvU8UxbkwsJolw==}
+  '@rivet-dev/agentos-runtime-sidecar-darwin-arm64@0.2.17':
+    resolution: {integrity: sha512-qgnuuB73l8zHzX6ljqU5K707Xb2lcXZZY0/pH5dL+WQMnXvnYwFTia7cQGbp5B5iy4J9XBee0SwwSVM5dCiZ4w==}
     engines: {node: '>=20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@rivet-dev/agentos-runtime-sidecar-darwin-x64@0.2.16-rc.3':
-    resolution: {integrity: sha512-NiOyfMBaIqXqrg7rhdcp9wK+iWCEW9oQob0R/r4iF9Kit2uyXP2GZBFXQ4g+T6K7KTr9wEG33+fF1mLNA9a7rA==}
+  '@rivet-dev/agentos-runtime-sidecar-darwin-x64@0.2.17':
+    resolution: {integrity: sha512-a9rJ4CIbw5Ej2974GdGv9J6zt+V+fbilU+9GSgT8kikkdUtn4Y8CKdvZsxQaNNMal7Thpsq6zsUgYHvp6t0mRA==}
     engines: {node: '>=20'}
     cpu: [x64]
     os: [darwin]
 
-  '@rivet-dev/agentos-runtime-sidecar-linux-arm64-gnu@0.2.16-rc.3':
-    resolution: {integrity: sha512-hTIkuc12FmjetKDAkuYrr3NGsjuLMeA1docsD0jxUxrfvT3APX1rLqUORfqZpnykqzEnbUtQJMu8zP3QTDvHoA==}
+  '@rivet-dev/agentos-runtime-sidecar-linux-arm64-gnu@0.2.17':
+    resolution: {integrity: sha512-EuinK4HkwGjzazYmBdkJDN43OCjOW6RVNBmeyCv1Vb//yS09H8GPdX0GN3PmZyNIH1yssELNAztzMzbfFE2Hxw==}
     engines: {node: '>=20'}
     cpu: [arm64]
     os: [linux]
 
-  '@rivet-dev/agentos-runtime-sidecar@0.2.16-rc.3':
-    resolution: {integrity: sha512-0IQs0gOY8Y48im3lCTFI06UJ0RZDlFeFfe/MTiTQg1O7WWqRXMZe/oJdX4AD6vLJQLPuoI8rGSgOAMJYWngwMg==}
-    engines: {node: '>=20'}
-
-  '@rivet-dev/agentos-sidecar-darwin-arm64@0.2.16-rc.3':
-    resolution: {integrity: sha512-wlnQP+Pu+DfEtb/cHda4mYyR/dKqX600kP0JILjh3rYKmhH3wWr/e/+bkLNMpTH2MrjcLNjxSUNW0Wwt1MGddg==}
-    engines: {node: '>=20'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rivet-dev/agentos-sidecar-darwin-x64@0.2.16-rc.3':
-    resolution: {integrity: sha512-UV9Nmu6ziHXQEuXMioeCZyc1emzVETwTZwF5J64O4vp/YbmGfu6TPKnEnCRUs3XyqOoh5cPRJvo0WRSzg1GtgA==}
-    engines: {node: '>=20'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rivet-dev/agentos-sidecar-linux-arm64-gnu@0.2.16-rc.3':
-    resolution: {integrity: sha512-D6fBNJz+i6cnm/AAx9pUo5m+uIKjkGP5Cl/ltU86VKsva49zXDH8f+GbnYr5OCQb+yAdoRgRHAnlrdsC1f6IVw==}
-    engines: {node: '>=20'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rivet-dev/agentos-sidecar-linux-x64-gnu@0.2.16-rc.3':
-    resolution: {integrity: sha512-82bvLR2mj7AAaCexfkyWkUmnW3jfplfM1NgFZV3PMXs5tlwuK1SrkX+Js70OZKmc45vwMUZJha3cgxOxelBTgQ==}
+  '@rivet-dev/agentos-runtime-sidecar-linux-x64-gnu@0.2.17':
+    resolution: {integrity: sha512-m1w53QAyHo32Pkyux9osnCJ1ePq2Ow3laNfLJJQ5rLG7xNYDKlzhAHbBTFJFyEa4a96ctFKEl+C7t1RKyo/l4w==}
     engines: {node: '>=20'}
     cpu: [x64]
     os: [linux]
 
-  '@rivet-dev/agentos-sidecar@0.2.16-rc.3':
-    resolution: {integrity: sha512-yJshB14bF938+MyB2dsa8wXxr+xKc+9t8CDQsnMZUi956RMjEJsPsqEsf62sN93o/KLBj9itgxNkafZQygQ2qA==}
+  '@rivet-dev/agentos-runtime-sidecar@0.2.17':
+    resolution: {integrity: sha512-S+JoiWIf/v3zceZgFArNFgmojlsyrqNKF4yysGILM+/0xOb+uKnRVq5I1U1vD970LE3yUiYJiyzck2NFzoagvA==}
     engines: {node: '>=20'}
 
-  '@rivet-dev/agentos-toolchain@0.2.16-rc.3':
-    resolution: {integrity: sha512-ZtL3NhK/4QGmkOoudWl21+Kzn2wFlyV6VkS2NqGBzbtGnJweWoAhFhD9eq3dZ0HvqL0WBn2r7Dy/2PX7Ki0Q5w==}
+  '@rivet-dev/agentos-sidecar-darwin-arm64@0.2.17':
+    resolution: {integrity: sha512-PPuOU5g+pqln68OZ85YJ5RZRMRD/PFeNOPBVXkVQuZFEIec145BgAHB8t86Oxjb5aKbRRD6csbni8W453aYMbQ==}
+    engines: {node: '>=20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rivet-dev/agentos-sidecar-darwin-x64@0.2.17':
+    resolution: {integrity: sha512-JQsxFveqhmTToIRPfA5zi5OJErCqTAXZq3IcTm7fXqADkLypSkQuHYEb09NxBTn2+e+82HhYDeo5kkD5WL1+sw==}
+    engines: {node: '>=20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rivet-dev/agentos-sidecar-linux-arm64-gnu@0.2.17':
+    resolution: {integrity: sha512-cxxVtnfQ5GkohtCKb7qLCLEYTX2KXxeI2lTvCw/1EXod/JozZJnYDOqIdRCzwMBf1xERO0fGH31dQ289HGWx4Q==}
+    engines: {node: '>=20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rivet-dev/agentos-sidecar-linux-x64-gnu@0.2.17':
+    resolution: {integrity: sha512-JDQVBVTR1m7N8Gxpy9FHLKDr1swe1I8MIPJpReH/U6OIvkCEkwnn0rZILnnHi8x8rcVzKdMDr+VmOL4jFyigUA==}
+    engines: {node: '>=20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@rivet-dev/agentos-sidecar@0.2.17':
+    resolution: {integrity: sha512-QTfjMKzTo0ouBGCJMs4NpJZVJX1DRSAts7V5EX1NpoTgoWsGGFK69IVYeMzToQ4WPmfHTnLDhTIG/13yy17z2w==}
+    engines: {node: '>=20'}
+
+  '@rivet-dev/agentos-toolchain@0.2.17':
+    resolution: {integrity: sha512-socJFrHv1uEnCb3P1umRbEjTyZfQC6eIR3H5jpBvwAT8rNnZiK/DSBwxTZKENGbjF6Xaodd5NMCVpYSbiWSElw==}
     hasBin: true
 
   '@rivetkit/bare-ts@0.6.2':
@@ -3706,7 +3712,7 @@ snapshots:
 
   '@agentos-software/codex-cli@0.3.4': {}
 
-  '@agentos-software/common@0.2.16-rc.3':
+  '@agentos-software/common@0.2.17':
     dependencies:
       '@agentos-software/coreutils': 0.3.4
       '@agentos-software/diffutils': 0.3.4
@@ -3729,7 +3735,7 @@ snapshots:
 
   '@agentos-software/gzip@0.3.4': {}
 
-  '@agentos-software/manifest@0.2.16-rc.3': {}
+  '@agentos-software/manifest@0.2.17': {}
 
   '@agentos-software/opencode@0.2.7': {}
 
@@ -3748,7 +3754,7 @@ snapshots:
 
   '@agentos-software/sed@0.3.4': {}
 
-  '@agentos-software/sh@0.2.16-rc.3': {}
+  '@agentos-software/sh@0.2.17': {}
 
   '@agentos-software/tar@0.3.5': {}
 
@@ -4618,18 +4624,18 @@ snapshots:
     dependencies:
       '@secure-exec/core': 0.2.1
 
-  '@rivet-dev/agentos-core@0.2.16-rc.3(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)':
+  '@rivet-dev/agentos-core@0.2.17(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)':
     dependencies:
       '@agentclientprotocol/sdk': 0.16.1(zod@4.4.3)
       '@agentos-software/claude-code': 0.2.7
       '@agentos-software/codex-cli': 0.3.4
-      '@agentos-software/common': 0.2.16-rc.3
-      '@agentos-software/manifest': 0.2.16-rc.3
+      '@agentos-software/common': 0.2.17
+      '@agentos-software/manifest': 0.2.17
       '@agentos-software/opencode': 0.2.7
       '@agentos-software/pi': 0.2.7(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
       '@aws-sdk/client-s3': 3.1113.0
-      '@rivet-dev/agentos-runtime-core': 0.2.16-rc.3
-      '@rivet-dev/agentos-sidecar': 0.2.16-rc.3
+      '@rivet-dev/agentos-runtime-core': 0.2.17
+      '@rivet-dev/agentos-sidecar': 0.2.17
       '@rivetkit/bare-ts': 0.6.2
       '@xterm/headless': 6.0.0
       better-sqlite3: 12.11.1
@@ -4648,47 +4654,51 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@rivet-dev/agentos-runtime-core@0.2.16-rc.3':
+  '@rivet-dev/agentos-runtime-core@0.2.17':
     dependencies:
-      '@rivet-dev/agentos-runtime-sidecar': 0.2.16-rc.3
+      '@rivet-dev/agentos-runtime-sidecar': 0.2.17
       '@rivetkit/bare-ts': 0.6.2
       zod: 4.4.3
 
-  '@rivet-dev/agentos-runtime-sidecar-darwin-arm64@0.2.16-rc.3':
+  '@rivet-dev/agentos-runtime-sidecar-darwin-arm64@0.2.17':
     optional: true
 
-  '@rivet-dev/agentos-runtime-sidecar-darwin-x64@0.2.16-rc.3':
+  '@rivet-dev/agentos-runtime-sidecar-darwin-x64@0.2.17':
     optional: true
 
-  '@rivet-dev/agentos-runtime-sidecar-linux-arm64-gnu@0.2.16-rc.3':
+  '@rivet-dev/agentos-runtime-sidecar-linux-arm64-gnu@0.2.17':
     optional: true
 
-  '@rivet-dev/agentos-runtime-sidecar@0.2.16-rc.3':
+  '@rivet-dev/agentos-runtime-sidecar-linux-x64-gnu@0.2.17':
+    optional: true
+
+  '@rivet-dev/agentos-runtime-sidecar@0.2.17':
     optionalDependencies:
-      '@rivet-dev/agentos-runtime-sidecar-darwin-arm64': 0.2.16-rc.3
-      '@rivet-dev/agentos-runtime-sidecar-darwin-x64': 0.2.16-rc.3
-      '@rivet-dev/agentos-runtime-sidecar-linux-arm64-gnu': 0.2.16-rc.3
+      '@rivet-dev/agentos-runtime-sidecar-darwin-arm64': 0.2.17
+      '@rivet-dev/agentos-runtime-sidecar-darwin-x64': 0.2.17
+      '@rivet-dev/agentos-runtime-sidecar-linux-arm64-gnu': 0.2.17
+      '@rivet-dev/agentos-runtime-sidecar-linux-x64-gnu': 0.2.17
 
-  '@rivet-dev/agentos-sidecar-darwin-arm64@0.2.16-rc.3':
+  '@rivet-dev/agentos-sidecar-darwin-arm64@0.2.17':
     optional: true
 
-  '@rivet-dev/agentos-sidecar-darwin-x64@0.2.16-rc.3':
+  '@rivet-dev/agentos-sidecar-darwin-x64@0.2.17':
     optional: true
 
-  '@rivet-dev/agentos-sidecar-linux-arm64-gnu@0.2.16-rc.3':
+  '@rivet-dev/agentos-sidecar-linux-arm64-gnu@0.2.17':
     optional: true
 
-  '@rivet-dev/agentos-sidecar-linux-x64-gnu@0.2.16-rc.3':
+  '@rivet-dev/agentos-sidecar-linux-x64-gnu@0.2.17':
     optional: true
 
-  '@rivet-dev/agentos-sidecar@0.2.16-rc.3':
+  '@rivet-dev/agentos-sidecar@0.2.17':
     optionalDependencies:
-      '@rivet-dev/agentos-sidecar-darwin-arm64': 0.2.16-rc.3
-      '@rivet-dev/agentos-sidecar-darwin-x64': 0.2.16-rc.3
-      '@rivet-dev/agentos-sidecar-linux-arm64-gnu': 0.2.16-rc.3
-      '@rivet-dev/agentos-sidecar-linux-x64-gnu': 0.2.16-rc.3
+      '@rivet-dev/agentos-sidecar-darwin-arm64': 0.2.17
+      '@rivet-dev/agentos-sidecar-darwin-x64': 0.2.17
+      '@rivet-dev/agentos-sidecar-linux-arm64-gnu': 0.2.17
+      '@rivet-dev/agentos-sidecar-linux-x64-gnu': 0.2.17
 
-  '@rivet-dev/agentos-toolchain@0.2.16-rc.3':
+  '@rivet-dev/agentos-toolchain@0.2.17':
     dependencies:
       '@rivetkit/bare-ts': 0.6.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ onlyBuiltDependencies:
   - esbuild
 
 overrides:
-  '@rivet-dev/agentos-core': 0.2.16-rc.3
+  '@rivet-dev/agentos-core': 0.2.17
   '@rivetkit/engine-cli': 2.3.11
   '@rivetkit/react': 2.3.11
   '@rivetkit/rivetkit-wasm': 2.3.11

--- a/scripts/check-boundaries.mjs
+++ b/scripts/check-boundaries.mjs
@@ -32,8 +32,8 @@ const corePackage = JSON.parse(
 );
 assert(
 	!corePackage.dependencies?.["@rivet-dev/agentos"] &&
-		corePackage.dependencies?.["@rivet-dev/agentos-core"] === "0.2.15" &&
-		corePackage.dependencies?.["@rivet-dev/agentos-toolchain"] === "0.2.15",
+		corePackage.dependencies?.["@rivet-dev/agentos-core"] === "0.2.17" &&
+		corePackage.dependencies?.["@rivet-dev/agentos-toolchain"] === "0.2.17",
 	"core must use exact pinned agentOS Core implementation dependencies",
 );
 assert(
@@ -58,11 +58,14 @@ assert(
 			mainPackage.version,
 	"the adapter must use the exact matching core version",
 );
+assert(
+	mainPackage.dependencies?.["@rivet-dev/agentos-core"] === "0.2.17",
+	"the adapter must declare the exact agentOS runtime it imports",
+);
 for (const dependency of [
 	"@agentos-software/sh",
 	"@agentos-software/tar",
 	"@rivet-dev/agentos",
-	"@rivet-dev/agentos-core",
 	"@rivet-dev/agentos-toolchain",
 	"@rivet-dev/dynamic-apps-builder",
 	"isolated-vm",

--- a/scripts/test-packed.mjs
+++ b/scripts/test-packed.mjs
@@ -99,7 +99,13 @@ const main = await import(pathToFileURL(join(mainRoot, "dist/index.js")));
 const exports = Object.keys(main).sort();
 if (
 	JSON.stringify(exports) !==
-	JSON.stringify(["appsRouter", "deployApp", "setDynamicAppsLogHandler"])
+	JSON.stringify([
+		"appsRouter",
+		"deployApp",
+		"rivetActorsSkill",
+		"setDynamicAppsLogHandler",
+		"webServerSkill",
+	])
 ) {
 	throw new Error(`packed main package has unexpected exports: ${exports}`);
 }

--- a/tests/e2e/dynamic-apps/package.json
+++ b/tests/e2e/dynamic-apps/package.json
@@ -15,7 +15,7 @@
 		"rivetkit": "2.3.11"
 	},
 	"devDependencies": {
-		"@rivet-dev/agentos-toolchain": "0.2.16-rc.3",
+		"@rivet-dev/agentos-toolchain": "0.2.17",
 		"@rivetkit/engine-cli": "2.3.11",
 		"@types/node": "^22.19.15",
 		"get-port": "^7.1.0",


### PR DESCRIPTION
## Summary
- upgrade AgentOS runtime and toolchain to 0.2.17
- declare the AgentOS runtime dependency used by the adapter
- promote Dynamic Apps 0.12.0 to stable

## Verification
- pnpm build
- pnpm check-boundaries
- packed runtime smoke remains blocked by the AgentOS 0.2.17 evaluate hang observed locally