### PR TITLE
Docs overhaul, un-deprecate createNamespace, generateObject examples

### DIFF
--- a/docs/content/docs/backends.mdx
+++ b/docs/content/docs/backends.mdx
@@ -1,16 +1,11 @@
 ---
 title: "Backends & REST APIs"
-description: "Serve HTTP backends and REST APIs from a Dynamic App."
+description: "Serve HTTP APIs and frontends from a generated app with any framework that speaks fetch."
 ---
 
 import ExampleLinkBar from "@/components/docs/ExampleLinkBar.astro";
 
 <ExampleLinkBar href="https://github.com/rivet-dev/dynamic-apps/tree/main/examples/apps-hello-world" />
-
-An app is a directory with a `package.json` and an entrypoint that
-default-exports a `fetch` handler. Any framework that speaks `fetch` works.
-The app does not bind a port; Dynamic Apps owns its listener. This app serves a
-frontend and a JSON API from the same handler.
 
 ## Example generated code
 
@@ -26,5 +21,5 @@ Deploy the directory and every route the app defines is served under
 
 <CodeSnippet file="examples/apps-hello-world/src/server.ts" title="src/server.ts" />
 
-See [Routing](/dynamic-apps/docs/routing) for how requests reach the app and
+See [Route](/dynamic-apps/docs/routing) for how requests reach the app and
 [Deploy](/dynamic-apps/docs/deploy) for builds and releases.

--- a/docs/content/docs/connect.mdx
+++ b/docs/content/docs/connect.mdx
@@ -4,18 +4,24 @@ description: "Every deployed app gets its own Rivet namespace for actors, workfl
 skill: true
 ---
 
-Every deployment gets its own Rivet namespace. That gives each user's app:
+`deployApp()` creates one Rivet namespace per app and returns the endpoint,
+namespace, pool, and publishable token your client needs to connect.
+
+## What are namespaces?
+
+A namespace holds an app's Rivet Actors, which power:
+
+- [Workflows](/workflows/docs/)
+- [SQLite](/actors/docs/sqlite/)
+- [Realtime state](/actors/docs/events/)
+- [Queues](/actors/docs/queues/)
+- [Crons](/actors/docs/schedule/)
+
+Each app gets its own Rivet namespace, which provides it:
 
 - Complete per-tenant isolation
 - Per-user billing
 - Infrastructure that costs nothing when idle
-
-## What namespaces are
-
-A namespace holds an app's Rivet Actors, which power its workflows, SQLite,
-realtime state, queues, and crons. `deployApp()` creates one namespace per app
-and returns the endpoint, namespace, pool, and publishable token your client
-needs to connect.
 
 ## Connecting to Rivet
 

--- a/docs/content/docs/deploy.mdx
+++ b/docs/content/docs/deploy.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Deploy"
-description: "Deploy a directory or generated files with deployApp(), preserve rollback, and configure app actors."
+description: "Deploy a directory or generated files with deployApp() and repair failed builds."
 skill: true
 ---
 
@@ -13,7 +13,7 @@ Deploy a local application directory:
 ```ts
 await deployApp({
   appId: "hello-world",
-  source: new URL("../fixtures/app/", import.meta.url),
+  source: new URL("./app/", import.meta.url),
 });
 ```
 

--- a/docs/content/docs/multiplayer.mdx
+++ b/docs/content/docs/multiplayer.mdx
@@ -1,14 +1,11 @@
 ---
 title: "Multiplayer"
-description: "Share realtime state between every client connected to an app."
+description: "An actor holds a room's shared state and broadcasts events to every connected client."
 ---
 
 import ExampleLinkBar from "@/components/docs/ExampleLinkBar.astro";
 
 <ExampleLinkBar href="https://github.com/rivet-dev/dynamic-apps/tree/main/examples/apps-multiplayer" />
-
-An actor holds the shared state for one room and broadcasts events to every
-connected client.
 
 ## Example generated code
 
@@ -21,5 +18,5 @@ Deploy the app, then connect to its actors from your own system:
 <CodeSnippet file="examples/apps-multiplayer/src/client.ts" region="client" title="Client" />
 
 Dynamic Apps does not wrap RivetKit's action, event, or connection APIs. See
-[Events](https://rivet.dev/actors/docs/events/) and
-[Connections](https://rivet.dev/actors/docs/connections/) in Rivet Actors.
+[Events](/actors/docs/events/) and
+[Connections](/actors/docs/connections/) in Rivet Actors.

--- a/docs/content/docs/quickstart-core.mdx
+++ b/docs/content/docs/quickstart-core.mdx
@@ -24,7 +24,7 @@ Quickstart](/dynamic-apps/docs/quickstart).
 | Build artifact storage | Provide upload and download handlers | Stored automatically |
 | Cache invalidation after updates | Manual notification with `watchActiveRelease` | Handled automatically |
 | Rivet namespace per app | Bring your own integration | Created and connected automatically |
-| Regions and scaling | Managed by your host | Managed through Rivet deployment options |
+| Regions and scaling | Managed by your host | Managed by Rivet |
 | Lifecycle | Explicit `dispose()` | Managed by the package |
 | Best for | Custom infrastructure | Batteries included and scalable |
 
@@ -37,7 +37,7 @@ Quickstart](/dynamic-apps/docs/quickstart).
 Use Node.js 22 or newer:
 
 ```sh
-npm add @rivet-dev/dynamic-apps-core @hono/node-server hono
+npm add @rivet-dev/dynamic-apps-core @rivet-dev/dynamic-apps @hono/node-server hono
 npm add --save-dev tsx
 ```
 
@@ -120,5 +120,5 @@ the first request. Warm requests reuse the cached agentOS VM. Call
 
 </Steps>
 
-Continue with [Core](/dynamic-apps/docs/core) before using
-Core across multiple processes.
+Read [Core](/dynamic-apps/docs/core) before running it across multiple
+processes.

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -85,7 +85,7 @@ await deployApp({
 });
 ```
 
-Run the deploy script:
+Save this as `src/deploy.ts` and run it:
 
 ```sh
 npx tsx src/deploy.ts

--- a/docs/content/docs/sqlite.mdx
+++ b/docs/content/docs/sqlite.mdx
@@ -1,15 +1,11 @@
 ---
 title: "SQLite"
-description: "Store durable relational data in an actor-owned SQLite database."
+description: "Each actor owns its own SQLite database, giving generated apps durable relational data with no extra infrastructure."
 ---
 
 import ExampleLinkBar from "@/components/docs/ExampleLinkBar.astro";
 
 <ExampleLinkBar href="https://github.com/rivet-dev/dynamic-apps/tree/main/examples/apps-sqlite" />
-
-Apps that depend on `rivetkit` can define actors. Each actor owns its own
-SQLite database, so a generated app gets durable relational data without any
-extra infrastructure.
 
 ## Example generated code
 
@@ -22,5 +18,5 @@ Deploy the app, then connect to its actors from your own system:
 <CodeSnippet file="examples/apps-sqlite/src/client.ts" region="client" title="Client" />
 
 `deployApp()` returns the endpoint, namespace, pool, and token the ordinary
-RivetKit client needs. See [SQLite in Rivet Actors](https://rivet.dev/actors/docs/sqlite/)
+RivetKit client needs. See [SQLite in Rivet Actors](/actors/docs/sqlite/)
 for the full database API.

--- a/docs/content/docs/static-websites.mdx
+++ b/docs/content/docs/static-websites.mdx
@@ -1,15 +1,11 @@
 ---
 title: "Frontends & Static Sites"
-description: "Serve an HTML, CSS, and JavaScript site from a Dynamic App."
+description: "Serve an HTML, CSS, and JavaScript site from a public/ folder in a generated app."
 ---
 
 import ExampleLinkBar from "@/components/docs/ExampleLinkBar.astro";
 
 <ExampleLinkBar href="https://github.com/rivet-dev/dynamic-apps/tree/main/examples/apps-static-website" />
-
-An app is a directory with a `package.json` and a fetch entrypoint. A static
-site is the same directory plus a `public/` folder and a handler that serves
-it.
 
 ## Example generated code
 

--- a/docs/content/docs/workflows.mdx
+++ b/docs/content/docs/workflows.mdx
@@ -1,15 +1,11 @@
 ---
 title: "Workflows"
-description: "Run durable multi-step jobs that sleep, scale to zero, and resume."
+description: "Run durable multi-step jobs that survive restarts and scale to zero while they sleep."
 ---
 
 import ExampleLinkBar from "@/components/docs/ExampleLinkBar.astro";
 
 <ExampleLinkBar href="https://github.com/rivet-dev/dynamic-apps/tree/main/examples/apps-workflows" />
-
-An actor's `run` workflow executes when the actor is created. Each step is
-durable, so the job survives restarts and the app scales to zero while it
-sleeps.
 
 ## Example generated code
 
@@ -21,5 +17,5 @@ Deploy the app, then connect to its actors from your own system:
 
 <CodeSnippet file="examples/apps-workflows/src/client.ts" region="client" title="Client" />
 
-See [Workflows in Rivet Actors](https://rivet.dev/actors/docs/workflows/) for
+See [Workflows in Rivet Actors](/workflows/docs/) for
 steps, loops, queues, and error handling.

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -37,11 +37,6 @@
      "title": "Route",
      "href": "/dynamic-apps/docs/routing",
      "icon": "faRoute"
-    },
-    {
-     "title": "Connect to Rivet",
-     "href": "/dynamic-apps/docs/connect",
-     "icon": "faPlug"
     }
    ]
   },
@@ -80,6 +75,10 @@
     {
      "title": "Authentication",
      "href": "/dynamic-apps/docs/authentication"
+    },
+    {
+     "title": "Connect to Rivet",
+     "href": "/dynamic-apps/docs/connect"
     },
     {
      "title": "Collecting Logs",


### PR DESCRIPTION
Docs restructure (Generate/Deploy/Route, Connect to Rivet, Workloads two-section pattern, ExampleLinkBar, simplified quickstarts), createNamespace: false disables namespace provisioning (rejected for rivetkit apps), and the ai-builder example now uses generateObject with a zod schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)